### PR TITLE
Bugfix: Process stream descriptor nullpointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.2
+-------------
+
+**Improvements**
+
+- Bugfix: Fix nullpointer on setting process stream flags.
+
 Version 0.2.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -57,6 +57,8 @@ class CliProcess:
 
     def _ensure_process_streams_are_non_blocking(self):
         for stream in (self._process.stdout, self._process.stderr):
+            if stream is None:
+                continue
             stream_descriptor = stream.fileno()
             current_stream_flags = fcntl.fcntl(stream_descriptor, fcntl.F_GETFL)
             fcntl.fcntl(stream_descriptor, fcntl.F_SETFL, current_stream_flags | os.O_NONBLOCK)

--- a/tests/cli/test_cli_process.py
+++ b/tests/cli/test_cli_process.py
@@ -14,7 +14,7 @@ def assert_non_blocking(stream):
 def test_non_blocking_streams():
     cli_process = cli.CliProcess([])
     cli_process._process = subprocess.Popen(
-        ['read', 'var'],
+        ['sleep', '3'],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
     cli_process._ensure_process_streams_are_non_blocking()
@@ -29,7 +29,7 @@ def test_non_blocking_streams_file_fd():
     with NamedTemporaryFile(mode='wb') as tf:
         cli_process = cli.CliProcess([])
         cli_process._process = subprocess.Popen(
-            ['read', 'var'],
+            ['sleep', '3'],
             stdout=tf,
             stderr=tf)
         cli_process._ensure_process_streams_are_non_blocking()

--- a/tests/cli/test_cli_process.py
+++ b/tests/cli/test_cli_process.py
@@ -1,0 +1,40 @@
+import fcntl
+import os
+import subprocess
+from tempfile import NamedTemporaryFile
+
+from codemagic import cli
+
+
+def assert_non_blocking(stream):
+    stream_flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
+    assert stream_flags & os.O_NONBLOCK == os.O_NONBLOCK
+
+
+def test_non_blocking_streams():
+    cli_process = cli.CliProcess([])
+    cli_process._process = subprocess.Popen(
+        ['read', 'var'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    cli_process._ensure_process_streams_are_non_blocking()
+
+    assert_non_blocking(cli_process._process.stdout)
+    assert_non_blocking(cli_process._process.stderr)
+
+    cli_process._process.kill()
+
+
+def test_non_blocking_streams_file_fd():
+    with NamedTemporaryFile(mode='wb') as tf:
+        cli_process = cli.CliProcess([])
+        cli_process._process = subprocess.Popen(
+            ['read', 'var'],
+            stdout=tf,
+            stderr=tf)
+        cli_process._ensure_process_streams_are_non_blocking()
+
+        assert cli_process._process.stdout is None
+        assert cli_process._process.stderr is None
+
+        cli_process._process.kill()


### PR DESCRIPTION
Streams on `Popen` objects are `None` if the streams are initialized as file descriptors. That resulted with
```{python}
AttributeError: 'NoneType' object has no attribute 'fileno'
```