### PR TITLE
Bugfix: Xcode managed profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+Version 0.1.3
+-------------
+
+Unreleased
+
+- Bugfix: Improve detection for Xcode managed provisioning profiles
+
+Version 0.1.2
+-------------
+
+Released 10.02.2020
+
+- Return exit code `0` on successful invocation of `git-changelog`
+- Return exit code `0` on successful invocation of `universal-apk`
+
+Version 0.1.1
+-------------
+
+Released 31.01.2020
+
+- Update documentation
+
+Version 0.1.0
+-------------
+
+Released 14.01.2020
+
+- Add tool `app-store-connect`
+- Add tool `keychain`
+- Add tool `xcode-project`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/provisioning_profile.py
+++ b/src/codemagic/models/provisioning_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import plistlib
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -135,4 +136,6 @@ class ProvisioningProfile(JsonSerializable, StringConverterMixin):
 
     @classmethod
     def is_xcode_managed(cls, profile_name: str) -> bool:
-        return profile_name.startswith('iOS Team Provisioning Profile:')
+        xcode_managed_profile_name_patt = re.compile(r'^iOS Team ((Ad Hoc|Store) )?Provisioning Profile:')
+        xcode_managed_name_match = xcode_managed_profile_name_patt.match(profile_name)
+        return xcode_managed_name_match is not None

--- a/tests/models/test_provisioning_profile.py
+++ b/tests/models/test_provisioning_profile.py
@@ -1,0 +1,21 @@
+import pytest
+
+from codemagic.models import ProvisioningProfile
+
+
+@pytest.mark.parametrize('profile_name', [
+    'iOS Team Provisioning Profile: io.codemagic.app.debug',
+    'iOS Team Ad Hoc Provisioning Profile: io.codemagic.app.ad-hoc',
+    'iOS Team Store Provisioning Profile: io.codemagic.app.store',
+])
+def test_is_xcode_managed_profile(profile_name):
+    assert ProvisioningProfile.is_xcode_managed(profile_name)
+
+
+@pytest.mark.parametrize('profile_name', [
+    '',
+    'io codemagic app development',
+    'iOS Team Profile: App Store',
+])
+def test_is_not_xcode_managed_profile(profile_name):
+    assert ProvisioningProfile.is_xcode_managed(profile_name) is False


### PR DESCRIPTION
If provisioning profile does not contain key `IsXcodeManaged`, then a fallback detection is initiated that checks if the provisioning profile name suggests that it is Xcode managed. Up until now the App Store and Ad Hoc profiles were always treated as _not_ managed by Xcode, in case they were lacking the `IsXcodeManaged` key.