### PR TITLE
Improvement: Single Xcpretty process to format xcodebuild logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.4.3
+-------------
+
+**Improvements**
+
+- Improvement: Use a single `xcpretty` process throughout `xcodebuild` invocation for log formatting instead of forking new processes for each log chunk.
+
 Version 0.4.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -298,3 +298,5 @@ class XcodebuildCliProcess(CliProcess):
             if self._buffer:
                 self._buffer.close()
                 self._buffer = None
+            if self.xcpretty:
+                self.xcpretty.flush()

--- a/src/codemagic/models/xcpretty.py
+++ b/src/codemagic/models/xcpretty.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from typing import AnyStr
 from typing import IO
+from typing import Optional
 from typing import Union
 
 from codemagic.mixins import StringConverterMixin
@@ -16,9 +17,9 @@ class Xcpretty(StringConverterMixin):
     def __init__(self, custom_options: str = '', stdout: _IO = sys.stdout, stderr: _IO = sys.stderr):
         self._ensure_xcpretty()
         self._command = ['xcpretty'] + shlex.split(custom_options)
-        self._process = None
-        self._stdout = stdout
-        self._stderr = stderr
+        self._process: Optional[subprocess.Popen] = None
+        self._stdout: _IO = stdout
+        self._stderr: _IO = stderr
 
     @classmethod
     def _ensure_xcpretty(cls):
@@ -37,7 +38,8 @@ class Xcpretty(StringConverterMixin):
                 stderr=self._stderr,
             )
 
-        self._process.stdin.write(self._bytes(chunk))
+        if self._process.stdin:
+            self._process.stdin.write(self._bytes(chunk))
 
     def flush(self):
         if self._process is None:


### PR DESCRIPTION
Use single Xcpretty process thoughout the xcodebuild invokation to format logs instead of creating separate process to format each chunk.