### PR TITLE
Bugfix: Support profile state 'EXPIRED'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.8
+-------------
+
+**Improvements**
+
+- Bugfix: Support profile state `EXPIRED`.
+
 Version 0.2.7
 -------------
 

--- a/docs/app-store-connect/list-bundle-id-profiles.md
+++ b/docs/app-store-connect/list-bundle-id-profiles.md
@@ -32,7 +32,7 @@ Alphanumeric ID value of the Bundle ID. Multiple arguments
 
 
 Type of the provisioning profile
-##### `--state=ACTIVE | INVALID`
+##### `--state=ACTIVE | INVALID | EXPIRED`
 
 
 State of the provisioning profile

--- a/docs/app-store-connect/list-profiles.md
+++ b/docs/app-store-connect/list-profiles.md
@@ -25,7 +25,7 @@ app-store-connect list-profiles [-h] [--log-stream STREAM] [--no-color] [--versi
 
 
 Type of the provisioning profile
-##### `--state=ACTIVE | INVALID`
+##### `--state=ACTIVE | INVALID | EXPIRED`
 
 
 State of the provisioning profile

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -105,6 +105,7 @@ class DeviceStatus(_ResourceEnum):
 class ProfileState(_ResourceEnum):
     ACTIVE = 'ACTIVE'
     INVALID = 'INVALID'
+    EXPIRED = 'EXPIRED'  # Undocumented Profile State
 
 
 class ProfileType(_ResourceEnum):


### PR DESCRIPTION
Despite the supported states `ACTIVE` and `INVALID` defined in the Profile resource API [documentation](https://developer.apple.com/documentation/appstoreconnectapi/profile/attributes), for some cases the API responds with `profileState` attribute set to `EXPIRED`.

For example the profile entry in the response of `GET https://api.appstoreconnect.apple.com/v1/bundleIds/<bundle_id_resource_id>/profiles` was

```javascript
{
    "type": "profiles",
    "id": "<profile_resource_id>",
    "attributes": {
        "profileState": "EXPIRED",   // <-- this should not happen according to the docs
        "createdDate": null,
        "profileType": "IOS_APP_STORE",
        "name": "iOS Team Store Provisioning Profile: com.example.app",
        "profileContent": "...",
        "uuid": "d0e231cf-2d40-4c68-af54-8df241acb71a",
        "platform": "IOS",
        "expirationDate": "2019-05-22T08:12:27.000+0000"
    },
    "relationships": ...,
    "links": ...
}
```
