### PR TITLE
Do not exit with code 1 when action returns something

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -10,7 +10,7 @@ workflows:
       - git tag -a v$(python3 setup.py --version) -m "Release v$(python3 setup.py --version)"
       - python3 setup.py bdist_wheel
       - git push "https://$GH_USER:$GH_PAT@github.com/$REPOSITORY" --tags
-      - echo "Initial release\n" > release_notes.txt
+      - echo "git-changelog and universal-apk now exit with code 0 on success\n" > release_notes.txt
       - |
         # draft a release
         set -e

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 def get_version():
     # TODO: implement versioning
-    return '0.0.1'
+    return '0.0.2'
 
 
 setup(

--- a/src/codemagic_cli_tools/cli/cli_app.py
+++ b/src/codemagic_cli_tools/cli/cli_app.py
@@ -48,12 +48,12 @@ class CliApp(metaclass=abc.ABCMeta):
         return cls(**{argument.value.key: argument.from_args(cli_args) for argument in cls._CLASS_ARGUMENTS})
 
     @classmethod
-    def _handle_cli_exception(cls, cli_exception: CliAppException) -> NoReturn:
+    def _handle_cli_exception(cls, cli_exception: CliAppException) -> int:
         sys.stderr.write(f'{Color.RED(cli_exception.message)}\n')
         if cli_exception.cli_process:
-            sys.exit(cli_exception.cli_process.returncode)
+            return cli_exception.cli_process.returncode
         else:
-            sys.exit(1)
+            return 1
 
     @classmethod
     def invoke_cli(cls):
@@ -72,9 +72,10 @@ class CliApp(metaclass=abc.ABCMeta):
             for arg_type in cli_action.arguments
         }
         try:
-            return cli_action(**action_args)
+            cli_action(**action_args)
+            return 0
         except cls.CLI_EXCEPTION_TYPE as cli_exception:
-            cls._handle_cli_exception(cli_exception)
+            return cls._handle_cli_exception(cli_exception)
 
     @classmethod
     def get_class_cli_actions(cls) -> Iterable[ActionCallable]:

--- a/src/codemagic_cli_tools/cli/cli_types.py
+++ b/src/codemagic_cli_tools/cli/cli_types.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import pathlib
-import re
-from typing import Union, AnyStr, NewType, Callable
+from typing import Union, AnyStr, NewType, Callable, Pattern
 
 CommandArg = Union[AnyStr, pathlib.Path]
-ObfuscationPattern = Union[re.Pattern, Callable[[CommandArg], bool], CommandArg]
+ObfuscationPattern = Union[Pattern, Callable[[CommandArg], bool], CommandArg]
 ObfuscatedCommand = NewType('ObfuscatedCommand', str)

--- a/src/codemagic_cli_tools/git_changelog.py
+++ b/src/codemagic_cli_tools/git_changelog.py
@@ -78,8 +78,8 @@ class GitChangelog(cli.CliApp):
         if process.returncode != 0:
             raise GitChangelogError('Unable to execute git log', process)
         raw_log = process.stdout.strip()
-        if not raw_log:
-            raise GitChangelogError('Aborting due to empty output from git log. Nothing to generate', process)
+        if raw_log:
+            raise GitChangelogError('Aborting due to empty output from git log. Nothing to generate')
         return raw_log
 
     def _get_changelog_list(self, changelog) -> Iterator[ChangelogEntry]:

--- a/src/codemagic_cli_tools/git_changelog.py
+++ b/src/codemagic_cli_tools/git_changelog.py
@@ -37,10 +37,10 @@ class GitChangelogArgument(cli.Argument):
 
 
 class ChangelogEntry(typing.NamedTuple):
-    hash: str = None
-    date: str = None
-    author: str = None
-    description: str = None
+    hash: str = ''
+    date: str = ''
+    author: str = ''
+    description: str = ''
 
 
 @cli.common_arguments(*GitChangelogArgument)
@@ -60,7 +60,7 @@ class GitChangelog(cli.CliApp):
         self.commit_limit = commit_limit
 
     @cli.action('generate')
-    def generate(self) -> List[str]:
+    def generate(self) -> Iterator[ChangelogEntry]:
         """
         Generate a changelog text from git history
         """

--- a/src/codemagic_cli_tools/git_changelog.py
+++ b/src/codemagic_cli_tools/git_changelog.py
@@ -78,7 +78,7 @@ class GitChangelog(cli.CliApp):
         if process.returncode != 0:
             raise GitChangelogError('Unable to execute git log', process)
         raw_log = process.stdout.strip()
-        if raw_log:
+        if not raw_log:
             raise GitChangelogError('Aborting due to empty output from git log. Nothing to generate')
         return raw_log
 

--- a/src/codemagic_cli_tools/git_changelog.py
+++ b/src/codemagic_cli_tools/git_changelog.py
@@ -103,8 +103,6 @@ class GitChangelog(cli.CliApp):
                 for line in description_lines[1:]:
                     descriptions.append(f'  {line}')
         formatted_log = '\n'.join(descriptions)
-        if descriptions:
-            formatted_log = formatted_log + '\n'
         return formatted_log, len(descriptions)
 
     def _should_include_log_line(self, line):


### PR DESCRIPTION
Code you return to `__main__` will be interpreted as system exit code. Change cli app invocation logic to take that into account. Return code `0` by default unless an error is catched, then return an other error code, instead of running `sys.exit()` manually.

Also send exit code 1 from empty git log and skip the newline.