### PR TITLE
Bugfix: Creating iOS App Store and In House provisioning profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-Version 0.1.4
+Version 0.1.6
+-------------
+
+Unreleased
+
+- Bugfix: Fix creating iOS App Store and iOS In House provisioning profiles.
+Do not include devices in the create resource payload.
+
+Version 0.1.5
 -------------
 
 Unreleased

--- a/docs/app-store-connect/create‑bundle‑id.md
+++ b/docs/app-store-connect/create‑bundle‑id.md
@@ -30,7 +30,7 @@ Identifier of the Bundle ID
 
 
 Name of the Bundle ID. If the resource is being created, the default will be deduced from given Bundle ID identifier.
-##### `--platform=IOS | MAC_OS`
+##### `--platform=IOS | MAC_OS | UNIVERSAL`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`

--- a/docs/app-store-connect/fetch‑signing‑files.md
+++ b/docs/app-store-connect/fetch‑signing‑files.md
@@ -30,7 +30,7 @@ app-store-connect fetch‑signing‑files [-h] [-s] [-v] [--no-color] [--log-str
 Identifier of the Bundle ID
 ### Optional arguments for action `fetch‑signing‑files`
 
-##### `--platform=IOS | MAC_OS`
+##### `--platform=IOS | MAC_OS | UNIVERSAL`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`

--- a/docs/app-store-connect/list‑bundle‑ids.md
+++ b/docs/app-store-connect/list‑bundle‑ids.md
@@ -28,7 +28,7 @@ Identifier of the Bundle ID
 
 
 Name of the Bundle ID. If the resource is being created, the default will be deduced from given Bundle ID identifier.
-##### `--platform=IOS | MAC_OS`
+##### `--platform=IOS | MAC_OS | UNIVERSAL`
 
 
 Bundle ID platform

--- a/docs/app-store-connect/list‑devices.md
+++ b/docs/app-store-connect/list‑devices.md
@@ -20,7 +20,7 @@ app-store-connect list‑devices [-h] [-s] [-v] [--no-color] [--log-stream STREA
 ```
 ### Optional arguments for action `list‑devices`
 
-##### `--platform=IOS | MAC_OS`
+##### `--platform=IOS | MAC_OS | UNIVERSAL`
 
 
 Bundle ID platform

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -55,6 +55,8 @@ class Profiles(ResourceManager[Profile]):
         """
         https://developer.apple.com/documentation/appstoreconnectapi/create_a_profile
         """
+        if profile_type.devices_not_allowed() and devices:
+            raise ValueError(f'Cannot assign devices to profile with type {profile_type}')
         if devices is None:
             devices = []
         attributes = {

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -118,8 +118,11 @@ class ProfileType(_ResourceEnum):
     TVOS_APP_INHOUSE = 'TVOS_APP_INHOUSE'
     TVOS_APP_STORE = 'TVOS_APP_STORE'
 
-    def requires_devices(self) -> bool:
+    def devices_not_allowed(self) -> bool:
         return self in (ProfileType.IOS_APP_STORE, ProfileType.IOS_APP_INHOUSE)
+
+    def devices_allowed(self) -> bool:
+        return not self.devices_not_allowed()
 
 
 class ResourceType(_ResourceEnum):

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -368,9 +368,12 @@ class AppStoreConnect(cli.CliApp):
             profile_type=profile_type,
             bundle_id=bundle_id_resource_id,
             certificates=certificate_resource_ids,
-            devices=device_resource_ids,
-            omit_keys=['devices']
         )
+        if profile_type.devices_allowed():
+            create_params.update({
+                'devices': device_resource_ids,
+                'omit_keys': ['devices']
+            })
         profile = self._create_resource(self.api_client.profiles, should_print, **create_params)
 
         if save:

--- a/tests/apple/app_store_connect/provisioning/conftest.py
+++ b/tests/apple/app_store_connect/provisioning/conftest.py
@@ -8,7 +8,16 @@ import pytest
 _RESOURCE_MOCKS_DIR = pathlib.Path(__file__).parent.parent.parent / 'resources' / 'mocks'
 
 
+class MockResponse:
+    def __init__(self, mock_data):
+        self.data = {'data': mock_data}
+
+    def json(self):
+        return self.data
+
+
 @pytest.fixture
-def profile_response() -> Dict:
+def profile_response() -> MockResponse:
     mock_path = _RESOURCE_MOCKS_DIR / 'profile.json'
-    return {'data': json.loads(mock_path.read_text())}
+    mock_data = json.loads(mock_path.read_text())
+    return MockResponse(mock_data)

--- a/tests/apple/app_store_connect/provisioning/conftest.py
+++ b/tests/apple/app_store_connect/provisioning/conftest.py
@@ -1,0 +1,14 @@
+import json
+import pathlib
+from typing import Dict
+
+import pytest
+
+
+_RESOURCE_MOCKS_DIR = pathlib.Path(__file__).parent.parent.parent / 'resources' / 'mocks'
+
+
+@pytest.fixture
+def profile_response() -> Dict:
+    mock_path = _RESOURCE_MOCKS_DIR / 'profile.json'
+    return {'data': json.loads(mock_path.read_text())}

--- a/tests/apple/app_store_connect/provisioning/test_profiles.py
+++ b/tests/apple/app_store_connect/provisioning/test_profiles.py
@@ -13,15 +13,6 @@ from codemagic.apple.resources import ResourceType
 from tests.apple.app_store_connect.resource_manager_test_base import ResourceManagerTestsBase
 
 
-class _MockResponse:
-
-    def __init__(self, mock_response_payload):
-        self.mock_response_payload = mock_response_payload
-
-    def json(self):
-        return self.mock_response_payload
-
-
 @pytest.mark.parametrize('profile_type', [ProfileType.IOS_APP_STORE, ProfileType.IOS_APP_INHOUSE])
 def test_create_profile_failure_with_devices(profile_type, api_client):
     with pytest.raises(ValueError):
@@ -36,9 +27,7 @@ def test_create_profile_failure_with_devices(profile_type, api_client):
 
 @pytest.mark.parametrize('profile_type', [ProfileType.IOS_APP_DEVELOPMENT, ProfileType.IOS_APP_ADHOC])
 def test_create_profile_success_with_devices(profile_type, profile_response, api_client):
-    mock_post = mock.Mock(return_value=_MockResponse(profile_response))
-    api_client.session.post = mock_post
-
+    api_client.session.post = mock.Mock(return_value=profile_response)
     api_client.profiles.create(
         name='test profile',
         profile_type=profile_type,
@@ -46,7 +35,7 @@ def test_create_profile_success_with_devices(profile_type, profile_response, api
         certificates=[ResourceId('certificate_resource_id')],
         devices=[ResourceId('device_resource_id')],
     )
-    mock_post.assert_called_once()
+    api_client.session.post.assert_called_once()
 
 
 @pytest.mark.skip(reason='Live App Store Connect API access')

--- a/tests/apple/app_store_connect/provisioning/test_profiles.py
+++ b/tests/apple/app_store_connect/provisioning/test_profiles.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from codemagic.apple.resources import BundleId
@@ -9,6 +11,42 @@ from codemagic.apple.resources import ProfileType
 from codemagic.apple.resources import ResourceId
 from codemagic.apple.resources import ResourceType
 from tests.apple.app_store_connect.resource_manager_test_base import ResourceManagerTestsBase
+
+
+class _MockResponse:
+
+    def __init__(self, mock_response_payload):
+        self.mock_response_payload = mock_response_payload
+
+    def json(self):
+        return self.mock_response_payload
+
+
+@pytest.mark.parametrize('profile_type', [ProfileType.IOS_APP_STORE, ProfileType.IOS_APP_INHOUSE])
+def test_create_profile_failure_with_devices(profile_type, api_client):
+    with pytest.raises(ValueError):
+        api_client.profiles.create(
+            name='test profile',
+            profile_type=profile_type,
+            bundle_id=ResourceId('bundle_id_resource_id'),
+            certificates=[ResourceId('certificate_resource_id')],
+            devices=[ResourceId('device_resource_id')],
+        )
+
+
+@pytest.mark.parametrize('profile_type', [ProfileType.IOS_APP_DEVELOPMENT, ProfileType.IOS_APP_ADHOC])
+def test_create_profile_success_with_devices(profile_type, profile_response, api_client):
+    mock_post = mock.Mock(return_value=_MockResponse(profile_response))
+    api_client.session.post = mock_post
+
+    api_client.profiles.create(
+        name='test profile',
+        profile_type=profile_type,
+        bundle_id=ResourceId('bundle_id_resource_id'),
+        certificates=[ResourceId('certificate_resource_id')],
+        devices=[ResourceId('device_resource_id')],
+    )
+    mock_post.assert_called_once()
 
 
 @pytest.mark.skip(reason='Live App Store Connect API access')


### PR DESCRIPTION
Attaching devices to App Store and In House provisioning profiles is not valid. Example log of failing request:

```
[04:43:07 12-03-2020] INFO  resource_printer.py:72 > Creating new Profile: name: '...', profile type: IOS_APP_STORE, bundle id: ..., certificates: ['...']
[04:43:07 12-03-2020] INFO  api_session.py:31 > >>> POST https://api.appstoreconnect.apple.com/v1/profiles None
[04:43:07 12-03-2020] INFO  api_session.py:21 > <<< 409 {'errors': [{'id': '9f2d1584-d967-4d2b-9a3b-a824afc95e3f', 'status': '409', 'code': 'ENTITY_ERROR.RELATIONSHIP.NOT_ALLOWED', 'title': 'A relationship in the provided entity is not allowed for this request', 'detail': 'No devices can be associated to Provisioning Profiles for the App Store.'}]}
[04:43:07 12-03-2020] ERROR cli_app.py:107 >  POST https://api.appstoreconnect.apple.com/v1/profiles returned 409: A relationship in the provided entity is not allowed for this request - No devices can be associated to Provisioning Profiles for the App Store.
```