### PR TITLE
Feature: Custom xcodebuild flags and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.3.0
+-------------
+
+**Improvements**
+
+- Feature: Add option to specify custom `xcodebuild` arguments and flags for `archive` and `-exportArchive` actions with `xcode-project build-ipa` using `--archive-flags`, `--archive-xcargs`, `--export-flags` and `--export-xcargs` modifiers.
+
 Version 0.2.13
 -------------
 

--- a/docs/xcode-project/build-ipa.md
+++ b/docs/xcode-project/build-ipa.md
@@ -13,8 +13,12 @@ xcode-project build-ipa [-h] [--log-stream STREAM] [--no-color] [--version] [-s]
     [--config CONFIGURATION_NAME]
     [--scheme SCHEME_NAME]
     [--archive-directory ARCHIVE_DIRECTORY]
+    [--archive-flags ARCHIVE_FLAGS]
+    [--archive-xcargs ARCHIVE_XCARGS]
     [--ipa-directory IPA_DIRECTORY]
     [--export-options-plist EXPORT_OPTIONS_PATH]
+    [--export-flags EXPORT_FLAGS]
+    [--export-xcargs EXPORT_XCARGS]
     [--remove-xcarchive]
     [--disable-xcpretty]
     [--xcpretty-options OPTIONS]
@@ -45,6 +49,14 @@ Name of the Xcode Scheme
 
 
 Directory where the created archive is stored. Default:&nbsp;`build/ios/xcarchive`
+##### `--archive-flags=ARCHIVE_FLAGS`
+
+
+Pass additional command line options to xcodebuild for the archive phase. For example "-derivedDataPath=$HOME/myDerivedData -quiet".
+##### `--archive-xcargs=ARCHIVE_XCARGS`
+
+
+Pass additional arguments to xcodebuild for the archive phase. For example 'COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++'. Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
 ##### `--ipa-directory=IPA_DIRECTORY`
 
 
@@ -53,6 +65,14 @@ Directory where the built ipa is stored. Default:&nbsp;`build/ios/ipa`
 
 
 Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.plist`
+##### `--export-flags=EXPORT_FLAGS`
+
+
+Pass additional command line options to xcodebuild for the exportArchive phase. For example "-derivedDataPath=$HOME/myDerivedData -quiet".
+##### `--export-xcargs=EXPORT_XCARGS`
+
+
+Pass additional arguments to xcodebuild for the exportArchive phase. For example "COMPILER_INDEX_STORE_ENABLE=NO". Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
 ##### `--remove-xcarchive`
 
 

--- a/docs/xcode-project/build-ipa.md
+++ b/docs/xcode-project/build-ipa.md
@@ -52,11 +52,11 @@ Directory where the created archive is stored. Default:&nbsp;`build/ios/xcarchiv
 ##### `--archive-flags=ARCHIVE_FLAGS`
 
 
-Pass additional command line options to xcodebuild for the archive phase. For example "-derivedDataPath=$HOME/myDerivedData -quiet".
+Pass additional command line options to xcodebuild for the archive phase. For example `-derivedDataPath=$HOME/myDerivedData -quiet`.
 ##### `--archive-xcargs=ARCHIVE_XCARGS`
 
 
-Pass additional arguments to xcodebuild for the archive phase. For example 'COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++'. Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
+Pass additional arguments to xcodebuild for the archive phase. For example `COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++`. Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
 ##### `--ipa-directory=IPA_DIRECTORY`
 
 
@@ -68,11 +68,11 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 ##### `--export-flags=EXPORT_FLAGS`
 
 
-Pass additional command line options to xcodebuild for the exportArchive phase. For example "-derivedDataPath=$HOME/myDerivedData -quiet".
+Pass additional command line options to xcodebuild for the exportArchive phase. For example `-derivedDataPath=$HOME/myDerivedData -quiet`.
 ##### `--export-xcargs=EXPORT_XCARGS`
 
 
-Pass additional arguments to xcodebuild for the exportArchive phase. For example "COMPILER_INDEX_STORE_ENABLE=NO". Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
+Pass additional arguments to xcodebuild for the exportArchive phase. For example `COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++`. Default:&nbsp;`COMPILER_INDEX_STORE_ENABLE=NO`
 ##### `--remove-xcarchive`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.2.13"
