### PR TITLE
Improvement/resolve warnings

### DIFF
--- a/src/codemagic/models/junit/definitions.py
+++ b/src/codemagic/models/junit/definitions.py
@@ -21,6 +21,8 @@ class TestSuites:
     name: str
     test_suites: List[TestSuite] = field(default_factory=lambda: [])
 
+    __test__ = False  # Tell Pytest not to collect this class as test
+
     @property
     def disabled(self) -> int:
         """ Total number of disabled tests from all testsuites. """
@@ -86,6 +88,8 @@ class TestSuite:
     properties: List[Property] = field(default_factory=lambda: [])
     testcases: List[TestCase] = field(default_factory=lambda: [])
 
+    __test__ = False  # Tell Pytest not to collect this class as test
+
     def get_errored_test_cases(self) -> List[TestCase]:
         return [tc for tc in self.testcases if tc.error]
 
@@ -136,6 +140,8 @@ class TestCase:
     error: Optional[Error] = None
     failure: Optional[Failure] = None
     skipped: Optional[Skipped] = None
+
+    __test__ = False  # Tell Pytest not to collect this class as test
 
     def as_xml(self) -> Element:
         extras = {

--- a/src/codemagic/models/simulator/simulator.py
+++ b/src/codemagic/models/simulator/simulator.py
@@ -4,12 +4,12 @@ import json
 import pathlib
 import re
 import subprocess
-from collections import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Union
 
 from codemagic.mixins import RunningCliAppMixin

--- a/src/codemagic/models/xctests/xcresulttool.py
+++ b/src/codemagic/models/xctests/xcresulttool.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 import pathlib
 import subprocess
-from collections import Sequence
 from tempfile import NamedTemporaryFile
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 from codemagic.cli import CommandArg
 from codemagic.mixins import RunningCliAppMixin


### PR DESCRIPTION
Some warnings are raised during [tests](https://github.com/codemagic-ci-cd/cli-tools/runs/1919403495?check_suite_focus=true#step:8:57):
- `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working`
- `PytestCollectionWarning: cannot collect test class 'TestSuite' because it has a __init__ constructor (from: tests/models/junit/test_xml_generation.py)`

Changes introduced in this pull request:
- Fix `Sequence` type annotation imports - instead of importing it from `collections` module, import it from `typing`.
- Add `__test__ = False` attribute to source classes that have name which starts with `Test`.