### PR TITLE
Bugfix: Do not fail `keychain add-certificate` if certificate already exists in keychain 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.3.2
+-------------
+
+**Improvements**
+
+- Bugfix: Do not fail `keychain add-certificate` action in case the added certificate already exists in keychain.
+
 Version 0.3.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -280,8 +280,12 @@ class Keychain(cli.CliApp, PathFinderMixin):
             '-T', shutil.which('codesign'),
             '-P', certificate_password.value,
         ], obfuscate_patterns=obfuscate_patterns)
+
         if process.returncode != 0:
-            raise KeychainError(f'Unable to add certificate {certificate_path} to keychain {self.path}', process)
+            if 'The specified item already exists in the keychain' in process.stderr:
+                pass  # It is fine that the certificate is already in keychain
+            else:
+                raise KeychainError(f'Unable to add certificate {certificate_path} to keychain {self.path}', process)
 
     def _find_certificates(self):
         process = self.execute(('security', 'find-certificate', '-a', '-p', self.path), show_output=False)


### PR DESCRIPTION
It used to be that `keychain add-certificate` would exit with status code 1 in case a certificate that already exists in specified keychin exists. Like that:
```bash
> keychain add-certificates
Add certificates to keychain /Users/priit/Library/Keychains/login.keychain-db
Searching for files matching /Users/priit/Library/MobileDevice/Certificates/*.p12
Add certificate /Users/priit/Library/MobileDevice/Certificates/IOS_DEVELOPMENT_certificate_3924A8A5ADAD4FBE_jsq0iv3p.p12 to keychain /Users/priit/Library/Keychains/login.keychain-db
1 key imported.
1 certificate imported.
Add certificate /Users/priit/Library/MobileDevice/Certificates/IOS_DEVELOPMENT_certificate_3924A8A5ADAD4FBE_w7m2zrrp.p12 to keychain /Users/priit/Library/Keychains/login.keychain-db
security: SecKeychainItemImport: The specified item already exists in the keychain.
Unable to add certificate /Users/priit/Library/MobileDevice/Certificates/IOS_DEVELOPMENT_certificate_3924A8A5ADAD4FBE_w7m2zrrp.p12 to keychain /Users/priit/Library/Keychains/login.keychain-db
```

This is not a desired behaviour as our main goal is to add certificates to keychain. In case some of the certificates are already present in the keychain, then naturally our aspiration is fulfilled, and we can ignore the underlying error from `security`.

Updated behaviour is that `The specified item already exists in the keychain.`  errors are ignored:
```bash
> keychain add-certificates
Add certificates to keychain /Users/priit/Library/Keychains/login.keychain-db
Searching for files matching /Users/priit/Library/MobileDevice/Certificates/*.p12
Add certificate /Users/priit/Library/MobileDevice/Certificates/IOS_DEVELOPMENT_certificate_3924A8A5ADAD4FBE_jsq0iv3p.p12 to keychain /Users/priit/Library/Keychains/login.keychain-db
security: SecKeychainItemImport: The specified item already exists in the keychain.
Add certificate /Users/priit/Library/MobileDevice/Certificates/IOS_DEVELOPMENT_certificate_3924A8A5ADAD4FBE_w7m2zrrp.p12 to keychain /Users/priit/Library/Keychains/login.keychain-db
1 key imported.
1 certificate imported.
```