+__version__ = "0.3.0"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -11,6 +11,7 @@ from typing import IO
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Union
 
 from codemagic.cli import CliProcess
 from codemagic.utilities import log
@@ -215,7 +216,7 @@ class Xcodebuild:
                        custom_flags: Optional[str] = None,
                        cli_app: Optional['CliApp'] = None) -> pathlib.Path:
         ipa_directory.mkdir(parents=True, exist_ok=True)
-        cmd = [
+        cmd: List[Union[str, pathlib.Path]] = [
             'xcodebuild', '-exportArchive',
             '-archivePath', archive_path,
             '-exportPath', ipa_directory,

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import pathlib
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -61,7 +63,7 @@ class Xcodebuild:
                 fd.write(chunk)
                 chunk = process_logs.read(8192)
             # do an extra read in case xcodebuild exited unexpectedly and did not flush last buffer
-            fd.write(process_logs.read()) 
+            fd.write(process_logs.read())
 
             fd.write('\n\n')
             duration = time.strftime("%M:%S", time.gmtime(xcodebuild_cli_process.duration))
@@ -97,7 +99,11 @@ class Xcodebuild:
     def _detect_schemes(cls, project: pathlib.Path) -> List[str]:
         return [scheme.stem for scheme in project.glob('**/*.xcscheme')]
 
-    def _construct_archive_command(self, archive_path: pathlib.Path, export_options: ExportOptions) -> List[str]:
+    def _construct_archive_command(self,
+                                   archive_path: pathlib.Path,
+                                   export_options: ExportOptions,
+                                   xcargs: Optional[str],
+                                   custom_flags: Optional[str]) -> List[str]:
         command = ['xcodebuild']
 
         if self.workspace:
@@ -110,12 +116,15 @@ class Xcodebuild:
             command.extend(['-target', self.target])
         if self.configuration:
             command.extend(['-config', self.configuration])
+        if custom_flags:
+            command.extend([os.path.expandvars(part) for part in shlex.split(custom_flags)])
 
         command.extend([
             '-archivePath', str(archive_path),
-            'archive',
-            'COMPILER_INDEX_STORE_ENABLE=NO'
+            'archive'
         ])
+        if xcargs:
+            command.extend(shlex.split(xcargs))
 
         if not export_options.has_xcode_managed_profiles():
             if export_options.teamID:
@@ -169,6 +178,8 @@ class Xcodebuild:
                 export_options: ExportOptions,
                 archive_directory: pathlib.Path,
                 *,
+                xcargs: Optional[str] = None,
+                custom_flags: Optional[str] = None,
                 cli_app: Optional['CliApp'] = None) -> pathlib.Path:
         archive_directory.mkdir(parents=True, exist_ok=True)
         temp_dir = tempfile.mkdtemp(
@@ -177,7 +188,7 @@ class Xcodebuild:
             dir=archive_directory,
         )
         xcarchive = pathlib.Path(temp_dir)
-        cmd = self._construct_archive_command(xcarchive, export_options)
+        cmd = self._construct_archive_command(xcarchive, export_options, xcargs, custom_flags)
 
         self._ensure_clean_core_simulator_service(cli_app)
 
@@ -200,15 +211,20 @@ class Xcodebuild:
                        export_options_plist: pathlib.Path,
                        ipa_directory: pathlib.Path,
                        *,
+                       xcargs: Optional[str] = None,
+                       custom_flags: Optional[str] = None,
                        cli_app: Optional['CliApp'] = None) -> pathlib.Path:
         ipa_directory.mkdir(parents=True, exist_ok=True)
-        cmd = (
+        cmd = [
             'xcodebuild', '-exportArchive',
             '-archivePath', archive_path,
             '-exportPath', ipa_directory,
             '-exportOptionsPlist', export_options_plist,
-            'COMPILER_INDEX_STORE_ENABLE=NO'
-        )
+        ]
+        if custom_flags:
+            cmd.extend([os.path.expandvars(part) for part in shlex.split(custom_flags)])
+        if xcargs:
+            cmd.extend(shlex.split(xcargs))
 
         process = None
         try:

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -144,7 +144,7 @@ class XcodeProjectArgument(cli.Argument):
         type=str,
         description=(
             'Pass additional arguments to xcodebuild for the archive phase. '
-            'For example \'COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++\'.'
+            'For example `COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++`.'
         ),
         argparse_kwargs={'required': False, 'default': 'COMPILER_INDEX_STORE_ENABLE=NO'},
     )
