### PR TITLE
Bugfix: Checking if Android app bundle is signed got stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.1
+-------------
+
+**Improvements**
+
+- Bugfix: Reading `jarsigner verify` output streams got stuck on some Android App bundles.
+
 Version 0.2.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import shlex
 import subprocess
 import sys
+import threading
 import time
+import queue
 from typing import IO
 from typing import Optional
 from typing import Sequence
@@ -54,7 +56,23 @@ class CliProcess:
         self.logger.debug(f'Completed "{self.safe_form}" with returncode {self.returncode} in {duration}')
 
     def _handle_stream(self, input_stream: IO, output_stream: IO, buffer_size: Optional[int] = None) -> str:
-        chunk = (input_stream.read(buffer_size) if buffer_size else input_stream.read()).decode()
+        result = queue.Queue()
+
+        def read_result():
+            if buffer_size:
+                result.put(input_stream.read(buffer_size))
+            else:
+                result.put(input_stream.read())
+
+        stream_reader = threading.Thread(target=read_result)
+        stream_reader.start()
+        stream_reader.join(1)  # Under normal circumstances reading the stream should never take full second
+
+        try:
+            chunk = result.get(block=False).decode()
+        except queue.Empty:
+            chunk = ''
+
         if self._print_streams:
             output_stream.write(chunk)
         return chunk

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -56,7 +56,7 @@ class CliProcess:
         self.logger.debug(f'Completed "{self.safe_form}" with returncode {self.returncode} in {duration}')
 
     def _handle_stream(self, input_stream: IO, output_stream: IO, buffer_size: Optional[int] = None) -> str:
-        result = queue.Queue()
+        result: queue.Queue[bytes] = queue.Queue()
 
         def read_result():
             if buffer_size:


### PR DESCRIPTION
Running
```{shell}
android-app-bundle is-signed --bundle /path/to/bundle.aab
```
did not return in case of some Android app bundles as reading `stderr` stream halted. Mitigate this by adding graceful timeouts to reading from child processes.
