### PR TITLE
Fix NameErrors in code signing manager

### DIFF
--- a/cli-tools/bin/code_signing_manager.rb
+++ b/cli-tools/bin/code_signing_manager.rb
@@ -109,7 +109,7 @@ class VariableResolver
       if project_build_configuration.name == @build_configuration.name
         Log.info "Found build config on PBXProj for target #{@build_target.name}: #{project_build_configuration.name}"
         value = project_build_configuration.build_settings[variable_name] \
-                || resolve_variable_from_xcconfig(key, project_build_configuration)
+                || resolve_variable_from_xcconfig(variable_name, project_build_configuration)
         if value
           break
         end
@@ -124,7 +124,7 @@ class VariableResolver
       return nil
     end
 
-    Log.info "Checking value for '#{key}' from #{base_configuration_reference.real_path}"
+    Log.info "Checking value for '#{variable_name}' from #{base_configuration_reference.real_path}"
     xcconfig = Xcodeproj::Config.new(base_configuration_reference.real_path)
     xcconfig.attributes[variable_name]
   end


### PR DESCRIPTION
Fixes
```ruby
cli-tools/bin/code_signing_manager.rb:112:in `block in resolve_variable_from_target_configs': undefined local variable or method `key' for #<VariableResolver:0x00007fe67d316238> (NameError)
	cli-tools/bin/code_signing_manager.rb:108:in `each'
	cli-tools/bin/code_signing_manager.rb:108:in `resolve_variable_from_target_configs'
	cli-tools/bin/code_signing_manager.rb:137:in `resolve_from_target_or_config'
	cli-tools/bin/code_signing_manager.rb:63:in `block in resolve'
	cli-tools/bin/code_signing_manager.rb:62:in `each'
	cli-tools/bin/code_signing_manager.rb:62:in `resolve'
	cli-tools/bin/code_signing_manager.rb:299:in `get_bundle_id'
	cli-tools/bin/code_signing_manager.rb:404:in `set_configuration_build_settings'
	cli-tools/bin/code_signing_manager.rb:458:in `block in set_target_build_settings'
	cli-tools/bin/code_signing_manager.rb:457:in `each'
	cli-tools/bin/code_signing_manager.rb:457:in `set_target_build_settings'
	cli-tools/bin/code_signing_manager.rb:464:in `block in set_xcodeproj_build_settings'
	cli-tools/bin/code_signing_manager.rb:463:in `each'
	cli-tools/bin/code_signing_manager.rb:463:in `set_xcodeproj_build_settings'
	cli-tools/bin/code_signing_manager.rb:221:in `set_code_signing_settings'
	cli-tools/bin/code_signing_manager.rb:525:in `main'
	cli-tools/bin/code_signing_manager.rb:531:in `<main>'
```