### PR TITLE
Feature: Optional xcarchive removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+Version 0.2.10
+-------------
+
+**Improvements**
+
+- Update: Make removing generated xcarchive optional.
+
+Version 0.2.9
+-------------
+
+**Improvements**
+
+- Update: Change included `bundletool.jar` to version 1.2.0 from 0.15.0.
+
 Version 0.2.8
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,9 @@
-Version 0.2.10
--------------
-
-**Improvements**
-
-- Update: Make removing generated xcarchive optional.
-
 Version 0.2.9
 -------------
 
 **Improvements**
 
-- Update: Change included `bundletool.jar` to version 1.2.0 from 0.15.0.
+- Update: Make removing generated xcarchive optional.
 
 Version 0.2.8
 -------------

--- a/docs/xcode-project/build-ipa.md
+++ b/docs/xcode-project/build-ipa.md
@@ -15,6 +15,7 @@ xcode-project build-ipa [-h] [--log-stream STREAM] [--no-color] [--version] [-s]
     [--archive-directory ARCHIVE_DIRECTORY]
     [--ipa-directory IPA_DIRECTORY]
     [--export-options-plist EXPORT_OPTIONS_PATH]
+    [--remove-xcarchive]
     [--disable-xcpretty]
     [--xcpretty-options OPTIONS]
 ```
@@ -52,6 +53,10 @@ Directory where the built ipa is stored. Default:&nbsp;`build/ios/ipa`
 
 
 Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.plist`
+##### `--remove-xcarchive`
+
+
+Remove generated xcarchive container while building ipa
 ##### `--disable-xcpretty`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.8"
+__version__ = "0.2.10"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.10"
+__version__ = "0.2.9"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -130,6 +130,13 @@ class XcodeProjectArgument(cli.Argument):
         ),
         argparse_kwargs={'required': False}
     )
+    REMOVE_XCARCHIVE = cli.ArgumentProperties(
+        key='remove_xcarchive',
+        flags=('--remove-xcarchive',),
+        type=bool,
+        description='Remove generated xcarchive container while building ipa',
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
 
 
 class XcprettyArguments(cli.Argument):
@@ -272,6 +279,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 XcodeProjectArgument.ARCHIVE_DIRECTORY,
                 XcodeProjectArgument.IPA_DIRECTORY,
                 XcodeProjectArgument.EXPORT_OPTIONS_PATH,
+                XcodeProjectArgument.REMOVE_XCARCHIVE,
                 XcprettyArguments.DISABLE,
                 XcprettyArguments.OPTIONS)
     def build_ipa(self,
@@ -283,6 +291,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                   archive_directory: pathlib.Path = XcodeProjectArgument.ARCHIVE_DIRECTORY.get_default(),
                   ipa_directory: pathlib.Path = XcodeProjectArgument.IPA_DIRECTORY.get_default(),
                   export_options_plist: pathlib.Path = XcodeProjectArgument.EXPORT_OPTIONS_PATH.get_default(),
+                  remove_xcarchive: bool = False,
                   disable_xcpretty: bool = False,
                   xcpretty_options: str = XcprettyArguments.OPTIONS.get_default()) -> pathlib.Path:
         """
@@ -318,7 +327,8 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         finally:
             if not disable_xcpretty and xcodebuild:
                 self.logger.info(f'Raw xcodebuild logs stored in {xcodebuild.logs_path}')
-            if xcarchive is not None:
+            if xcarchive is not None and remove_xcarchive:
+                self.logger.info(f'Removing generated xcarchive {xcarchive.resolve()}')
                 shutil.rmtree(xcarchive, ignore_errors=True)
         return ipa
 


### PR DESCRIPTION
When building ipa using `xcode-project build-ipa` the intermediate `xcarchive` container was always removed. But often times we'd like to persist the archive too. Change the default behaviour so that the xcarchive is removed only if `--remove-xcarchive` feature flag is specified.