### PR TITLE
Improvement: Do not store xcodebuild logs in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.4.4
+-------------
+
+**Improvements**
+
+- Improvement: Reduce memory footprint for `xcode-process` by not storing xcodebuild logs in memory. Read them from file if need be.
+
 Version 0.4.3
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -252,7 +252,7 @@ class Xcodebuild(RunningCliAppMixin):
             if cli_app:
                 process = XcodebuildCliProcess(command, xcpretty=self.xcpretty)
                 cli_app.logger.info(f'Execute "%s"\n', process.safe_form)
-                process.execute().raise_for_returncode()
+                process.execute().raise_for_returncode(include_logs=False)
             else:
                 subprocess.check_output(command)
         except subprocess.CalledProcessError as cpe:
@@ -272,6 +272,14 @@ class XcodebuildCliProcess(CliProcess):
         self._buffer: Optional[IO] = None
         self.xcpretty = xcpretty
 
+    @property
+    def stdout(self) -> str:
+        return self.log_path.read_text()
+
+    @property
+    def stderr(self) -> str:
+        return ''
+
     def _print_stream(self, chunk: str):
         if not self._print_streams:
             return
@@ -286,7 +294,6 @@ class XcodebuildCliProcess(CliProcess):
         lines = self._buffer.readlines(buffer_size or -1)
         chunk = ''.join(lines)
         self._print_stream(chunk)
-        self.stdout += chunk
 
     def execute(self, *args, **kwargs) -> XcodebuildCliProcess:
         try:


### PR DESCRIPTION
Currently `xcode-project` stores `xcodebuild` logs both in memory and in a file. The former is not needed and adds unnecessary memory overhead.