### PR TITLE
Improve error message for invalid user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+Version 0.1.9
+-------------
+
+- Improve error messages on invalid inputs when using argument values from environment variables.
+
 Version 0.1.8
 -------------
 
-- Add `--version` option to tools to display current version
+- Add `--version` option to tools to display current version.
 
 Version 0.1.7
 -------------

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument.py
+++ b/src/codemagic/cli/argument.py
@@ -190,7 +190,10 @@ class Argument(ArgumentProperties, enum.Enum):
         if not value and \
                 inspect.isclass(self.value.type) and \
                 issubclass(self.value.type, TypedCliArgument):
-            return self.value.type.from_environment_variable_default()
+            try:
+                return self.value.type.from_environment_variable_default()
+            except ValueError as ve:
+                self.raise_argument_error(str(ve))
         return value
 
     @classmethod

--- a/tests/tools/test_app_store_connect.py
+++ b/tests/tools/test_app_store_connect.py
@@ -79,6 +79,15 @@ def test_missing_arg_from_env(MockApiClient, namespace_kwargs, argument, api_cli
     assert client_arg == argument.type.argument_type('environment-value')
 
 
+def test_invalid_private_key_from_env(namespace_kwargs):
+    os.environ[Types.PrivateKeyArgument.environment_variable_key] = 'this is not a private key'
+    namespace_kwargs[AppStoreConnectArgument.PRIVATE_KEY.key] = None
+    cli_args = argparse.Namespace(**{k: v for k, v in namespace_kwargs.items()})
+    with pytest.raises(argparse.ArgumentError) as exception_info:
+        AppStoreConnect.from_cli_args(cli_args)
+    assert 'this is not a private key' in str(exception_info.value)
+
+
 def test_private_key_invalid_path(namespace_kwargs):
     os.environ[Types.PrivateKeyArgument.environment_variable_key] = '@file:this-is-not-a-file'
     namespace_kwargs[AppStoreConnectArgument.PRIVATE_KEY.key] = None


### PR DESCRIPTION
When instead of CLI arguments envrionemnt variables are used to define the argument values then on invalid input values the command execution fails unexpectely with vague error messages.

Take for example `APP_STORE_CONNECT_PRIVATE_KEY="..."` environment variable in place of `--private-key="..."` as described in the [docs](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/README.md#--private-keyprivate_key)) for `app-store-connect`.

Previously the result with value from environment variable was like

```bash
$ APP_STORE_CONNECT_PRIVATE_KEY="not a valid private key" app-store-connect fetch-signing-files io.bundleId.example
Executing AppStoreConnect action fetch-signing-files failed unexpectedly. Detailed logs are available at "/var/folders/s_/1kqm5m1x0gg_r7yvbm2j1h3h0000gn/T/codemagic-16-04-20.log". To see more details about the error, add `--verbose` command line option.
```

When `--private-key` argument was used then the output was as expected:

```bash
$ app-store-connect fetch-signing-files io.bundleId.example --private-key="not a valid private key"
usage: app_store_connect.py fetch-signing-files [-h] [-s] [-v] [--no-color] [--log-stream {stderr,stdout}]
                                                [--platform {IOS,MAC_OS,UNIVERSAL}] [--certificate-key CERTIFICATE_KEY]
                                                [--certificate-key-password CERTIFICATE_KEY_PASSWORD]
                                                [--p12-password P12_CONTAINER_PASSWORD]
                                                [--type {IOS_APP_ADHOC,IOS_APP_DEVELOPMENT,IOS_APP_INHOUSE,IOS_APP_STORE,MAC_APP_DEVELOPMENT,MAC_APP_DIRECT,MAC_APP_STORE,TVOS_APP_ADHOC,TVOS_APP_DEVELOPMENT,TVOS_APP_INHOUSE,TVOS_APP_STORE}]
                                                [--create] [--log-api-calls] [--json] [--issuer-id ISSUER_ID]
                                                [--key-id KEY_IDENTIFIER] [--private-key PRIVATE_KEY]
                                                [--certificates-dir CERTIFICATES_DIRECTORY]
                                                [--profiles-dir PROFILES_DIRECTORY]
                                                bundle_id_identifier
app_store_connect.py fetch-signing-files: error: argument --private-key: invalid PrivateKeyArgument value: 'not a valid private key'
```

With introduced changes invalid value from environment results in
```bash
APP_STORE_CONNECT_PRIVATE_KEY="not a valid private key" app-store-connect fetch-signing-files io.bundleId.example                                        
usage: app_store_connect.py [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v]
                            {create-bundle-id,create-certificate,create-profile,delete-bundle-id,delete-certificate,delete-profile,fetch-signing-files,get-bundle-id,get-certificate,get-profile,list-bundle-id-profiles,list-bundle-ids,list-certificates,list-devices,list-profiles}
                            ...
app_store_connect.py: error: argument --private-key: Provided value "not a valid private key" is not valid
```