### PR TITLE
Fix NameError in resolve_from_target_or_config

### DIFF
--- a/cli-tools/bin/code_signing_manager.rb
+++ b/cli-tools/bin/code_signing_manager.rb
@@ -132,7 +132,7 @@ class VariableResolver
   def resolve_from_target_or_config(variable_name)
     default_options = {:TARGET_NAME => @build_target.name, :CONFIGURATION => @build_configuration.name}
     value = default_options[variable_name.to_sym] \
-        || build_configuration.build_settings[variable_name] \
+        || @build_configuration.build_settings[variable_name] \
         || resolve_variable_from_xcconfig(variable_name) \
         || resolve_variable_from_target_configs(variable_name)
     value


### PR DESCRIPTION
Fixes
```
cli-tools/bin/code_signing_manager.rb:135:in `resolve_from_target_or_config': undefined local variable or method `build_configuration' for #<VariableResolver:0x00007fd87e04cde8> (NameError)
	from cli-tools/bin/code_signing_manager.rb:63:in `block in resolve'
	from cli-tools/bin/code_signing_manager.rb:62:in `each'
	from cli-tools/bin/code_signing_manager.rb:62:in `resolve'
	from cli-tools/bin/code_signing_manager.rb:299:in `get_bundle_id'
	from cli-tools/bin/code_signing_manager.rb:404:in `set_configuration_build_settings'
	from cli-tools/bin/code_signing_manager.rb:458:in `block in set_target_build_settings'
	from cli-tools/bin/code_signing_manager.rb:457:in `each'
	from cli-tools/bin/code_signing_manager.rb:457:in `set_target_build_settings'
	from cli-tools/bin/code_signing_manager.rb:464:in `block in set_xcodeproj_build_settings'
	from cli-tools/bin/code_signing_manager.rb:463:in `each'
	from cli-tools/bin/code_signing_manager.rb:463:in `set_xcodeproj_build_settings'
	from cli-tools/bin/code_signing_manager.rb:221:in `set_code_signing_settings'
	from cli-tools/bin/code_signing_manager.rb:525:in `main'
	from cli-tools/bin/code_signing_manager.rb:531:in `<main>'
```