@@ -154,7 +154,7 @@ class XcodeProjectArgument(cli.Argument):
         type=str,
         description=(
             'Pass additional command line options to xcodebuild for the archive phase. '
-            'For example "-derivedDataPath=$HOME/myDerivedData -quiet".'
+            'For example `-derivedDataPath=$HOME/myDerivedData -quiet`.'
         ),
         argparse_kwargs={'required': False, 'default': ''},
     )
@@ -164,7 +164,7 @@ class XcodeProjectArgument(cli.Argument):
         type=str,
         description=(
             'Pass additional arguments to xcodebuild for the exportArchive phase. '
-            'For example "COMPILER_INDEX_STORE_ENABLE=NO".'
+            'For example `COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++`.'
         ),
         argparse_kwargs={'required': False, 'default': 'COMPILER_INDEX_STORE_ENABLE=NO'},
     )
@@ -174,7 +174,7 @@ class XcodeProjectArgument(cli.Argument):
         type=str,
         description=(
             'Pass additional command line options to xcodebuild for the exportArchive phase. '
-            'For example "-derivedDataPath=$HOME/myDerivedData -quiet".'
+            'For example `-derivedDataPath=$HOME/myDerivedData -quiet`.'
         ),
         argparse_kwargs={'required': False, 'default': ''},
     )

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -138,16 +138,45 @@ class XcodeProjectArgument(cli.Argument):
         description='Remove generated xcarchive container while building ipa',
         argparse_kwargs={'required': False, 'action': 'store_true'},
     )
+    ARCHIVE_XCARGS = cli.ArgumentProperties(
+        key='archive_xcargs',
+        flags=('--archive-xcargs',),
+        type=str,
+        description=(
+            'Pass additional arguments to xcodebuild for the archive phase. '
+            'For example \'COMPILER_INDEX_STORE_ENABLE=NO OTHER_LDFLAGS="-ObjC -lstdc++\'.'
+        ),
+        argparse_kwargs={'required': False, 'default': 'COMPILER_INDEX_STORE_ENABLE=NO'},
+    )
     ARCHIVE_FLAGS = cli.ArgumentProperties(
         key='archive_flags',
         flags=('--archive-flags',),
-        type=bool,
+        type=str,
         description=(
-            # TODO
-            'Command line options for xcodebuild archive action. '
-            'For example "-derivedDataPath=$HOME/derivedData" or "-quiet".'
+            'Pass additional command line options to xcodebuild for the archive phase. '
+            'For example "-derivedDataPath=$HOME/myDerivedData -quiet".'
         ),
-        argparse_kwargs={'required': False, 'default': '--color'},
+        argparse_kwargs={'required': False, 'default': ''},
+    )
+    EXPORT_XCARGS = cli.ArgumentProperties(
+        key='export_xcargs',
+        flags=('--export-xcargs',),
+        type=str,
+        description=(
+            'Pass additional arguments to xcodebuild for the exportArchive phase. '
+            'For example "COMPILER_INDEX_STORE_ENABLE=NO".'
+        ),
+        argparse_kwargs={'required': False, 'default': 'COMPILER_INDEX_STORE_ENABLE=NO'},
+    )
+    EXPORT_FLAGS = cli.ArgumentProperties(
+        key='export_flags',
+        flags=('--export-flags',),
+        type=str,
+        description=(
+            'Pass additional command line options to xcodebuild for the exportArchive phase. '
+            'For example "-derivedDataPath=$HOME/myDerivedData -quiet".'
+        ),
+        argparse_kwargs={'required': False, 'default': ''},
     )
 
 
@@ -289,10 +318,13 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 XcodeProjectArgument.CONFIGURATION_NAME,
                 XcodeProjectArgument.SCHEME_NAME,
                 XcodeProjectArgument.ARCHIVE_DIRECTORY,
