### PR TITLE
Bugfix: Handle non string objects when logging Apple Developer Portal resource creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Version 0.1.4
 
 Unreleased
 
+- Bugfix: Fix `TypeError` on Apple Developer Portal resource creation
+
+Version 0.1.4
+-------------
+
+Unreleased
+
 - Bugfix: Accept `UNIVERSAL` as valid Bundle ID platform value
 
 Version 0.1.3

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -59,7 +59,7 @@ class ResourcePrinter:
         def fmt(item: Tuple[str, Any]):
             name, value = item
             if isinstance(value, list):
-                return f'{name.replace("_", " ")}: {[shlex.quote(el) for el in value]}'
+                return f'{name.replace("_", " ")}: {[shlex.quote(str(el)) for el in value]}'
             elif isinstance(value, enum.Enum):
                 value = str(value.value)
             elif not isinstance(value, (str, bytes)):

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import json
 import pathlib
 import shlex
@@ -59,6 +60,10 @@ class ResourcePrinter:
             name, value = item
             if isinstance(value, list):
                 return f'{name.replace("_", " ")}: {[shlex.quote(el) for el in value]}'
+            elif isinstance(value, enum.Enum):
+                value = str(value.value)
+            elif not isinstance(value, (str, bytes)):
+                value = str(value)
             return f'{name.replace("_", " ")}: {shlex.quote(value)}'
 
         message = f'Creating new {resource_type}'


### PR DESCRIPTION
Enums and other non-string objects cannot be escaped directly with `shlex.quote`. This caused the tool to crash:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/codemagic/cli/cli_app.py", line 149, in invoke_cli
    app._invoke_action(args)
  File "/usr/local/lib/python3.7/site-packages/codemagic/cli/cli_app.py", line 132, in _invoke_action
    return cli_action(**action_args)
  File "/usr/local/lib/python3.7/site-packages/codemagic/cli/cli_app.py", line 323, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/app_store_connect.py", line 493, in fetch_signing_files
    profile_type, certificate_key, certificate_key_password, create_resource)
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/app_store_connect.py", line 528, in _get_or_create_certificates
    should_print=False))
  File "/usr/local/lib/python3.7/site-packages/codemagic/cli/cli_app.py", line 323, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/app_store_connect.py", line 251, in create_certificate
    certificate = self._create_resource(self.api_client.signing_certificates, should_print, **create_params)
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/app_store_connect.py", line 108, in _create_resource
    **{k: v for k, v in create_params.items() if k not in omit_keys}
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/_app_store_connect/resource_printer.py", line 66, in log_creating
    message = f'{message}: {", ".join(map(fmt, params.items()))}'
  File "/usr/local/lib/python3.7/site-packages/codemagic/tools/_app_store_connect/resource_printer.py", line 62, in fmt
    return f'{name.replace("_", " ")}: {shlex.quote(value)}'
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/shlex.py", line 319, in quote
    if _find_unsafe(s) is None:
TypeError: expected string or bytes-like object
```