### PR TITLE
Improvement: Improv error handling for missing export options on build-ipa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.12
+-------------
+
+**Improvements**
+
+- Improvement: Fail gracefully with appropriate error message when non-existent export options plist path is passed to `xcode-project build-ipa`. 
+
 Version 0.2.11
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -299,9 +299,9 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         Build ipa by archiving the Xcode project and then exporting it
         """
 
-        # if xcode_project_path is None and xcode_workspace_path is None:
-        #     error = 'Workspace or project argument needs to be specified'
-        #     XcodeProjectArgument.XCODE_WORKSPACE_PATH.raise_argument_error(error)
+        if xcode_project_path is None and xcode_workspace_path is None:
+            error = 'Workspace or project argument needs to be specified'
+            XcodeProjectArgument.XCODE_WORKSPACE_PATH.raise_argument_error(error)
         if not export_options_plist.is_file():
             error = f'Path "{export_options_plist}" does not exist'
             XcodeProjectArgument.EXPORT_OPTIONS_PATH.raise_argument_error(error)

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -299,9 +299,12 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         Build ipa by archiving the Xcode project and then exporting it
         """
 
-        if xcode_project_path is None and xcode_workspace_path is None:
-            error = 'Workspace or project argument needs to be specified'
-            XcodeProjectArgument.XCODE_WORKSPACE_PATH.raise_argument_error(error)
+        # if xcode_project_path is None and xcode_workspace_path is None:
+        #     error = 'Workspace or project argument needs to be specified'
+        #     XcodeProjectArgument.XCODE_WORKSPACE_PATH.raise_argument_error(error)
+        if not export_options_plist.is_file():
+            error = f'Path "{export_options_plist}" does not exist'
+            XcodeProjectArgument.EXPORT_OPTIONS_PATH.raise_argument_error(error)
 
         xcarchive: Optional[pathlib.Path] = None
         xcodebuild: Optional[Xcodebuild] = None


### PR DESCRIPTION
If given export options plist does not exist then running `xcode-project build-ipa` action fails unexpectely:

```bash
$ xcode-project build-ipa --project Project.xcodeproj --export-options-plist missing-export-options.plist
Executing XcodeProject action build-ipa failed unexpectedly. Detailed logs are available at "/var/folders/s_/1kqm5m1x0gg_r7yvbm2j1h3h0000gn/T/codemagic-11-09-20.log". To see more details about the error, add `--verbose` command line option.
```

With the introduced changes the reason for error is highlighted in a more user-friendly fashion:

```bash
$ xcode-project build-ipa --project Project.xcodeproj --export-options-plist missing-export-options.plist
usage: xcode_project.py [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] {build-ipa,detect-bundle-id,use-profiles} ...
xcode-project: error: argument --export-options-plist: Path "missing-export-options.plist" does not exist
```