+                XcodeProjectArgument.ARCHIVE_FLAGS,
+                XcodeProjectArgument.ARCHIVE_XCARGS,
                 XcodeProjectArgument.IPA_DIRECTORY,
                 XcodeProjectArgument.EXPORT_OPTIONS_PATH,
+                XcodeProjectArgument.EXPORT_FLAGS,
+                XcodeProjectArgument.EXPORT_XCARGS,
                 XcodeProjectArgument.REMOVE_XCARCHIVE,
-                XcodeProjectArgument.ARCHIVE_FLAGS,
                 XcprettyArguments.DISABLE,
                 XcprettyArguments.OPTIONS)
     def build_ipa(self,
@@ -302,8 +334,12 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                   configuration_name: Optional[str] = None,
                   scheme_name: Optional[str] = None,
                   archive_directory: pathlib.Path = XcodeProjectArgument.ARCHIVE_DIRECTORY.get_default(),
+                  archive_xcargs: Optional[str] = XcodeProjectArgument.ARCHIVE_XCARGS.get_default(),
+                  archive_flags: Optional[str] = XcodeProjectArgument.ARCHIVE_FLAGS.get_default(),
                   ipa_directory: pathlib.Path = XcodeProjectArgument.IPA_DIRECTORY.get_default(),
                   export_options_plist: pathlib.Path = XcodeProjectArgument.EXPORT_OPTIONS_PATH.get_default(),
+                  export_xcargs: Optional[str] = XcodeProjectArgument.EXPORT_XCARGS.get_default(),
+                  export_flags: Optional[str] = XcodeProjectArgument.EXPORT_FLAGS.get_default(),
                   remove_xcarchive: bool = False,
                   disable_xcpretty: bool = False,
                   xcpretty_options: str = XcprettyArguments.OPTIONS.get_default()) -> pathlib.Path:
@@ -332,13 +368,24 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
             )
 
             self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
-            xcarchive = xcodebuild.archive(export_options, archive_directory, cli_app=self)
+            xcarchive = xcodebuild.archive(
+                export_options,
+                archive_directory,
+                xcargs=archive_xcargs,
+                custom_flags=archive_flags,
+                cli_app=self)
             self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}\n'))
 
             self._update_export_options(xcarchive, export_options_plist, export_options)
 
             self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))
-            ipa = xcodebuild.export_archive(xcarchive, export_options_plist, ipa_directory, cli_app=self)
+            ipa = xcodebuild.export_archive(
+                xcarchive,
+                export_options_plist,
+                ipa_directory,
+                xcargs=export_xcargs,
+                custom_flags=export_flags,
+                cli_app=self)
             self.logger.info(Colors.GREEN(f'Successfully exported ipa to {ipa}\n'))
         except (ValueError, IOError) as error:
             raise XcodeProjectException(*error.args)

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -138,6 +138,17 @@ class XcodeProjectArgument(cli.Argument):
         description='Remove generated xcarchive container while building ipa',
         argparse_kwargs={'required': False, 'action': 'store_true'},
     )
+    ARCHIVE_FLAGS = cli.ArgumentProperties(
+        key='archive_flags',
+        flags=('--archive-flags',),
+        type=bool,
+        description=(
+            # TODO
+            'Command line options for xcodebuild archive action. '
+            'For example "-derivedDataPath=$HOME/derivedData" or "-quiet".'
+        ),
+        argparse_kwargs={'required': False, 'default': '--color'},
+    )
 
 
 class XcprettyArguments(cli.Argument):
@@ -281,6 +292,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 XcodeProjectArgument.IPA_DIRECTORY,
                 XcodeProjectArgument.EXPORT_OPTIONS_PATH,
                 XcodeProjectArgument.REMOVE_XCARCHIVE,
+                XcodeProjectArgument.ARCHIVE_FLAGS,
                 XcprettyArguments.DISABLE,
                 XcprettyArguments.OPTIONS)
     def build_ipa(self,


### PR DESCRIPTION
Resolves PR https://github.com/codemagic-ci-cd/cli-tools/issues/27.

**New feature**:

Add option to specify custom `xcodebuild` arguments and flags for `archive` and `-exportArchive` actions that are launched as part of `xcode-project build-ipa` using the following modifiers:
- `--archive-flags`,
- `--archive-xcargs`,
- `--export-flags` and
- `--export-xcargs`.
