### PR TITLE
Bugfix: Apple Developer Portal pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.1.7
+-------------
+
+- Bugfix: Fix Apple Developer Portal API pagination.
+Avoid duplicate query parameters in subsequent pagination calls when listing resources.
+
 Version 0.1.6
 -------------
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -180,13 +180,6 @@
             ],
             "version": "==0.1.0"
         },
-        "bleach": {
-            "hashes": [
-                "sha256:44f69771e2ac81ff30d929d485b7f9919f3ad6d019b6b20c74f3b8687c3f70df",
-                "sha256:aa8b870d0f46965bac2c073a93444636b0e1ca74e9777e34f03dd494b8a59d48"
-            ],
-            "version": "==3.1.1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
When paginating resources in Apple Developer Portal, the URL parameters from previous API calls are urlencoded into the next URL. Thus we end up sending duplicate URL parameters when paginating.

For example, when listing Bundle IDs, then the first request is

```javascript
>>> GET https://api.appstoreconnect.apple.com/v1/bundleIds {'limit': 20, 'sort': 'name'}
<<< 200 {
    "data": [],
    "links": {
        "self": "https://api.appstoreconnect.apple.com/v1/bundleIds?sort=name&limit=20",
        "next": "https://api.appstoreconnect.apple.com/v1/bundleIds?sort=name&cursor=eyJvZmZzZXQiOiIyMCJ9&limit=20"
    },
    "meta": {
        "paging": {
            "total": 21,
            "limit": 20
        }
    }
}
```

It is followed by this failing request:

```javascript
>>> GET https://api.appstoreconnect.apple.com/v1/bundleIds?sort=name&cursor=eyJvZmZzZXQiOiIyMCJ9&limit=20 {'sort': 'name'}
<<< 400 {
    "errors": [
        {
            "id": "01bcc901-c81b-443c-98d0-14d50a395062",
            "status": "400",
            "code": "PARAMETER_ERROR.DUPLICATE",
            "title": "A parameter is included more than once",
            "detail": "The parameter 'sort' can only be included once",
            "source": {
                "parameter": "sort"
            }
        }
    ]
}
```
