### PR TITLE
Improvement: Add option to specify allowed apps for keychain add-certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.4.5
+-------------
+
+**Improvements**
+
+- Improvement: Add options to `keychain add-certificates` to specify which applications have access to the imported certificate without warning.
+
 Version 0.4.4
 -------------
 

--- a/doc.py
+++ b/doc.py
@@ -88,6 +88,8 @@ class ArgumentsSerializer:
         def _process_default(default):
             if not default:
                 return ''
+            if isinstance(default, tuple) and len(default) > 1 and isinstance(default[0], Path):
+                default = ', '.join(str(p).replace(str(Path.home()), '$HOME') for p in default)
             if isinstance(default, tuple) and isinstance(default[0], Path):
                 default = default[0]
             if isinstance(default, Path):

--- a/docs/keychain/add-certificates.md
+++ b/docs/keychain/add-certificates.md
@@ -10,6 +10,9 @@ keychain add-certificates [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [-p PATH]
     [-c CERTIFICATE_PATHS]
     [--certificate-password CERTIFICATE_PASSWORD]
+    [-a ALLOWED_APPLICATIONS]
+    [-A]
+    [-D]
 ```
 ### Optional arguments for action `add-certificates`
 
@@ -21,6 +24,18 @@ Path to pkcs12 certificate. Can be either a path literal, or a glob pattern to m
 
 
 Encrypted p12 certificate password. Alternatively to entering CERTIFICATE_PASSWORD in plaintext, it may also be specified using a "@env:" prefix followed by a environment variable name, or "@file:" prefix followed by a path to the file containing the value. Example: "@env:<variable>" uses the value in the environment variable named "<variable>", and "@file:<file_path>" uses the value from file at "<file_path>". [Default: '']
+##### `-a, --allow-app=ALLOWED_APPLICATIONS`
+
+
+Specify an application which may access the imported key without warning. Multiple arguments. Default:&nbsp;`('/usr/bin/codesign', '/usr/bin/productsign')`
+##### `-A, --allow-all-applications`
+
+
+Allow any application to access the imported key without warning
+##### `-D, --disallow-all-applications`
+
+
+Do not allow any applications to access the imported key without warning
 ### Optional arguments for command `keychain`
 
 ##### `-p, --path=PATH`

--- a/docs/keychain/add-certificates.md
+++ b/docs/keychain/add-certificates.md
@@ -27,7 +27,7 @@ Encrypted p12 certificate password. Alternatively to entering CERTIFICATE_PASSWO
 ##### `-a, --allow-app=ALLOWED_APPLICATIONS`
 
 
-Specify an application which may access the imported key without warning. Multiple arguments. Default:&nbsp;`('/usr/bin/codesign', '/usr/bin/productsign')`
+Specify an application which may access the imported key without warning. Multiple arguments. Default:&nbsp;`codesign, productsign`
 ##### `-A, --allow-all-applications`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument/argument.py
+++ b/src/codemagic/cli/argument/argument.py
@@ -15,6 +15,10 @@ from .argument_properties import ArgumentProperties
 
 class Argument(ArgumentProperties, enum.Enum):
 
+    @property
+    def flag(self) -> str:
+        return sorted(self.value.flags, key=len, reverse=True)[0]
+
     def register(self, argument_group: argparse._ArgumentGroup):
         kwargs = self.value.argparse_kwargs or {}
         if 'action' not in kwargs:

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -270,19 +270,6 @@ class Keychain(cli.CliApp, PathFinderMixin):
         with NamedTemporaryFile(prefix='build_', suffix='.keychain') as tf:
             self._path = pathlib.Path(tf.name)
 
-    @classmethod
-    def _get_certificate_allowed_applications(
-            cls, given_allowed_applications: Sequence[pathlib.Path]) -> Iterable[str]:
-        for application in given_allowed_applications:
-            resolved_path = shutil.which(application)
-            if resolved_path is None:
-                # Only raise exception if user-specified path is not present
-                if application not in KeychainArgument.ALLOWED_APPLICATIONS.get_default():
-                    raise KeychainArgument.ALLOWED_APPLICATIONS.raise_argument_error(
-                        f'Application "{application}" does not exist or is not in PATH')
-            else:
-                yield resolved_path
-
     @cli.action('add-certificates',
                 KeychainArgument.CERTIFICATE_PATHS,
                 KeychainArgument.CERTIFICATE_PASSWORD,
@@ -318,6 +305,19 @@ class Keychain(cli.CliApp, PathFinderMixin):
             raise KeychainError('Did not find any certificates from specified locations')
         for certificate_path in certificate_paths:
             self._add_certificate(certificate_path, certificate_password, add_for_all_apps, add_for_apps)
+
+    @classmethod
+    def _get_certificate_allowed_applications(
+            cls, given_allowed_applications: Sequence[pathlib.Path]) -> Iterable[str]:
+        for application in given_allowed_applications:
+            resolved_path = shutil.which(application)
+            if resolved_path is None:
+                # Only raise exception if user-specified path is not present
+                if application not in KeychainArgument.ALLOWED_APPLICATIONS.get_default():
+                    raise KeychainArgument.ALLOWED_APPLICATIONS.raise_argument_error(
+                        f'Application "{application}" does not exist or is not in PATH')
+            else:
+                yield resolved_path
 
     def _add_certificate(self,
                          certificate_path: pathlib.Path,

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -77,6 +77,32 @@ class KeychainArgument(cli.Argument):
         description='Encrypted p12 certificate password',
         argparse_kwargs={'required': False, 'default': ''},
     )
+    ALLOWED_APPLICATIONS = cli.ArgumentProperties(
+        flags=('-a', '--allow-app'),
+        key='allowed_applications',
+        description='Specify an application which may access the imported key without warning',
+        type=cli.CommonArgumentTypes.existing_path,
+        argparse_kwargs={
+            'required': False,
+            'default': tuple(filter(None, map(shutil.which, ('codesign', 'productsign')))),
+            'nargs': '+',
+            'metavar': 'allowed-app',
+        },
+    )
+    ALLOW_ALL_APPLICATIONS = cli.ArgumentProperties(
+        flags=('-A', '--allow-all-applications'),
+        key='allow_all_applications',
+        type=bool,
+        description='Allow any application to access the imported key without warning',
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
+    DISALLOW_ALL_APPLICATIONS = cli.ArgumentProperties(
+        flags=('-D', '--disallow-all-applications'),
+        key='disallow_all_applications',
+        type=bool,
+        description='Do not allow any applications to access the imported key without warning',
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
 
 
 @cli.common_arguments(KeychainArgument.PATH)
@@ -245,24 +271,45 @@ class Keychain(cli.CliApp, PathFinderMixin):
 
     @cli.action('add-certificates',
                 KeychainArgument.CERTIFICATE_PATHS,
-                KeychainArgument.CERTIFICATE_PASSWORD)
-    def add_certificates(self,
-                         certificate_path_patterns: Sequence[pathlib.Path],
-                         certificate_password: Password = Password('')):
+                KeychainArgument.CERTIFICATE_PASSWORD,
+                KeychainArgument.ALLOWED_APPLICATIONS,
+                KeychainArgument.ALLOW_ALL_APPLICATIONS,
+                KeychainArgument.DISALLOW_ALL_APPLICATIONS)
+    def add_certificates(
+            self,
+            certificate_path_patterns: Sequence[pathlib.Path],
+            certificate_password: Password = Password(''),
+            allowed_applications: Sequence[pathlib.Path] = KeychainArgument.ALLOWED_APPLICATIONS.get_default(),
+            allow_all_applications: bool = KeychainArgument.ALLOW_ALL_APPLICATIONS.get_default(),
+            disallow_all_applications: bool = KeychainArgument.DISALLOW_ALL_APPLICATIONS.get_default()):
         """
         Add p12 certificate to specified keychain.
         """
 
-        self.logger.info(f'Add certificates to keychain {self.path}')
+        add_for_all_apps = False
+        add_for_apps: Sequence[pathlib.Path] = []
+        if allow_all_applications and disallow_all_applications:
+            raise KeychainArgument.ALLOW_ALL_APPLICATIONS.raise_argument_error(
+                f'Using mutually exclusive options '
+                f'{KeychainArgument.ALLOWED_APPLICATIONS.flag!r} and '
+                f'{KeychainArgument.DISALLOW_ALL_APPLICATIONS.flag!r}')
+        elif allow_all_applications:
+            add_for_all_apps = True
+        elif not disallow_all_applications:
+            add_for_apps = allowed_applications
+
+        self.logger.info('Add certificates to keychain %s', self.path)
         certificate_paths = list(self.find_paths(*certificate_path_patterns))
         if not certificate_paths:
             raise KeychainError('Did not find any certificates from specified locations')
         for certificate_path in certificate_paths:
-            self._add_certificate(certificate_path, certificate_password)
+            self._add_certificate(certificate_path, certificate_password, add_for_all_apps, add_for_apps)
 
     def _add_certificate(self,
                          certificate_path: pathlib.Path,
-                         certificate_password: Optional[Password] = None):
+                         certificate_password: Optional[Password] = None,
+                         allow_for_all_apps: bool = False,
+                         allowed_applications: Sequence[pathlib.Path] = tuple()):
         self.logger.info(f'Add certificate {certificate_path} to keychain {self.path}')
         # If case of no password, we need to explicitly set -P '' flag. Otherwise,
         # security tries to open an interactive dialog to prompt the user for a password,
@@ -273,13 +320,18 @@ class Keychain(cli.CliApp, PathFinderMixin):
             certificate_password = Password('')
             obfuscate_patterns = []
 
-        process = self.execute([
+        import_cmd = [
             'security', 'import', certificate_path,
             '-f', "pkcs12",
             '-k', self.path,
-            '-T', shutil.which('codesign'),
             '-P', certificate_password.value,
-        ], obfuscate_patterns=obfuscate_patterns)
+        ]
+        if allow_for_all_apps:
+            import_cmd.append('-A')
+        for allowed_application in allowed_applications:
+            import_cmd.extend(['-T', str(allowed_application)])
+
+        process = self.execute(import_cmd, obfuscate_patterns=obfuscate_patterns)
 
         if process.returncode != 0:
             if 'The specified item already exists in the keychain' in process.stderr:

--- a/tests/tools/test_keychain.py
+++ b/tests/tools/test_keychain.py
@@ -1,12 +1,11 @@
 import argparse
 import pathlib
-from typing import List
 from unittest import mock
 from unittest.mock import Mock
 
 import pytest
-from codemagic.cli import CliProcess
 
+from codemagic.cli import CliProcess
 from codemagic.tools.keychain import Keychain
 from codemagic.tools.keychain import KeychainArgument
 
@@ -21,9 +20,14 @@ def mock_find_paths(_self, *args):
     (['app1', 'app2'], False, True, [], ['-A', 'app1', 'app2']),  # Do not allow any apps
 ])
 @mock.patch.object(Keychain, 'find_paths', mock_find_paths)
-def test_add_certificates_allowed_applications(allowed_apps, allow_all, disallow_all, expected_args, not_expected_args):
+def test_add_certificates_allowed_applications(
+        allowed_apps, allow_all, disallow_all, expected_args, not_expected_args, cli_argument_group):
+    KeychainArgument.ALLOWED_APPLICATIONS.register(cli_argument_group)
     keychain = Keychain(path=pathlib.Path('/tmp/keychain'))
-    with mock.patch.object(keychain, 'execute') as mock_execute:
+
+    with mock.patch.object(keychain, 'execute') as mock_execute, \
+            mock.patch('codemagic.tools.keychain.shutil') as mock_shutil:
+        mock_shutil.which = lambda path: str(path)
         mock_execute.return_value = Mock(returncode=0, spec=CliProcess)
         keychain.add_certificates(
             [pathlib.Path('*.p12')],
@@ -32,10 +36,11 @@ def test_add_certificates_allowed_applications(allowed_apps, allow_all, disallow
             disallow_all_applications=disallow_all,
         )
         mock_call_args = mock_execute.call_args[0][0]
-        for arg in expected_args:
-            assert arg in mock_call_args
-        for arg in not_expected_args:
-            assert arg not in mock_call_args
+
+    for arg in expected_args:
+        assert arg in mock_call_args
+    for arg in not_expected_args:
+        assert arg not in mock_call_args
 
 
 @mock.patch.object(Keychain, 'find_paths', mock_find_paths)

--- a/tests/tools/test_keychain.py
+++ b/tests/tools/test_keychain.py
@@ -1,0 +1,53 @@
+import argparse
+import pathlib
+from typing import List
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+from codemagic.cli import CliProcess
+
+from codemagic.tools.keychain import Keychain
+from codemagic.tools.keychain import KeychainArgument
+
+
+def mock_find_paths(_self, *args):
+    return [*args]
+
+
+@pytest.mark.parametrize('allowed_apps, allow_all, disallow_all, expected_args, not_expected_args', [
+    (['app1', 'app2'], False, False, ['app1', 'app2'], ['-A']),  # Only allow specified apps
+    (['app1', 'app2'], True, False, ['-A'], ['app1', 'app2']),  # Allow all apps
+    (['app1', 'app2'], False, True, [], ['-A', 'app1', 'app2']),  # Do not allow any apps
+])
+@mock.patch.object(Keychain, 'find_paths', mock_find_paths)
+def test_add_certificates_allowed_applications(allowed_apps, allow_all, disallow_all, expected_args, not_expected_args):
+    keychain = Keychain(path=pathlib.Path('/tmp/keychain'))
+    with mock.patch.object(keychain, 'execute') as mock_execute:
+        mock_execute.return_value = Mock(returncode=0, spec=CliProcess)
+        keychain.add_certificates(
+            [pathlib.Path('*.p12')],
+            allowed_applications=list(map(pathlib.Path, allowed_apps)),
+            allow_all_applications=allow_all,
+            disallow_all_applications=disallow_all,
+        )
+        mock_call_args = mock_execute.call_args[0][0]
+        for arg in expected_args:
+            assert arg in mock_call_args
+        for arg in not_expected_args:
+            assert arg not in mock_call_args
+
+
+@mock.patch.object(Keychain, 'find_paths', mock_find_paths)
+def test_add_certificates_all_apps_allowed_and_disallowed(cli_argument_group, keychain):
+    KeychainArgument.ALLOW_ALL_APPLICATIONS.register(cli_argument_group)
+    KeychainArgument.DISALLOW_ALL_APPLICATIONS.register(cli_argument_group)
+    with pytest.raises(argparse.ArgumentError) as argument_error:
+        Keychain(path=pathlib.Path('/tmp/keychain')).add_certificates(
+            [pathlib.Path('*.p12')],
+            allowed_applications=[],
+            allow_all_applications=True,
+            disallow_all_applications=True,
+        )
+    assert KeychainArgument.ALLOW_ALL_APPLICATIONS.flag in argument_error.value.argument_name
+    assert 'mutually exclusive options' in argument_error.value.message

--- a/tests/tools/test_keychain.py
+++ b/tests/tools/test_keychain.py
@@ -39,7 +39,7 @@ def test_add_certificates_allowed_applications(allowed_apps, allow_all, disallow
 
 
 @mock.patch.object(Keychain, 'find_paths', mock_find_paths)
-def test_add_certificates_all_apps_allowed_and_disallowed(cli_argument_group, keychain):
+def test_add_certificates_all_apps_allowed_and_disallowed(cli_argument_group):
     KeychainArgument.ALLOW_ALL_APPLICATIONS.register(cli_argument_group)
     KeychainArgument.DISALLOW_ALL_APPLICATIONS.register(cli_argument_group)
     with pytest.raises(argparse.ArgumentError) as argument_error:


### PR DESCRIPTION
**Add options to `keychain add-certificates` to specify which applications have access to the imported certificate without warning.**

Up until now certificates are added to specified keychain in a way that only `codesign` can access them without prompting UI warning. But to fulfill the needs for not only iOS developers it might be necessare to make certificates usable from headless session for other executables too, such as `productsign`, which is used to sign macOS applications. The apps that can access certificate in keychain can be configured during import via `-T` flag on `security import ...`. If one desires to make the certificate fully available for all applications without warning, then it can be imported to keychain using `security import` in conjunction with`-A` option. By default certificates are now added to keychain so that
- both `codesign` and `productsign` can access them without warnings,
- `-A` or `--allow-all-applications` can be used with `keychain add-certificates` to allow any application to access the imported key without warning,
- `-D` or `--disallow-all-applications` can be used with `keychain add-certificates` in order to prohibit all applications from accessing the imported key without warning.

**Modified action**:
- [`keychain add-certificate`](https://github.com/codemagic-ci-cd/cli-tools/blob/feature/keychain-add-certificate-allowed-apps/docs/keychain/add-certificates.md)

**Example executions of modified actions**

- Specify path to non-existent executable
```bash
> keychain add-certificates -c certificate.p12 --allow-app /path/to/non/existent/executable
usage: keychain add-certificates [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] [-c certificate-path [certificate-path ...]] [--certificate-password CERTIFICATE_PASSWORD]
                                    [-a allowed-app [allowed-app ...]] [-A] [-D] [-p PATH]
keychain add-certificates: error: argument -a/--allow-app: Application "/path/to/non/existent/executable" does not exist or is not in PATH
```

- Allow all apps to use certificate without warnings
```bash
> keychain add-certificates -c certificate.p12 --allow-all-applications
Add certificates to keychain /private/var/folders/s_/1kqm5m1x0gg_r7yvbm2j1h3h0000gn/T/build_ylx26sua.keychain
Searching for files matching certificate.p12
Add certificate /Users/priit/Library/MobileDevice/Certificates/certificate.p12 to keychain /private/var/folders/s_/1kqm5m1x0gg_r7yvbm2j1h3h0000gn/T/build_ylx26sua.keychain
1 key imported.
1 certificate imported.
```

- Error handling on conflicting options
```bash
> keychain add-certificates -c certificate.p12 --allow-all-applications --disallow-all-applications
usage: keychain [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] {add-certificates,create,delete,get-default,initialize,list-certificates,lock,make-default,set-timeout,show-info,unlock} ...
keychain: error: argument -A/--allow-all-applications: Using mutually exclusive options '--allow-app' and '--disallow-all-applications'
```