### PR TITLE
Bugfix: Support choosing iCloudContainerEnvironment from multiple options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.11
+-------------
+
+**Improvements**
+
+- Bugfix: Fix obtaining `iCloudContainerEnvironment` export option when multiple values are available.
+
 Version 0.2.10
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/code_sign_entitlements.py
+++ b/src/codemagic/models/code_sign_entitlements.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import zipfile
 from typing import Any
+from typing import AnyStr
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -31,6 +32,11 @@ class CodeSignEntitlements(StringConverterMixin):
             raise IOError('Missing executable "codesign"')
 
     @classmethod
+    def from_plist(cls, plist: AnyStr) -> CodeSignEntitlements:
+        parsed_plist = plistlib.loads(cls._bytes(plist))
+        return CodeSignEntitlements(parsed_plist)
+
+    @classmethod
     def from_app(cls, app_path: pathlib.Path, cli_app: Optional['CliApp'] = None) -> CodeSignEntitlements:
         cls._ensure_codesign()
         cmd = ('codesign', '-d', '--entitlements', ':-', str(app_path))
@@ -38,13 +44,13 @@ class CodeSignEntitlements(StringConverterMixin):
             if cli_app:
                 process = cli_app.execute(cmd, show_output=False)
                 process.raise_for_returncode()
-                output = cls._bytes(process.stdout)
+                output = process.stdout
             else:
                 output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as cpe:
             raise IOError(f'Failed to obtain entitlements from {app_path}, {cls._str(cpe.stderr)}')
 
-        return CodeSignEntitlements(plistlib.loads(output))
+        return cls.from_plist(output)
 
     @classmethod
     def from_ipa(cls, ipa_path: pathlib.Path, cli_app: Optional['CliApp'] = None) -> CodeSignEntitlements:
@@ -70,8 +76,15 @@ class CodeSignEntitlements(StringConverterMixin):
             raise IOError(f'Failed to obtain entitlements from {xcarchive_path}, .app not found')
         return cls.from_app(app_path, cli_app=cli_app)
 
-    def get_icloud_container_environment(self) -> Optional[str]:
-        return self.plist.get('com.apple.developer.icloud-container-environment')
+    def get_icloud_container_environments(self) -> List[str]:
+        environment = self.plist.get('com.apple.developer.icloud-container-environment')
+        if environment is None:
+            return []
+        elif isinstance(environment, str):
+            return [environment]
+        elif isinstance(environment, list):
+            return environment
+        raise ValueError(f'Unknown type for environment: {type(environment)}')
 
     def get_icloud_services(self) -> List[str]:
         return self.plist.get('com.apple.developer.icloud-services', [])

--- a/src/codemagic/models/code_sign_entitlements.py
+++ b/src/codemagic/models/code_sign_entitlements.py
@@ -44,7 +44,7 @@ class CodeSignEntitlements(StringConverterMixin):
             if cli_app:
                 process = cli_app.execute(cmd, show_output=False)
                 process.raise_for_returncode()
-                output = process.stdout
+                output = cls._bytes(process.stdout)
             else:
                 output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as cpe:

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -342,7 +342,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         # needs to be specified. Available options are Development and Production.
         # Defaults to Development.
 
-        if export_options.is_app_store_export():
+        if export_options.is_app_store_export() or export_options.iCloudContainerEnvironment:
             return
 
         archive_entitlements = CodeSignEntitlements.from_xcarchive(xcarchive, cli_app=self)
@@ -350,7 +350,11 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         if not {'CloudKit', 'CloudDocuments'}.intersection(icloud_services):
             return
 
-        icloud_container_environment = archive_entitlements.get_icloud_container_environment() or 'Development'
+        if 'Production' in archive_entitlements.get_icloud_container_environments():
+            icloud_container_environment = 'Production'
+        else:
+            icloud_container_environment = 'Development'
+
         self.echo('App is using iCloud services that require iCloudContainerEnvironment export option')
         self.echo('Set iCloudContainerEnvironment export option to %s', icloud_container_environment)
         export_options.set_value('iCloudContainerEnvironment', icloud_container_environment)

--- a/tests/models/mocks/mock_0_icloud_container_environments.plist
+++ b/tests/models/mocks/mock_0_icloud_container_environments.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>X8NNQ9CYL2</string>
+	<key>get-task-allow</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	</array>
+</dict>
+</plist>

--- a/tests/models/mocks/mock_1_icloud_container_environments.plist
+++ b/tests/models/mocks/mock_1_icloud_container_environments.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	<key>com.apple.developer.icloud-container-environment</key>
+	<string>Production</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>X8NNQ9CYL2</string>
+	<key>get-task-allow</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	</array>
+</dict>
+</plist>

--- a/tests/models/mocks/mock_2_icloud_container_environments.plist
+++ b/tests/models/mocks/mock_2_icloud_container_environments.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	<key>com.apple.developer.icloud-container-environment</key>
+	<array>
+		<string>Development</string>
+		<string>Production</string>
+	</array>
+	<key>com.apple.developer.team-identifier</key>
+	<string>X8NNQ9CYL2</string>
+	<key>get-task-allow</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>X8NNQ9CYL2.io.codemagic.capybara</string>
+	</array>
+</dict>
+</plist>

--- a/tests/models/test_code_sign_entitlements.py
+++ b/tests/models/test_code_sign_entitlements.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from codemagic.models import CodeSignEntitlements
@@ -22,3 +24,15 @@ def test_from_xcarchive(mock_xcarchive_path):
 def test_from_ipa(mock_ipa_path):
     entitlements = CodeSignEntitlements.from_ipa(mock_ipa_path)
     assert entitlements.plist == _expected_entitlements
+
+
+@pytest.mark.parametrize('defined_environments_number, expected_environments', [
+    (0, []),
+    (1, ['Production']),
+    (2, ['Development', 'Production']),
+])
+def test_get_icloud_container_environments(defined_environments_number, expected_environments):
+    mock_filename = f'mock_{defined_environments_number}_icloud_container_environments.plist'
+    mock_path = pathlib.Path(__file__).parent / 'mocks' / mock_filename
+    entitlements = CodeSignEntitlements.from_plist(mock_path.read_bytes())
+    assert entitlements.get_icloud_container_environments() == expected_environments


### PR DESCRIPTION
Entitlements in xcarchvies can specify all possible values for iCloudContainerEnvironment. Choose the most sensible for exporting ipa.