### PR TITLE
Bugfix: Improve variable resolving from Xcode projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.3
+-------------
+
+**Improvements**
+
+- Bugfix: Improve variable resolving from Xcode projects for setting code signing settings.
+
 Version 0.2.2
 -------------
 

--- a/bin/code_signing_manager.rb
+++ b/bin/code_signing_manager.rb
@@ -131,11 +131,19 @@ class VariableResolver
   end
 
   def resolve_from_target_or_config(variable_name)
+    def discard(resolved_value, original_name)
+      # Return resolved variable if it does not contain recursive reference to
+      # original key. Otherwise discard this value as it is recursive definition.
+      if !resolved_value.nil? && !(resolved_value.include? original_name)
+        resolved_value
+      end
+    end
+
     default_options = {:TARGET_NAME => @build_target.name, :CONFIGURATION => @build_configuration.name}
-    value = default_options[variable_name.to_sym] \
-        || @build_configuration.build_settings[variable_name] \
-        || resolve_variable_from_xcconfig(variable_name) \
-        || resolve_variable_from_target_configs(variable_name)
+    value = discard(default_options[variable_name.to_sym], variable_name) \
+        || discard(@build_configuration.build_settings[variable_name], variable_name) \
+        || discard(resolve_variable_from_xcconfig(variable_name), variable_name) \
+        || discard(resolve_variable_from_target_configs(variable_name), variable_name)
     value
   end
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
In some cases setting code signing settings failed since the resolved variable actually contained the key that was being resolved. For example bundle ID

```
'${PRODUCT_BUNDLE_IDENTIFIER}.OneSignalNotificationServiceExtension'
```

was resolved to

```
${PRODUCT_BUNDLE_IDENTIFIER}.OneSignalNotificationServiceExtension.OneSignalNotificationServiceExtension
```

because `PRODUCT_BUNDLE_IDENTIFIER` was expanded to 

```
${PRODUCT_BUNDLE_IDENTIFIER}.OneSignalNotificationServiceExtension.OneSignalNotificationServiceExtension
```

This of course is not a desired result and we should discard the recursive definitions when looking up the final value. 