### PR TITLE
Bugfix: Fix Xcode log copying

### DIFF
--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -55,8 +55,13 @@ class Xcodebuild:
         with self.logs_path.open('a') as fd, xcodebuild_cli_process.log_path.open('r') as process_logs:
             fd.write(f'>>> {xcodebuild_cli_process.safe_form}')
             fd.write('\n\n')
-            for chunk in process_logs.read(8192):
+
+            chunk = process_logs.read(8192)
+            while chunk:
                 fd.write(chunk)
+                chunk = process_logs.read(8192)
+            fd.write(process_logs.read())
+
             fd.write('\n\n')
             duration = time.strftime("%M:%S", time.gmtime(xcodebuild_cli_process.duration))
             fd.write(f'<<< Process completed with status code {xcodebuild_cli_process.returncode} in {duration}')

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -60,7 +60,8 @@ class Xcodebuild:
             while chunk:
                 fd.write(chunk)
                 chunk = process_logs.read(8192)
-            fd.write(process_logs.read())
+            # do an extra read in case xcodebuild exited unexpectedly and did not flush last buffer
+            fd.write(process_logs.read()) 
 
             fd.write('\n\n')
             duration = time.strftime("%M:%S", time.gmtime(xcodebuild_cli_process.duration))


### PR DESCRIPTION
Capturing unprocessed `xcodebuild` log into log file was not working properly and the tail of the actual log was not always included.