### PR TITLE
Feature: Add option to specify where intermediate xcarchive is stored for `xcode-project build-ios`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.2.4
 
 **Improvements**
 
-- Feature: Add option to specify archive directory to `xcode-project archive` using `--archive-directory` flag.
+- Feature: Add option to specify archive directory to `xcode-project build-ipa` using `--archive-directory` flag.
 
 Version 0.2.3
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.4
+-------------
+
+**Improvements**
+
+- Feature: Add option to specify archive directory to `xcode-project archive` using `--archive-directory` flag.
+
 Version 0.2.3
 -------------
 

--- a/docs/xcode-project/build-ipa.md
+++ b/docs/xcode-project/build-ipa.md
@@ -12,6 +12,7 @@ xcode-project build-ipa [-h] [--log-stream STREAM] [--no-color] [--version] [-s]
     [--target TARGET_NAME]
     [--config CONFIGURATION_NAME]
     [--scheme SCHEME_NAME]
+    [--archive-directory ARCHIVE_DIRECTORY]
     [--ipa-directory IPA_DIRECTORY]
     [--export-options-plist EXPORT_OPTIONS_PATH]
     [--disable-xcpretty]
@@ -39,6 +40,10 @@ Name of the Xcode build configuration
 
 
 Name of the Xcode Scheme
+##### `--archive-directory=ARCHIVE_DIRECTORY`
+
+
+Directory where the created archive is stored. Default:&nbsp;`build/ios/xcarchive`
 ##### `--ipa-directory=IPA_DIRECTORY`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -127,9 +127,10 @@ class Xcodebuild:
 
     def archive(self,
                 export_options: ExportOptions,
+                archive_directory: pathlib.Path,
                 *,
-                archive_directory: Optional[pathlib.Path] = None,
                 cli_app: Optional['CliApp'] = None) -> pathlib.Path:
+        archive_directory.mkdir(parents=True, exist_ok=True)
         temp_dir = tempfile.mkdtemp(
             prefix=f'{self.xcode_project.stem}_',
             suffix='.xcarchive',

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -128,8 +128,13 @@ class Xcodebuild:
     def archive(self,
                 export_options: ExportOptions,
                 *,
+                archive_directory: Optional[pathlib.Path] = None,
                 cli_app: Optional['CliApp'] = None) -> pathlib.Path:
-        temp_dir = tempfile.mkdtemp(prefix=f'{self.xcode_project.stem}_', suffix='.xcarchive')
+        temp_dir = tempfile.mkdtemp(
+            prefix=f'{self.xcode_project.stem}_',
+            suffix='.xcarchive',
+            dir=archive_directory,
+        )
         xcarchive = pathlib.Path(temp_dir)
         cmd = self._construct_archive_command(xcarchive, export_options)
 

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -142,8 +142,9 @@ class Xcodebuild:
         process = None
         try:
             if cli_app:
-                process = XcodebuildCliProcess(cmd, xcpretty=self.xcpretty).execute()
-                process.raise_for_returncode()
+                process = XcodebuildCliProcess(cmd, xcpretty=self.xcpretty)
+                cli_app.logger.info(f'Execute "%s"\n', process.safe_form)
+                process.execute().raise_for_returncode()
             else:
                 subprocess.check_output(cmd)
         except subprocess.CalledProcessError:
@@ -170,8 +171,9 @@ class Xcodebuild:
         process = None
         try:
             if cli_app:
-                process = XcodebuildCliProcess(cmd, xcpretty=self.xcpretty).execute()
-                process.raise_for_returncode()
+                process = XcodebuildCliProcess(cmd, xcpretty=self.xcpretty)
+                cli_app.logger.info(f'Execute "%s"\n', process.safe_form)
+                process.execute().raise_for_returncode()
             else:
                 subprocess.check_output(cmd)
         except subprocess.CalledProcessError:

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -269,6 +269,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 XcodeProjectArgument.TARGET_NAME,
                 XcodeProjectArgument.CONFIGURATION_NAME,
                 XcodeProjectArgument.SCHEME_NAME,
+                XcodeProjectArgument.ARCHIVE_DIRECTORY,
                 XcodeProjectArgument.IPA_DIRECTORY,
                 XcodeProjectArgument.EXPORT_OPTIONS_PATH,
                 XcprettyArguments.DISABLE,

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -100,6 +100,16 @@ class XcodeProjectArgument(cli.Argument):
             'default': pathlib.Path('~/export_options.plist').expanduser()
         }
     )
+    ARCHIVE_DIRECTORY = cli.ArgumentProperties(
+        key='archive_directory',
+        flags=('--archive-directory',),
+        type=pathlib.Path,
+        description='Directory where the created archive is stored',
+        argparse_kwargs={
+            'required': False,
+            'default': pathlib.Path('build/ios/xcarchive')
+        }
+    )
     IPA_DIRECTORY = cli.ArgumentProperties(
         key='ipa_directory',
         flags=('--ipa-directory',),
@@ -269,6 +279,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                   target_name: Optional[str] = None,
                   configuration_name: Optional[str] = None,
                   scheme_name: Optional[str] = None,
+                  archive_directory: pathlib.Path = XcodeProjectArgument.ARCHIVE_DIRECTORY.get_default(),
                   ipa_directory: pathlib.Path = XcodeProjectArgument.IPA_DIRECTORY.get_default(),
                   export_options_plist: pathlib.Path = XcodeProjectArgument.EXPORT_OPTIONS_PATH.get_default(),
                   disable_xcpretty: bool = False,
@@ -295,7 +306,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
             )
 
             self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
-            xcarchive = xcodebuild.archive(export_options, cli_app=self)
+            xcarchive = xcodebuild.archive(export_options, cli_app=self, archive_directory=archive_directory)
             self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}'))
 
             self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -306,7 +306,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
             )
 
             self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
-            xcarchive = xcodebuild.archive(export_options, cli_app=self, archive_directory=archive_directory)
+            xcarchive = xcodebuild.archive(export_options, archive_directory, cli_app=self)
             self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}'))
 
             self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -307,11 +307,11 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
 
             self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
             xcarchive = xcodebuild.archive(export_options, archive_directory, cli_app=self)
-            self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}'))
+            self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}\n'))
 
             self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))
             ipa = xcodebuild.export_archive(xcarchive, export_options_plist, ipa_directory, cli_app=self)
-            self.logger.info(Colors.GREEN(f'Successfully exported ipa to {ipa}'))
+            self.logger.info(Colors.GREEN(f'Successfully exported ipa to {ipa}\n'))
         except (ValueError, IOError) as error:
             raise XcodeProjectException(*error.args)
         finally:


### PR DESCRIPTION
**Changes**:
- Add option to define where the `xcarchive` package is saved during `build-ipa` execution. It now defaults to `build/ios/xcarchive` whereas it used to be in `$TMPDIR`.
- Always log out the exact `xcodebuild` commands that are being executed for transparency, even without verbose mode.