### PR TITLE
CI and code formatting: add isort and flake8 checks to CI pipeline

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -30,6 +30,14 @@ jobs:
       run: |
         pipenv check
 
+    - name: Check code formatting
+      run: |
+        pipenv run flake8 src/codemagic tests
+
+    - name: Check imports sort order
+      run: |
+        pipenv run isort src/codemagic tests --check-only
+
     - name: Static type checks with mypy
       env:
         MYPYPATH: stubs

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ pytest = "*"
 pytest-cov = "*"
 mdutils = "*"
 pipenv = "*"
+isort = "*"
+flake8 = "*"
 
 [packages]
 pyopenssl = "~=19.0"

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,9 @@ mdutils = "*"
 pipenv = "*"
 isort = "*"
 flake8 = "*"
+flake8-commas = "*"
+flake8-quotes = "*"
+pep8-naming = "*"
 
 [packages]
 pyopenssl = "~=19.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8cdcf7353790ee1188cfc9d9da1bb651c8ca2be070a6cbf20ce3fa5d3eb16de3"
+            "sha256": "9eaec21d361255db170ba59902d740500bd22d1923971256ff96edcf4e781683"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -74,11 +74,16 @@
         },
         "cryptography": {
             "hashes": [
+                "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b",
+                "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336",
                 "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87",
+                "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7",
                 "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799",
                 "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b",
+                "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df",
                 "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0",
                 "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3",
+                "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724",
                 "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2",
                 "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"
             ],
@@ -159,11 +164,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
-                "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
+                "sha256:87ae7f2398b8a0ae5638ddecf9987f081b756e0e9fc071aeebdca525671fc4dc",
+                "sha256:b31c92f545517dcc452f284bc9c044050862fbe6d93d2b3de4a215a6b384bf0d"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.4.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.0"
         },
         "attrs": {
             "hashes": [
@@ -302,6 +307,14 @@
             ],
             "version": "==3.0.12"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
+            ],
+            "index": "pypi",
+            "version": "==3.8.4"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -351,7 +364,7 @@
                 "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e",
                 "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "index": "pypi",
             "version": "==5.7.0"
         },
         "jedi": {
@@ -372,30 +385,33 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:1d33d6f789697f401b75ce08e73b1de567b947740f768376631079290118ad39",
+                "sha256:2f2de8f8ac0be3e40d17730e0600619d35c78c13a099ea91ef7fb4ad944ce694",
+                "sha256:3782931963dc89e0e9a0ae4348b44762e868ea280e4f8c233b537852a8996ab9",
+                "sha256:37d9c34b96cca6787fe014aeb651217944a967a5b165e2cacb6b858d2997ab84",
+                "sha256:38c3865bd220bd983fcaa9aa11462619e84a71233bafd9c880f7b1cb753ca7fa",
+                "sha256:429c4d1862f3fc37cd56304d880f2eae5bd0da83bdef889f3bd66458aac49128",
+                "sha256:522b7c94b524389f4a4094c4bf04c2b02228454ddd17c1a9b2801fac1d754871",
+                "sha256:57fb5c5504ddd45ed420b5b6461a78f58cbb0c1b0cbd9cd5a43ad30a4a3ee4d0",
+                "sha256:5944a9b95e97de1980c65f03b79b356f30a43de48682b8bdd90aa5089f0ec1f4",
+                "sha256:6f4e5e68b7af950ed7fdb594b3f19a0014a3ace0fedb86acb896e140ffb24302",
+                "sha256:71a1ef23f22fa8437974b2d60fedb947c99a957ad625f83f43fd3de70f77f458",
+                "sha256:8a44e9901c0555f95ac401377032f6e6af66d8fc1fbfad77a7a8b1a826e0b93c",
+                "sha256:b6577f15d5516d7d209c1a8cde23062c0f10625f19e8dc9fb59268859778d7d7",
+                "sha256:c8fe2d6ff0ff583784039d0255ea7da076efd08507f2be6f68583b0da32e3afb",
+                "sha256:cadfa2c2cf54d35d13dc8d231253b7985b97d629ab9ca6e7d672c35539d38163",
+                "sha256:cd1bdace1a8762534e9a36c073cd54e97d517a17d69a17985961265be6d22847",
+                "sha256:ddbdcd10eb999d7ab292677f588b658372aadb9a52790f82484a37127a390108",
+                "sha256:e7273c64bccfd9310e9601b8f4511d84730239516bada26a0c9846c9697617ef",
+                "sha256:e7428977763150b4cf83255625a80a23dfdc94d43be7791ce90799d446b4e26f",
+                "sha256:e960e8be509e8d6d618300a6c189555c24efde63e85acaf0b14b2cd1ac743315",
+                "sha256:ecb5dd5990cec6e7f5c9c1124a37cb2c710c6d69b0c1a5c4aa4b35eba0ada068",
+                "sha256:ef3f5e288aa57b73b034ce9c1f1ac753d968f9069cd0742d1d69c698a0167166",
+                "sha256:fa5b2dee0e231fa4ad117be114251bdfe6afe39213bd629d43deb117b6a6c40a",
+                "sha256:fa7fb7973c622b9e725bee1db569d2c2ee64d2f9a089201c5e8185d482c7352d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.5.2"
         },
         "mccabe": {
             "hashes": [
@@ -413,31 +429,31 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0d2fc8beb99cd88f2d7e20d69131353053fbecea17904ee6f0348759302c52fa",
-                "sha256:2b216eacca0ec0ee124af9429bfd858d5619a0725ee5f88057e6e076f9eb1a7b",
-                "sha256:319ee5c248a7c3f94477f92a729b7ab06bf8a6d04447ef3aa8c9ba2aa47c6dcf",
-                "sha256:3e0c159a7853e3521e3f582adb1f3eac66d0b0639d434278e2867af3a8c62653",
-                "sha256:5615785d3e2f4f03ab7697983d82c4b98af5c321614f51b8f1034eb9ebe48363",
-                "sha256:5ff616787122774f510caeb7b980542a7cc2222be3f00837a304ea85cd56e488",
-                "sha256:6f8425fecd2ba6007e526209bb985ce7f49ed0d2ac1cc1a44f243380a06a84fb",
-                "sha256:74f5aa50d0866bc6fb8e213441c41e466c86678c800700b87b012ed11c0a13e0",
-                "sha256:90b6f46dc2181d74f80617deca611925d7e63007cf416397358aa42efb593e07",
-                "sha256:947126195bfe4709c360e89b40114c6746ae248f04d379dca6f6ab677aa07641",
-                "sha256:a301da58d566aca05f8f449403c710c50a9860782148332322decf73a603280b",
-                "sha256:aa9d4901f3ee1a986a3a79fe079ffbf7f999478c281376f48faa31daaa814e86",
-                "sha256:b9150db14a48a8fa114189bfe49baccdff89da8c6639c2717750c7ae62316738",
-                "sha256:b95068a3ce3b50332c40e31a955653be245666a4bc7819d3c8898aa9fb9ea496",
-                "sha256:ca7ad5aed210841f1e77f5f2f7d725b62c78fa77519312042c719ed2ab937876",
-                "sha256:d16c54b0dffb861dc6318a8730952265876d90c5101085a4bc56913e8521ba19",
-                "sha256:e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a",
-                "sha256:e1c84c65ff6d69fb42958ece5b1255394714e0aac4df5ffe151bc4fe19c7600a",
-                "sha256:e32b7b282c4ed4e378bba8b8dfa08e1cfa6f6574067ef22f86bee5b1039de0c9",
-                "sha256:e3b8432f8df19e3c11235c4563a7250666dc9aa7cdda58d21b4177b20256ca9f",
-                "sha256:e497a544391f733eca922fdcb326d19e894789cd4ff61d48b4b195776476c5cf",
-                "sha256:f5fdf935a46aa20aa937f2478480ebf4be9186e98e49cc3843af9a5795a49a25"
+                "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e",
+                "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064",
+                "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c",
+                "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4",
+                "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97",
+                "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df",
+                "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8",
+                "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a",
+                "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56",
+                "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7",
+                "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6",
+                "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5",
+                "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a",
+                "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521",
+                "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564",
+                "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49",
+                "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66",
+                "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a",
+                "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119",
+                "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506",
+                "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c",
+                "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"
             ],
             "index": "pypi",
-            "version": "==0.800"
+            "version": "==0.812"
         },
         "mypy-extensions": {
             "hashes": [
@@ -531,6 +547,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
+        "pyflakes": {
+            "hashes": [
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.2.0"
+        },
         "pygments": {
             "hashes": [
                 "sha256:37a13ba168a02ac54cc5891a42b1caec333e59b66addb7fa633ea8a6d73445c0",
@@ -541,11 +565,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:718b74786ea7ed07aa0c58bf572154d4679f960d26e9641cc1de204a30b87fc9",
-                "sha256:e71c2e9614a4f06e36498f310027942b0f4f2fde20aebb01655b31edc63b9eaf"
+                "sha256:2e0c6749d809985e4f181c336a8f89b2b797340d8049160bf95f35a3f0ecf6fc",
+                "sha256:3ea3926700db399765db1faf53860f11e4e981a090646e9eacd01ca78e020579"
             ],
             "index": "pypi",
-            "version": "==2.6.2"
+            "version": "==2.7.0"
         },
         "pyparsing": {
             "hashes": [
@@ -618,11 +642,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:11d544652edbdfc9cc41aa4c8a5c166513e279f3f2d9f1a9e1c89935b51de6ff",
-                "sha256:a89be573bfddb81bb0b395a416d5e55e3ecc73ce95a368a4f6360bedea33195e"
+                "sha256:65185676e9fdf20d154cffd1c5de8e39ef9696ff7e59fe0156b1b08e468736af",
+                "sha256:70657337ec104eb4f3fb229285358f23f045433f6aea26846cdd55f0fd68945c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.56.2"
+            "version": "==4.57.0"
         },
         "traitlets": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9eaec21d361255db170ba59902d740500bd22d1923971256ff96edcf4e781683"
+            "sha256": "173f7fd0bbcfd11684244289da6bc0a09b46f675ae61ada66bc84742857b15e1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -315,6 +315,28 @@
             "index": "pypi",
             "version": "==3.8.4"
         },
+        "flake8-commas": {
+            "hashes": [
+                "sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7",
+                "sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "flake8-polyfill": {
+            "hashes": [
+                "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
+                "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
+            ],
+            "version": "==1.0.2"
+        },
+        "flake8-quotes": {
+            "hashes": [
+                "sha256:3f1116e985ef437c130431ac92f9b3155f8f652fda7405ac22ffdfd7a9d1055e"
+            ],
+            "index": "pypi",
+            "version": "==3.2.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -477,6 +499,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.8.1"
+        },
+        "pep8-naming": {
+            "hashes": [
+                "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724",
+                "sha256:f43bfe3eea7e0d73e8b5d07d6407ab47f2476ccaeff6937c84275cd30b016738"
+            ],
+            "index": "pypi",
+            "version": "==0.11.1"
         },
         "pexpect": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[isort]
+line_length=120
+force_single_line=True
+
+[flake8]
+max_line_length=120
+per-file-ignores =
+    # F401 imported but unused
+    __init__.py:F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,7 @@ max_line_length=120
 per-file-ignores =
     # F401 imported but unused
     __init__.py:F401
+    src/codemagic/apple/resources/__init__.py:F401
+    # N815 variable in class scope should not be mixedCase
+    src/codemagic/apple/resources/*.py:N815
+    src/codemagic/models/export_options.py:N815

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
-__title__ = "codemagic-cli-tools"
-__description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.4.6"
+__title__ = 'codemagic-cli-tools'
+__description__ = 'CLI tools used in Codemagic builds'
+__version__ = '0.4.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/api_client.py
+++ b/src/codemagic/apple/app_store_connect/api_client.py
@@ -11,6 +11,7 @@ from urllib import parse
 import jwt
 
 from codemagic.utilities import log
+
 from .api_session import AppStoreConnectApiSession
 from .builds import Builds
 from .provisioning import BundleIdCapabilities

--- a/src/codemagic/apple/app_store_connect/api_client.py
+++ b/src/codemagic/apple/app_store_connect/api_client.py
@@ -86,7 +86,7 @@ class AppStoreConnectApiClient:
         return {
             'iss': self._issuer_id,
             'exp': self._get_timestamp(),
-            'aud': AppStoreConnectApiClient.JWT_AUDIENCE
+            'aud': AppStoreConnectApiClient.JWT_AUDIENCE,
         }
 
     def generate_auth_headers(self) -> Dict[str, str]:

--- a/src/codemagic/apple/app_store_connect/api_session.py
+++ b/src/codemagic/apple/app_store_connect/api_session.py
@@ -6,6 +6,7 @@ from typing import Dict
 import requests
 
 from codemagic.utilities import log
+
 from .api_error import AppStoreConnectApiError
 
 

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_id_capabilities.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_id_capabilities.py
@@ -35,7 +35,7 @@ class BundleIdCapabilities(ResourceManager[BundleIdCapability]):
         if capability_settings is not None:
             attributes['settings'] = capability_settings.dict()
         relationships = {
-            'bundleId': {'data': self._get_attribute_data(bundle_id, ResourceType.BUNDLE_ID)}
+            'bundleId': {'data': self._get_attribute_data(bundle_id, ResourceType.BUNDLE_ID)},
         }
         payload = self._get_create_payload(
             ResourceType.BUNDLE_ID_CAPABILITIES, attributes=attributes, relationships=relationships)

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Type
 from typing import Union
 

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -61,7 +61,7 @@ class BundleIds(ResourceManager[BundleId]):
             attributes['seedId'] = seed_id
         response = self.client.session.post(
             f'{self.client.API_URL}/bundleIds',
-            json=self._get_create_payload(ResourceType.BUNDLE_ID, attributes=attributes)
+            json=self._get_create_payload(ResourceType.BUNDLE_ID, attributes=attributes),
         ).json()
         return BundleId(response['data'], created=True)
 

--- a/src/codemagic/apple/app_store_connect/provisioning/devices.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/devices.py
@@ -49,7 +49,7 @@ class Devices(ResourceManager[Device]):
         }
         response = self.client.session.post(
             f'{self.client.API_URL}/devices',
-            json=self._get_create_payload(ResourceType.DEVICES, attributes=attributes)
+            json=self._get_create_payload(ResourceType.DEVICES, attributes=attributes),
         ).json()
         return Device(response['data'], created=True)
 

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -61,18 +61,18 @@ class Profiles(ResourceManager[Profile]):
             devices = []
         attributes = {
             'name': name,
-            'profileType': profile_type.value
+            'profileType': profile_type.value,
         }
         relationships = {
             'bundleId': {
-                'data': self._get_attribute_data(bundle_id, ResourceType.BUNDLE_ID)
+                'data': self._get_attribute_data(bundle_id, ResourceType.BUNDLE_ID),
             },
             'certificates': {
-                'data': [self._get_attribute_data(c, ResourceType.CERTIFICATES) for c in certificates]
+                'data': [self._get_attribute_data(c, ResourceType.CERTIFICATES) for c in certificates],
             },
             'devices': {
-                'data': [self._get_attribute_data(d, ResourceType.DEVICES) for d in devices]
-            }
+                'data': [self._get_attribute_data(d, ResourceType.DEVICES) for d in devices],
+            },
         }
         payload = self._get_create_payload(
             ResourceType.PROFILES, attributes=attributes, relationships=relationships)

--- a/src/codemagic/apple/app_store_connect/provisioning/signing_certificates.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/signing_certificates.py
@@ -44,7 +44,7 @@ class SigningCertificates(ResourceManager[SigningCertificate]):
         }
         response = self.client.session.post(
             f'{self.client.API_URL}/certificates',
-            json=self._get_create_payload(ResourceType.CERTIFICATES, attributes=attributes)
+            json=self._get_create_payload(ResourceType.CERTIFICATES, attributes=attributes),
         ).json()
         return SigningCertificate(response['data'], created=True)
 

--- a/src/codemagic/apple/app_store_connect/resource_manager.py
+++ b/src/codemagic/apple/app_store_connect/resource_manager.py
@@ -4,11 +4,11 @@ import abc
 import enum
 import re
 import shlex
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Generic
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Type
 from typing import TypeVar
 from typing import Union

--- a/src/codemagic/apple/app_store_connect/resource_manager.py
+++ b/src/codemagic/apple/app_store_connect/resource_manager.py
@@ -76,11 +76,11 @@ class ResourceManager(Generic[R], metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def resource_type(self) -> Type[R]:
-        raise NotImplemented
+        raise NotImplementedError()
 
     @classmethod
     def _get_include_field_name(cls, include_type: Type[R]) -> str:
-        raise NotImplemented
+        raise NotImplemented  # noqa: F901
 
     @classmethod
     def _get_update_payload(
@@ -89,8 +89,8 @@ class ResourceManager(Generic[R], metaclass=abc.ABCMeta):
             'data': {
                 'id': resource_id,
                 'type': resource_type.value,
-                'attributes': attributes
-            }
+                'attributes': attributes,
+            },
         }
 
     @classmethod
@@ -118,5 +118,5 @@ class ResourceManager(Generic[R], metaclass=abc.ABCMeta):
                             resource_type: ResourceType) -> Dict[str, str]:
         return {
             'id': cls._get_resource_id(resource),
-            'type': resource_type.value
+            'type': resource_type.value,
         }

--- a/src/codemagic/apple/app_store_connect/versioning/pre_release_versions.py
+++ b/src/codemagic/apple/app_store_connect/versioning/pre_release_versions.py
@@ -50,5 +50,5 @@ class PreReleaseVersions(ResourceManager[PreReleaseVersion]):
         results = self.client.paginate_with_included(f'{self.client.API_URL}/preReleaseVersions', params=params)
         return (
             [PreReleaseVersion(prerelease_version) for prerelease_version in results.data],
-            [include_type(included) for included in results.included]
+            [include_type(included) for included in results.included],
         )

--- a/src/codemagic/apple/resources/resource.py
+++ b/src/codemagic/apple/resources/resource.py
@@ -15,6 +15,7 @@ from typing import overload
 
 from codemagic.models import JsonSerializable
 from codemagic.models import JsonSerializableMeta
+
 from .enums import ResourceType
 
 

--- a/src/codemagic/apple/resources/resource.py
+++ b/src/codemagic/apple/resources/resource.py
@@ -73,7 +73,7 @@ class PagingInformation(DictSerializable):
 class Links(DictSerializable):
     _OMIT_IF_NONE_KEYS = ('self', 'related')
 
-    def __init__(_self, self: Optional[str] = None, related: Optional[str] = None):
+    def __init__(_self, self: Optional[str] = None, related: Optional[str] = None):  # noqa: N805
         _self.self = self
         _self.related = related
 
@@ -83,7 +83,7 @@ class ResourceLinks(DictSerializable):
     https://developer.apple.com/documentation/appstoreconnectapi/resourcelinks
     """
 
-    def __init__(_self, self):
+    def __init__(_self, self):  # noqa: N805
         _self.self = self
 
 
@@ -127,22 +127,22 @@ class LinkedResourceData(DictSerializable, JsonSerializable):
     def __str__(self):
         return '\n'.join([
             f'Id: {self.id}',
-            f'Type: {self.type.value}'
+            f'Type: {self.type.value}',
         ])
 
 
 class PrettyNameMeta(JsonSerializableMeta):
-    def __str__(cls):
+    def __str__(cls):  # noqa: N805
         class_name = cls.__name__
-        name = re.sub(f'([A-Z])', r' \1', class_name).lstrip(' ')
+        name = re.sub(r'([A-Z])', r' \1', class_name).lstrip(' ')
         return re.sub('Id', 'ID', name)
 
     @property
-    def s(cls) -> str:
+    def s(cls) -> str:  # noqa: N805
         """ Plural name of the object """
         return cls.plural()
 
-    def plural(cls, count: Optional[int] = None) -> str:
+    def plural(cls, count: Optional[int] = None) -> str:  # noqa: N805
         """ Optional plural name of the object depending on the count """
         singular = str(cls)
         if count == 1:
@@ -229,7 +229,9 @@ class Resource(LinkedResourceData, metaclass=PrettyNameMeta):
             # while most of API responses contain timestamps as '2020-08-04T11:44:12.000+0000'
             # resolved to datetime.datetime(2020, 8, 4, 11, 44, 12, tzinfo=datetime.timezone.utc),
             # /builds endpoint returns timestamps as isoformat() '2021-01-28T06:01:32-08:00'
-            # resolved to datetime.datetime(2021, 1, 28, 6, 1, 32, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=57600))).
+            # resolved to datetime.datetime(
+            #   2021, 1, 28, 6, 1, 32, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=57600))
+            # ).
             # So need to convert it to the initial form based on the presense of the explicit utc timezone
             return dt.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + '+0000'
         return dt.isoformat()

--- a/src/codemagic/cli/argument/action_callable.py
+++ b/src/codemagic/cli/argument/action_callable.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Sequence
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .argument import Argument

--- a/src/codemagic/cli/argument/argument.py
+++ b/src/codemagic/cli/argument/argument.py
@@ -9,6 +9,7 @@ from typing import NoReturn
 from typing import Optional
 
 from codemagic.cli.colors import Colors
+
 from .argument_formatter import ArgumentFormatter
 from .argument_properties import ArgumentProperties
 

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -5,15 +5,16 @@ import abc
 import argparse
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Generic
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Type
 from typing import TypeVar
 from typing import Union
 
 from codemagic.cli.colors import Colors
+
 from .argument_formatter import ArgumentFormatter
 
 if TYPE_CHECKING:

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -201,7 +201,7 @@ class CliApp(metaclass=abc.ABCMeta):
     @classmethod
     def _log_cli_invoke_completed(cls, action_name: str, started_at: float, exit_status: int):
         seconds = int(time.time() - started_at)
-        duration = time.strftime("%M:%S", time.gmtime(seconds))
+        duration = time.strftime('%M:%S', time.gmtime(seconds))
         msg = f'Completed {cls.__name__} {action_name} in {duration} with status code {exit_status}'
         file_logger = log.get_file_logger(cls)
         file_logger.debug(Colors.MAGENTA('-' * len(msg)))
@@ -224,7 +224,7 @@ class CliApp(metaclass=abc.ABCMeta):
         log.initialize_logging(
             stream={'stderr': sys.stderr, 'stdout': sys.stdout}[cli_args.log_stream],
             verbose=cli_args.verbose,
-            enable_logging=cli_args.enable_logging
+            enable_logging=cli_args.enable_logging,
         )
 
     @classmethod

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -26,6 +26,7 @@ from typing import Type
 
 from codemagic import __version__
 from codemagic.utilities import log
+
 from .argument import ActionCallable
 from .argument import Argument
 from .argument import ArgumentFormatter

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -14,6 +14,7 @@ from typing import Sequence
 from typing import Union
 
 from codemagic.utilities import log
+
 from .cli_types import CommandArg
 from .cli_types import ObfuscatedCommand
 

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -35,8 +35,8 @@ class CliProcess:
         if safe_form is None:
             full_command = ' '.join(shlex.quote(str(arg)) for arg in command_args)
             self.safe_form = ObfuscatedCommand(full_command)
-        self._stdout = ""
-        self._stderr = ""
+        self._stdout = ''
+        self._stderr = ''
 
     @property
     def stdout(self) -> str:
@@ -57,7 +57,7 @@ class CliProcess:
             self.logger.debug(f'Execute "{self.safe_form}"')
 
     def _log_exec_completed(self):
-        duration = time.strftime("%M:%S", time.gmtime(self.duration))
+        duration = time.strftime('%M:%S', time.gmtime(self.duration))
         file_logger = log.get_file_logger(self.__class__)
         file_logger.debug('STDOUT: %s', self.stdout)
         file_logger.debug('STDERR: %s', self.stderr)

--- a/src/codemagic/cli/colors.py
+++ b/src/codemagic/cli/colors.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         Colors.BOLD,
         Colors.ITALIC,
         Colors.STRIKE,
-        Colors.BRIGHT_BLACK_BG
+        Colors.BRIGHT_BLACK_BG,
     ]
     print(Colors.apply(' '.join(s.name for s in styles), *styles))
     for c in Colors:

--- a/src/codemagic/mixins/running_cli_app.py
+++ b/src/codemagic/mixins/running_cli_app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Optional
 
 if TYPE_CHECKING:
     from codemagic.cli import CliApp

--- a/src/codemagic/models/bundle_id_detector.py
+++ b/src/codemagic/models/bundle_id_detector.py
@@ -14,6 +14,7 @@ from typing import Optional
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.mixins import StringConverterMixin
 from codemagic.utilities import log
+
 from .pbx_project import PbxProject
 
 

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -9,16 +9,17 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from OpenSSL import crypto
-from OpenSSL.crypto import X509
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
+from OpenSSL import crypto
+from OpenSSL.crypto import X509
 
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.mixins import StringConverterMixin
 from codemagic.utilities import log
+
 from .certificate_p12_exporter import P12Exporter
 from .json_serializable import JsonSerializable
 from .private_key import PrivateKey

--- a/src/codemagic/models/certificate_p12_exporter.py
+++ b/src/codemagic/models/certificate_p12_exporter.py
@@ -5,9 +5,9 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
+from typing import TYPE_CHECKING
 from typing import Optional
 from typing import Sequence
-from typing import TYPE_CHECKING
 from typing import Union
 
 from codemagic.mixins import RunningCliAppMixin

--- a/src/codemagic/models/certificate_p12_exporter.py
+++ b/src/codemagic/models/certificate_p12_exporter.py
@@ -73,7 +73,7 @@ class P12Exporter(RunningCliAppMixin, StringConverterMixin):
             '-out', pkcs12.expanduser(),
             '-in', self._temp_pem_certificate_path,
             '-inkey', self._temp_private_key_path,
-            '-passout', f'pass:{password}'
+            '-passout', f'pass:{password}',
         )
         self._run_openssl_command(export_args)
 

--- a/src/codemagic/models/code_sign_entitlements.py
+++ b/src/codemagic/models/code_sign_entitlements.py
@@ -10,7 +10,6 @@ from typing import Any
 from typing import AnyStr
 from typing import Dict
 from typing import List
-from typing import Optional
 
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.mixins import StringConverterMixin

--- a/src/codemagic/models/code_signing_settings_manager.py
+++ b/src/codemagic/models/code_signing_settings_manager.py
@@ -66,7 +66,7 @@ class CodeSigningSettingsManager(RunningCliAppMixin, StringConverterMixin):
         config = build_config_info['build_configuration']
         return Colors.BLUE(
             f' - Using profile "{profile.name}" [{profile.uuid}] '
-            f'for target "{target}" [{config}] from project "{project}"'
+            f'for target "{target}" [{config}] from project "{project}"',
         )
 
     def notify_profile_usage(self):

--- a/src/codemagic/models/code_signing_settings_manager.py
+++ b/src/codemagic/models/code_signing_settings_manager.py
@@ -16,6 +16,7 @@ from codemagic.cli import Colors
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.mixins import StringConverterMixin
 from codemagic.utilities import log
+
 from .certificate import Certificate
 from .export_options import ExportOptions
 from .matched_profile import MatchedProfile

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -17,6 +17,7 @@ from typing import overload
 
 from codemagic.cli import Colors
 from codemagic.utilities import log
+
 from .matched_profile import MatchedProfile
 from .provisioning_profile import ProvisioningProfile
 

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -27,10 +27,10 @@ class Destination(enum.Enum):
 
 
 class ArchiveMethod(enum.Enum):
-    AD_HOC = "ad-hoc"
-    DEVELOPMENT = "development"
-    APP_STORE = "app-store"
-    ENTERPRISE = "enterprise"
+    AD_HOC = 'ad-hoc'
+    DEVELOPMENT = 'development'
+    APP_STORE = 'app-store'
+    ENTERPRISE = 'enterprise'
 
     @classmethod
     def from_profiles(cls, profiles: Sequence[ProvisioningProfile]) -> ArchiveMethod:
@@ -227,7 +227,7 @@ class ExportOptions:
 
         for key in sorted(options.keys()):
             value = options[key]
-            option = re.sub(f'([A-Z])', r' \1', key.replace('ID', 'Id')).lstrip(' ').title()
+            option = re.sub(r'([A-Z])', r' \1', key.replace('ID', 'Id')).lstrip(' ').title()
             if isinstance(value, dict):
                 logger.info(Colors.BLUE(f' - {option}:'))
                 for k, v in value.items():

--- a/src/codemagic/models/junit/printer.py
+++ b/src/codemagic/models/junit/printer.py
@@ -7,6 +7,7 @@ from codemagic.models.table import Line
 from codemagic.models.table import Spacer
 from codemagic.models.table import Table
 from codemagic.utilities import log
+
 from .definitions import TestSuite
 from .definitions import TestSuites
 

--- a/src/codemagic/models/junit/printer.py
+++ b/src/codemagic/models/junit/printer.py
@@ -27,7 +27,7 @@ class TestSuitePrinter:
             Line('Total tests ran', test_suites.tests, value_color=tests_color),
             Line('Total tests failed', test_suites.failures, value_color=fails_color),
             Line('Total tests errored', test_suites.errors, value_color=errors_color),
-            Line('Total tests skipped', test_suites.skipped)
+            Line('Total tests skipped', test_suites.skipped),
         ], align_values_left=False)
         self.print(table.construct())
 
@@ -68,7 +68,7 @@ class TestSuitePrinter:
             Line('Total tests skipped', test_suite.skipped or 0),
             *self._get_test_suite_errored_lines(test_suite),
             *self._get_test_suite_failed_lines(test_suite),
-            *self._get_test_suite_skipped_lines(test_suite)
+            *self._get_test_suite_skipped_lines(test_suite),
         ])
 
         self.print(table.construct())

--- a/src/codemagic/models/private_key.py
+++ b/src/codemagic/models/private_key.py
@@ -61,7 +61,7 @@ class PrivateKey(StringConverterMixin):
         pem = self.rsa_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=key_format,
-            encryption_algorithm=algorithm
+            encryption_algorithm=algorithm,
         )
         return self._str(pem)
 
@@ -72,5 +72,5 @@ class PrivateKey(StringConverterMixin):
     def get_public_key(self) -> bytes:
         return self.public_key.public_bytes(
             serialization.Encoding.OpenSSH,
-            serialization.PublicFormat.OpenSSH
+            serialization.PublicFormat.OpenSSH,
         )

--- a/src/codemagic/models/private_key.py
+++ b/src/codemagic/models/private_key.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import AnyStr
 from typing import Optional
 
-from OpenSSL import crypto
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import KeySerializationEncryption
+from OpenSSL import crypto
 
 from codemagic.mixins import StringConverterMixin
 from codemagic.utilities import log

--- a/src/codemagic/models/provisioning_profile.py
+++ b/src/codemagic/models/provisioning_profile.py
@@ -10,7 +10,6 @@ from typing import AnyStr
 from typing import Dict
 from typing import Generator
 from typing import List
-from typing import Optional
 from typing import Sequence
 from typing import Union
 
@@ -84,19 +83,19 @@ class ProvisioningProfile(JsonSerializable, RunningCliAppMixin, StringConverterM
 
     @property
     def provisioned_devices(self) -> List[str]:
-        return self._plist.get("ProvisionedDevices", [])
+        return self._plist.get('ProvisionedDevices', [])
 
     @property
     def provisions_all_devices(self) -> bool:
-        return self._plist.get("ProvisionsAllDevices", False)
+        return self._plist.get('ProvisionsAllDevices', False)
 
     @property
     def application_identifier(self) -> str:
-        return self._plist.get('Entitlements', dict()).get("application-identifier", '')
+        return self._plist.get('Entitlements', dict()).get('application-identifier', '')
 
     @property
     def is_wildcard(self) -> bool:
-        return self.application_identifier.endswith("*")
+        return self.application_identifier.endswith('*')
 
     @property
     def bundle_id(self) -> str:

--- a/src/codemagic/models/simulator/simulator.py
+++ b/src/codemagic/models/simulator/simulator.py
@@ -13,6 +13,7 @@ from typing import Sequence
 from typing import Union
 
 from codemagic.mixins import RunningCliAppMixin
+
 from .runtime import Runtime
 
 

--- a/src/codemagic/models/table/table.py
+++ b/src/codemagic/models/table/table.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import Tuple
 
 from codemagic.cli import Colors
+
 from .line import Header
 from .line import Line
 from .line import Spacer

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -17,6 +17,7 @@ from codemagic.cli import CliProcess
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.utilities import log
 from codemagic.utilities.levenshtein_distance import levenshtein_distance
+
 from .export_options import ExportOptions
 from .simulator import CoreSimulatorService
 from .simulator import Simulator

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -67,7 +67,7 @@ class Xcodebuild(RunningCliAppMixin):
             fd.write(process_logs.read())
 
             fd.write('\n\n')
-            duration = time.strftime("%M:%S", time.gmtime(xcodebuild_cli_process.duration))
+            duration = time.strftime('%M:%S', time.gmtime(xcodebuild_cli_process.duration))
             fd.write(f'<<< Process completed with status code {xcodebuild_cli_process.returncode} in {duration}')
             fd.write('\n\n')
 
@@ -178,7 +178,7 @@ class Xcodebuild(RunningCliAppMixin):
             *max_devices_args,
             *max_simulators_args,
             'test',
-            *shlex.split(xcargs or '')
+            *shlex.split(xcargs or ''),
         ]
 
     def clean(self):
@@ -251,7 +251,7 @@ class Xcodebuild(RunningCliAppMixin):
         try:
             if cli_app:
                 process = XcodebuildCliProcess(command, xcpretty=self.xcpretty)
-                cli_app.logger.info(f'Execute "%s"\n', process.safe_form)
+                cli_app.logger.info('Execute "%s"\n', process.safe_form)
                 process.execute().raise_for_returncode(include_logs=False)
             else:
                 subprocess.check_output(command)

--- a/src/codemagic/models/xcpretty.py
+++ b/src/codemagic/models/xcpretty.py
@@ -2,8 +2,8 @@ import shlex
 import shutil
 import subprocess
 import sys
-from typing import AnyStr
 from typing import IO
+from typing import AnyStr
 from typing import Optional
 from typing import Union
 

--- a/src/codemagic/models/xctests/collector.py
+++ b/src/codemagic/models/xctests/collector.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import Set
 
 from codemagic.utilities import log
+
 from .xcresulttool import XcResultTool
 
 

--- a/src/codemagic/models/xctests/converter.py
+++ b/src/codemagic/models/xctests/converter.py
@@ -34,7 +34,7 @@ class XcResultConverter:
         return Error(
             message=test.get_error_message(),
             type=test.get_error_type(),
-            error_description=test.get_failure_description()
+            error_description=test.get_failure_description(),
         )
 
     @classmethod

--- a/src/codemagic/models/xctests/converter.py
+++ b/src/codemagic/models/xctests/converter.py
@@ -14,11 +14,12 @@ from codemagic.models.junit import Skipped
 from codemagic.models.junit import TestCase
 from codemagic.models.junit import TestSuite
 from codemagic.models.junit import TestSuites
+
 from .xcresult import ActionDeviceRecord
 from .xcresult import ActionRecord
-from .xcresult import ActionTestMetadata
-from .xcresult import ActionTestableSummary
 from .xcresult import ActionsInvocationRecord
+from .xcresult import ActionTestableSummary
+from .xcresult import ActionTestMetadata
 
 
 class XcResultConverter:

--- a/src/codemagic/models/xctests/xcresult.py
+++ b/src/codemagic/models/xctests/xcresult.py
@@ -58,7 +58,7 @@ class _AbstractRecord(_BaseAbstractRecord, metaclass=ABCMeta):
             bool: self._bool_value,
             float: self._float_value,
             int: self._int_value,
-            str: self._str_value
+            str: self._str_value,
         }
         for _type, getter in getters.items():
             try:

--- a/src/codemagic/models/xctests/xcresulttool.py
+++ b/src/codemagic/models/xctests/xcresulttool.py
@@ -29,7 +29,7 @@ class XcResultTool(RunningCliAppMixin):
             'xcrun', 'xcresulttool', 'get',
             '--format', 'json',
             '--path', xcresult.expanduser(),
-            '--id', object_id
+            '--id', object_id,
         ]
         stdout = cls._run_command(cmd_args, f'Failed to get result bundle object {object_id} from {xcresult}')
         return json.loads(stdout)
@@ -40,7 +40,7 @@ class XcResultTool(RunningCliAppMixin):
         with NamedTemporaryFile(prefix=result_prefix or 'Test-', suffix='-merged.xcresult') as tf:
             output_path = pathlib.Path(tf.name)
         cmd_args: List[CommandArg] = ['xcrun', 'xcresulttool', 'merge', *xcresults, '--output-path', output_path]
-        _ = cls._run_command(cmd_args, f'Failed to merge xcresult bundles')
+        _ = cls._run_command(cmd_args, 'Failed to merge xcresult bundles')
         return output_path
 
     @classmethod

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -195,7 +195,7 @@ class BundleIdArgument(cli.Argument):
         key='bundle_id_identifier',
         flags=('--bundle-id-identifier',),
         description='Identifier of the Bundle ID',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     BUNDLE_ID_NAME = cli.ArgumentProperties(
         key='bundle_id_name',
@@ -219,8 +219,8 @@ class BundleIdArgument(cli.Argument):
         argparse_kwargs={
             'required': True,
             'nargs': '+',
-            'metavar': 'bundle-identifier-id'
-        }
+            'metavar': 'bundle-identifier-id',
+        },
     )
     PLATFORM = cli.ArgumentProperties(
         key='platform',
@@ -254,14 +254,14 @@ class DeviceArgument(cli.Argument):
         argparse_kwargs={
             'required': True,
             'nargs': '+',
-            'metavar': 'device-id'
-        }
+            'metavar': 'device-id',
+        },
     )
     DEVICE_NAME = cli.ArgumentProperties(
         key='device_name',
         flags=('--name',),
         description='Name of the Device',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     DEVICE_STATUS = cli.ArgumentProperties(
         key='device_status',
@@ -271,7 +271,7 @@ class DeviceArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(DeviceStatus),
-        }
+        },
     )
 
 
@@ -289,8 +289,8 @@ class CertificateArgument(cli.Argument):
         argparse_kwargs={
             'required': True,
             'nargs': '+',
-            'metavar': 'certificate-id'
-        }
+            'metavar': 'certificate-id',
+        },
     )
     CERTIFICATE_TYPE = cli.ArgumentProperties(
         key='certificate_type',
@@ -301,7 +301,7 @@ class CertificateArgument(cli.Argument):
             'required': False,
             'choices': list(CertificateType),
             'default': CertificateType.IOS_DEVELOPMENT,
-        }
+        },
     )
     CERTIFICATE_TYPE_OPTIONAL = cli.ArgumentProperties(
         key='certificate_type',
@@ -311,7 +311,7 @@ class CertificateArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(CertificateType),
-        }
+        },
     )
     PROFILE_TYPE_OPTIONAL = cli.ArgumentProperties(
         key='profile_type',
@@ -321,13 +321,13 @@ class CertificateArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(ProfileType),
-        }
+        },
     )
     DISPLAY_NAME = cli.ArgumentProperties(
         key='display_name',
         flags=('--display-name',),
         description='Code signing certificate display name',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     PRIVATE_KEY = cli.ArgumentProperties(
         key='certificate_key',
@@ -377,8 +377,8 @@ class ProfileArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(ProfileType),
-            'default': ProfileType.IOS_APP_DEVELOPMENT
-        }
+            'default': ProfileType.IOS_APP_DEVELOPMENT,
+        },
     )
     PROFILE_TYPE_OPTIONAL = cli.ArgumentProperties(
         key='profile_type',
@@ -388,7 +388,7 @@ class ProfileArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(ProfileType),
-        }
+        },
     )
     PROFILE_STATE_OPTIONAL = cli.ArgumentProperties(
         key='profile_state',
@@ -398,13 +398,13 @@ class ProfileArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'choices': list(ProfileState),
-        }
+        },
     )
     PROFILE_NAME = cli.ArgumentProperties(
         key='profile_name',
         flags=('--name',),
         description='Name of the provisioning profile',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
 
 

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -4,11 +4,11 @@ import enum
 import json
 import pathlib
 import shlex
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Sequence
-from typing import TYPE_CHECKING
 from typing import Tuple
 from typing import Type
 from typing import TypeVar

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -33,7 +33,7 @@ class XcodeProjectArgument(cli.Argument):
             'required': False,
             'default': (pathlib.Path('**/*.xcodeproj'),),
             'nargs': '+',
-            'metavar': 'project-path'
+            'metavar': 'project-path',
         },
     )
     XCODE_PROJECT_PATH = cli.ArgumentProperties(
@@ -41,14 +41,14 @@ class XcodeProjectArgument(cli.Argument):
         flags=('--project',),
         type=cli.CommonArgumentTypes.existing_path,
         description='Path to Xcode project (*.xcodeproj)',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     XCODE_WORKSPACE_PATH = cli.ArgumentProperties(
         key='xcode_workspace_path',
         flags=('--workspace',),
         type=cli.CommonArgumentTypes.existing_path,
         description='Path to Xcode workspace (*.xcworkspace)',
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     SCHEME_NAME = cli.ArgumentProperties(
         key='scheme_name',
@@ -81,7 +81,7 @@ class XcodeProjectArgument(cli.Argument):
             'nargs': '+',
             'metavar': 'profile-path',
             'default': (ProvisioningProfile.DEFAULT_LOCATION / '*.mobileprovision',),
-        }
+        },
     )
 
 
@@ -93,8 +93,8 @@ class ExportIpaArgument(cli.Argument):
         description='Directory where the created archive is stored',
         argparse_kwargs={
             'required': False,
-            'default': pathlib.Path('build/ios/xcarchive')
-        }
+            'default': pathlib.Path('build/ios/xcarchive'),
+        },
     )
     CUSTOM_EXPORT_OPTIONS = cli.ArgumentProperties(
         key='custom_export_options',
@@ -104,7 +104,7 @@ class ExportIpaArgument(cli.Argument):
             'Custom options for generated export options as JSON string. '
             'For example \'{"uploadBitcode": false, "uploadSymbols": false}\'.'
         ),
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     EXPORT_OPTIONS_PATH = cli.ArgumentProperties(
         key='export_options_plist',
@@ -113,8 +113,8 @@ class ExportIpaArgument(cli.Argument):
         description='Path to the generated export options plist',
         argparse_kwargs={
             'required': False,
-            'default': pathlib.Path('~/export_options.plist').expanduser()
-        }
+            'default': pathlib.Path('~/export_options.plist').expanduser(),
+        },
     )
     EXPORT_OPTIONS_PATH_EXISTING = cli.ArgumentProperties(
         key='export_options_plist',
@@ -123,8 +123,8 @@ class ExportIpaArgument(cli.Argument):
         description='Path to the generated export options plist',
         argparse_kwargs={
             'required': False,
-            'default': pathlib.Path('~/export_options.plist').expanduser()
-        }
+            'default': pathlib.Path('~/export_options.plist').expanduser(),
+        },
     )
     IPA_DIRECTORY = cli.ArgumentProperties(
         key='ipa_directory',
@@ -133,8 +133,8 @@ class ExportIpaArgument(cli.Argument):
         description='Directory where the built ipa is stored',
         argparse_kwargs={
             'required': False,
-            'default': pathlib.Path('build/ios/ipa')
-        }
+            'default': pathlib.Path('build/ios/ipa'),
+        },
     )
     REMOVE_XCARCHIVE = cli.ArgumentProperties(
         key='remove_xcarchive',
@@ -165,7 +165,7 @@ class TestArgument(cli.Argument):
     )
     INCLUDE_UNAVAILABLE = cli.ArgumentProperties(
         key='include_unavailable',
-        flags=('-u', '--include-unavailable',),
+        flags=('-u', '--include-unavailable'),
         type=bool,
         description='Whether to include unavailable devices in output',
         argparse_kwargs={'required': False, 'action': 'store_true'},
@@ -242,7 +242,7 @@ class TestArgument(cli.Argument):
 class TestResultArgument(cli.Argument):
     XCRESULT_PATTERNS = cli.ArgumentProperties(
         key='xcresult_patterns',
-        flags=('-p', '--xcresult',),
+        flags=('-p', '--xcresult'),
         type=cli.CommonArgumentTypes.existing_dir,
         description=(
             'Path to Xcode Test result (*.xcresult) to be be converted. '
@@ -259,7 +259,7 @@ class TestResultArgument(cli.Argument):
     )
     XCRESULT_DIRS = cli.ArgumentProperties(
         key='xcresult_dirs',
-        flags=('-d', '--dir',),
+        flags=('-d', '--dir'),
         type=cli.CommonArgumentTypes.existing_dir,
         description=(
             'Directory where Xcode Test results (*.xcresult) should be converted. '
@@ -274,17 +274,17 @@ class TestResultArgument(cli.Argument):
     )
     OUTPUT_DIRECTORY = cli.ArgumentProperties(
         key='output_dir',
-        flags=('-o', '--output-dir',),
+        flags=('-o', '--output-dir'),
         type=cli.CommonArgumentTypes.existing_dir,
         description='Directory where the Junit XML results will be saved.',
         argparse_kwargs={
             'required': False,
-            'default': pathlib.Path('build/ios/test')
+            'default': pathlib.Path('build/ios/test'),
         },
     )
     OUTPUT_EXTENSION = cli.ArgumentProperties(
         key='output_extension',
-        flags=('-e', '--output-extension',),
+        flags=('-e', '--output-extension'),
         type=str,
         description='Extension for the created Junit XML file. For example `xml` or `junit`.',
         argparse_kwargs={

--- a/src/codemagic/tools/android_app_bundle.py
+++ b/src/codemagic/tools/android_app_bundle.py
@@ -101,21 +101,21 @@ class AndroidAppBundleArgument(cli.Argument):
         key='mode',
         description=(
             'Set the mode to universal if you want bundletool to build only a single APK '
-            'that includes all of your app\'s code and resources such that the APK is '
+            "that includes all of your app's code and resources such that the APK is "
             'compatible with all device configurations your app supports.'
         ),
         argparse_kwargs={
             'default': None,
             'required': False,
             'choices': ['universal'],
-        }
+        },
     )
     DUMP_TARGET = cli.ArgumentProperties(
         key='target',
         description='Target of the dump',
         argparse_kwargs={
-            'choices': ['manifest', 'resources', 'config']
-        }
+            'choices': ['manifest', 'resources', 'config'],
+        },
     )
     DUMP_XPATH = cli.ArgumentProperties(
         flags=('--xpath',),
@@ -127,7 +127,7 @@ class AndroidAppBundleArgument(cli.Argument):
         ),
         argparse_kwargs={
             'required': False,
-        }
+        },
     )
 
 
@@ -321,7 +321,7 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
 
         command = [
             'java', '-jar', str(self._bundletool_jar),
-            'dump', target, '--bundle', aab_path
+            'dump', target, '--bundle', aab_path,
         ]
         if xpath:
             command.extend(['--xpath', xpath])
@@ -359,7 +359,7 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             '-storepass', signing_info.store_pass,
             '-keypass', signing_info.key_pass,
             str(aab_path),
-            signing_info.key_alias
+            signing_info.key_alias,
         ]
         obfuscate_patterns = [signing_info.store_pass, signing_info.key_pass]
         process = self.execute(command, obfuscate_patterns=obfuscate_patterns, show_output=False)
@@ -384,7 +384,7 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
         self.logger.info(f'Validate {aab_path}')
         command = [
             'java', '-jar', str(self._bundletool_jar),
-            'validate', '--bundle', aab_path
+            'validate', '--bundle', aab_path,
         ]
         process = self.execute(command)
         if process.returncode != 0:
@@ -394,7 +394,7 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
     @cli.action('bundletool-version')
     def bundletool_version(self) -> str:
         """ Get Bundletool version """
-        self.logger.info(f'Get Bundletool version')
+        self.logger.info('Get Bundletool version')
         process = self.execute(('java', '-jar', str(self._bundletool_jar), 'version'), show_output=False)
         if process.returncode != 0:
             raise AndroidAppBundleError('Unable to get Bundletool version', process)

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -35,6 +35,7 @@ from codemagic.cli import Colors
 from codemagic.models import Certificate
 from codemagic.models import PrivateKey
 from codemagic.models import ProvisioningProfile
+
 from ._app_store_connect.arguments import AppStoreConnectArgument
 from ._app_store_connect.arguments import AppStoreVersionArgument
 from ._app_store_connect.arguments import BuildArgument

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -105,14 +105,14 @@ class AppStoreConnect(cli.CliApp):
             json_output=cli_args.json_output,
             profiles_directory=cli_args.profiles_directory,
             certificates_directory=cli_args.certificates_directory,
-            **cls._parent_class_kwargs(cli_args)
+            **cls._parent_class_kwargs(cli_args),
         )
 
     def _create_resource(self, resource_manager, should_print, **create_params):
         omit_keys = create_params.pop('omit_keys', tuple())
         self.printer.log_creating(
             resource_manager.resource_type,
-            **{k: v for k, v in create_params.items() if k not in omit_keys}
+            **{k: v for k, v in create_params.items() if k not in omit_keys},
         )
         try:
             resource = resource_manager.create(**create_params)
@@ -467,7 +467,7 @@ class AppStoreConnect(cli.CliApp):
             bundle_id=bundle_id_resource_id,
             certificates=certificate_resource_ids,
             devices=[],
-            omit_keys=['devices']
+            omit_keys=['devices'],
         )
         if profile_type.devices_allowed():
             create_params['devices'] = device_resource_ids
@@ -645,7 +645,7 @@ class AppStoreConnect(cli.CliApp):
                 [certificate.id for certificate in certificates],
                 [device.id for device in devices],
                 profile_type=profile_type,
-                should_print=False
+                should_print=False,
             )
 
     def _get_or_create_profiles(self,
@@ -687,7 +687,7 @@ class AppStoreConnect(cli.CliApp):
         profile_ids = {p.id for p in profiles}
         bundle_ids_without_profiles = list(filter(missing_profile, bundle_ids))
         if bundle_ids_without_profiles and not create_resource:
-            missing = ", ".join(f'"{bid.attributes.identifier}" [{bid.id}]' for bid in bundle_ids_without_profiles)
+            missing = ', '.join(f'"{bid.attributes.identifier}" [{bid.id}]' for bid in bundle_ids_without_profiles)
             raise AppStoreConnectError(f'Did not find {profile_type} {Profile.s} for {BundleId.s}: {missing}')
 
         created_profiles = self._create_missing_profiles(

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -40,7 +40,7 @@ class KeychainArgument(cli.Argument):
             'Keychain path. If not provided, the system default '
             'keychain will be used instead'
         ),
-        argparse_kwargs={'required': False}
+        argparse_kwargs={'required': False},
     )
     PASSWORD = cli.ArgumentProperties(
         flags=('-pw', '--password'),
@@ -69,7 +69,7 @@ class KeychainArgument(cli.Argument):
             'nargs': '+',
             'metavar': 'certificate-path',
             'default': (Certificate.DEFAULT_LOCATION / '*.p12',),
-        }
+        },
     )
     CERTIFICATE_PASSWORD = cli.ArgumentProperties(
         flags=('--certificate-password',),
@@ -211,7 +211,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
         Show the system default keychain
         """
 
-        self.logger.info(f'Get system default keychain')
+        self.logger.info('Get system default keychain')
         default = self._get_default()
         self.echo(default)
         return default
@@ -219,7 +219,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
     def _get_default(self):
         process = self.execute(('security', 'default-keychain'), show_output=False)
         if process.returncode != 0:
-            raise KeychainError(f'Unable to get default keychain', process)
+            raise KeychainError('Unable to get default keychain', process)
         cleaned = process.stdout.strip().strip('"').strip("'")
         return pathlib.Path(cleaned)
 
@@ -336,7 +336,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
 
         import_cmd = [
             'security', 'import', certificate_path,
-            '-f', "pkcs12",
+            '-f', 'pkcs12',
             '-k', self.path,
             '-P', certificate_password.value,
         ]

--- a/src/codemagic/tools/universal_apk_generator.py
+++ b/src/codemagic/tools/universal_apk_generator.py
@@ -92,7 +92,7 @@ class UniversalApkGenerator(cli.CliApp, PathFinderMixin):
         return UniversalApkGenerator(
             pattern=pattern,
             android_signing_info=signing_info,
-            **cls._parent_class_kwargs(cli_args)
+            **cls._parent_class_kwargs(cli_args),
         )
 
     @cli.action('generate')

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -30,6 +30,7 @@ from codemagic.models.simulator import Runtime
 from codemagic.models.simulator import Simulator
 from codemagic.models.xctests import XcResultCollector
 from codemagic.models.xctests import XcResultConverter
+
 from ._xcode_project.arguments import ExportIpaArgument
 from ._xcode_project.arguments import TestArgument
 from ._xcode_project.arguments import TestResultArgument

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -69,7 +69,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         )
 
         if not bundle_ids:
-            raise XcodeProjectException(f'Unable to detect Bundle ID')
+            raise XcodeProjectException('Unable to detect Bundle ID')
         bundle_id = bundle_ids.most_common(1)[0][0]
 
         self.logger.info(Colors.GREEN(f'Chose Bundle ID {bundle_id}'))
@@ -235,7 +235,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         except ValueError as ve:
             TestArgument.RUNTIMES.raise_argument_error(str(ve))
 
-        self.logger.info(Colors.BLUE(f'List available test devices'))
+        self.logger.info(Colors.BLUE('List available test devices'))
         try:
             simulators = Simulator.list(runtimes, simulator_name, include_unavailable)
         except IOError as e:
@@ -342,12 +342,12 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 max_concurrent_devices=max_concurrent_devices,
                 max_concurrent_simulators=max_concurrent_simulators,
             )
-        except IOError as error:
+        except IOError:
             testing_failed = True
-            self.echo(Colors.RED(f'\nTest run failed\n'))
+            self.echo(Colors.RED('\nTest run failed\n'))
         else:
             testing_failed = False
-            self.echo(Colors.GREEN(f'\nTest run completed successfully\n'))
+            self.echo(Colors.GREEN('\nTest run completed successfully\n'))
         xcresult_collector.gather_results(Xcode.DERIVED_DATA_PATH)
 
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -359,12 +359,13 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         test_suites, xcresult = self._get_test_suites(
             xcresult_collector, show_found_result=True, save_xcresult_dir=output_dir)
 
-        self.echo(Colors.BLUE(
+        message = (
             f'Executed {test_suites.tests} tests with '
             f'{test_suites.failures} failures and '
             f'{test_suites.errors} errors in '
             f'{test_suites.time:.2f} seconds.\n'
-        ))
+        )
+        self.echo(Colors.BLUE(message))
         TestSuitePrinter(self.echo).print_test_suites(test_suites)
         self._save_test_suite(xcresult, test_suites, output_dir, output_extension)
 
@@ -538,7 +539,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         if show_found_result:
             self.logger.info(Colors.GREEN('Found test results at'))
             for xcresult in xcresult_collector.get_collected_results():
-                self.logger.info(f'- %s', xcresult)
+                self.logger.info('- %s', xcresult)
             self.logger.info('')
 
         xcresult = xcresult_collector.get_merged_xcresult()

--- a/tests/apple/app_store_connect/provisioning/conftest.py
+++ b/tests/apple/app_store_connect/provisioning/conftest.py
@@ -1,9 +1,7 @@
 import json
 import pathlib
-from typing import Dict
 
 import pytest
-
 
 _RESOURCE_MOCKS_DIR = pathlib.Path(__file__).parent.parent.parent / 'resources' / 'mocks'
 

--- a/tests/apple/app_store_connect/provisioning/test_bundle_id_capabilities.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_id_capabilities.py
@@ -38,7 +38,7 @@ class BundleIdCapabilitiesTest(ResourceManagerTestsBase):
         capability = self.api_client.bundle_id_capabilities.modify_configuration(
             ResourceId('F88J43FA9J_GAME_CENTER_IOS'),
             CapabilityType.GAME_CENTER,
-            None
+            None,
         )
         assert isinstance(capability, BundleIdCapability)
         assert capability.type is ResourceType.BUNDLE_ID_CAPABILITIES

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -22,7 +22,7 @@ class BundleIdsTest(ResourceManagerTestsBase):
         bundle_id = self.api_client.bundle_ids.create(
             'com.example.test-app',
             'com example test app',
-            BundleIdPlatform.IOS
+            BundleIdPlatform.IOS,
         )
         assert isinstance(bundle_id, BundleId)
 

--- a/tests/apple/app_store_connect/provisioning/test_devices.py
+++ b/tests/apple/app_store_connect/provisioning/test_devices.py
@@ -21,7 +21,7 @@ class DevicesTest(ResourceManagerTestsBase):
         device = self.api_client.devices.create(
             f'test device from {self.__class__.__name__}',
             BundleIdPlatform.IOS,
-            DEVICE_UDID
+            DEVICE_UDID,
         )
         assert isinstance(device, Device)
 

--- a/tests/apple/app_store_connect/provisioning/test_signing_certificates.py
+++ b/tests/apple/app_store_connect/provisioning/test_signing_certificates.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from codemagic.apple.resources import CertificateType

--- a/tests/apple/resources/test_resource.py
+++ b/tests/apple/resources/test_resource.py
@@ -48,11 +48,12 @@ def test_resource_tabular_formatting(api_profile):
 @pytest.mark.parametrize('class_name, pretty_name', [
     ('BundleId', 'Bundle ID'),
     ('RandomNameWithIdInIt', 'Random Name With ID In It'),
-    ('Resource', 'Resource')
+    ('Resource', 'Resource'),
 ])
 def test_pretty_name_meta(class_name, pretty_name):
     class K(metaclass=PrettyNameMeta):
-        dict = lambda self: {}
+        def dict(self):
+            return {}
 
     K.__name__ = class_name
     assert str(K) == pretty_name

--- a/tests/cli/test_argument.py
+++ b/tests/cli/test_argument.py
@@ -151,7 +151,7 @@ def test_raise_argument_error(argument: cli.Argument, cli_argument_group):
     assert error_msg.startswith(f'argument {key}: ')
     assert any([
         f'Value {key.upper()} not provided' in error_msg,
-        f'Missing value {key.upper()}' in error_msg
+        f'Missing value {key.upper()}' in error_msg,
     ])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,10 @@ import pytest
 
 sys.path.append('src')
 
-from codemagic.utilities import log  # noqa: E402
 from codemagic.apple.app_store_connect import AppStoreConnectApiClient  # noqa: E402
 from codemagic.apple.app_store_connect import IssuerId  # noqa: E402
 from codemagic.apple.app_store_connect import KeyIdentifier  # noqa: E402
+from codemagic.utilities import log  # noqa: E402
 
 log.initialize_logging(
     stream=open(os.devnull, 'w'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,15 @@ import pytest
 
 sys.path.append('src')
 
-from codemagic.utilities import log
-from codemagic.apple.app_store_connect import AppStoreConnectApiClient
-from codemagic.apple.app_store_connect import IssuerId
-from codemagic.apple.app_store_connect import KeyIdentifier
+from codemagic.utilities import log  # noqa: E402
+from codemagic.apple.app_store_connect import AppStoreConnectApiClient  # noqa: E402
+from codemagic.apple.app_store_connect import IssuerId  # noqa: E402
+from codemagic.apple.app_store_connect import KeyIdentifier  # noqa: E402
 
 log.initialize_logging(
     stream=open(os.devnull, 'w'),
     verbose=False,
-    enable_logging=False
+    enable_logging=False,
 )
 
 
@@ -65,7 +65,7 @@ def _api_client() -> AppStoreConnectApiClient:
     return AppStoreConnectApiClient(
         KeyIdentifier(os.environ['TEST_APPLE_KEY_IDENTIFIER']),
         IssuerId(os.environ['TEST_APPLE_ISSUER_ID']),
-        private_key
+        private_key,
     )
 
 

--- a/tests/mixins/test_string_converter.py
+++ b/tests/mixins/test_string_converter.py
@@ -12,7 +12,7 @@ from codemagic.mixins import StringConverterMixin
     ('🤩', b'\xf0\x9f\xa4\xa9'),
     (b'\xf0\x9f\xa4\xa9', b'\xf0\x9f\xa4\xa9'),
     (b'', b''),
-    (b'test', b'test')
+    (b'test', b'test'),
 ])
 def test_to_bytes(bytes_or_str, expected_result):
     assert StringConverterMixin._bytes(bytes_or_str) == expected_result
@@ -27,7 +27,7 @@ def test_to_bytes(bytes_or_str, expected_result):
     (b'\xf0\x9f\xa4\xa9', '🤩'),
     ('🤩', '🤩'),
     (b'', ''),
-    (b'test', 'test')
+    (b'test', 'test'),
 ])
 def test_to_str(bytes_or_str, expected_result):
     assert StringConverterMixin._str(bytes_or_str) == expected_result

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -35,7 +35,7 @@ def export_options_dict() -> Dict[str, Union[bool, str, Dict[str, str]]]:
     return {
         'method': 'development',
         'provisioningProfiles': {
-            'io.codemagic.capybara': 'io codemagic capybara development 1555086834'
+            'io.codemagic.capybara': 'io codemagic capybara development 1555086834',
         },
         'signingCertificate': 'iPhone Developer',
         'signingStyle': 'manual',

--- a/tests/models/junit/test_xml_generation.py
+++ b/tests/models/junit/test_xml_generation.py
@@ -13,96 +13,321 @@ from codemagic.models.junit import TestSuites
 
 @pytest.fixture()
 def _testsuites() -> TestSuites:
-    return TestSuites(name='', test_suites=[
-        TestSuite(name='banaanTests', tests=5, disabled=0, errors=1, failures=1, package='banaanTests', skipped=1,
-                  time=0.31836485862731934, timestamp='2020-10-29T15:35:53',
-                  properties=[Property(name='device_architecture', value='x86_64'),
-                              Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
-                              Property(name='device_name', value='iPhone 8'),
-                              Property(name='device_operating_system', value='13.2.2 (17B102)'),
-                              Property(name='device_platform', value='iOS Simulator'),
-                              Property(name='ended_time', value='2020-10-29T15:35:53'),
-                              Property(name='started_time', value='2020-10-29T15:33:18'),
-                              Property(name='title', value='Testing project banaan with scheme banaan')], testcases=[
-                TestCase(classname='banaanTests', name='testExample()', assertions=None, status='Success',
-                         time=0.002252936363220215, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testExceptionExample()', assertions=None, status='Failure',
-                         time=0.02912592887878418, error=Error(
-                        message='failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"',
-                        type='banaanTests.MyErrors',
-                        error_description='failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"\nThrown Error: failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"'),
-                         failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testFailExample()', assertions=None, status='Failure',
-                         time=0.03098905086517334, error=None,
-                         failure=Failure(message="failed - This won't make the cut", type='Assertion Failure',
-                                         failure_description="/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:44 failed - This won't make the cut\nAssertion Failure at banaanTests.swift:44: failed - This won't make the cut"),
-                         skipped=None),
-                TestCase(classname='banaanTests', name='testPerformanceExample()', assertions=None, status='Success',
-                         time=0.2531629800796509, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testSkippedExample()', assertions=None, status='Skipped',
-                         time=0.0028339624404907227, error=None, failure=None, skipped=Skipped(
-                        message='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 Test skipped - This test is skipped'))]),
-        TestSuite(name='banaanUITests', tests=2, disabled=0, errors=0, failures=1, package='banaanUITests', skipped=0,
-                  time=4.375350117683411, timestamp='2020-10-29T15:35:53',
-                  properties=[Property(name='device_architecture', value='x86_64'),
-                              Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
-                              Property(name='device_name', value='iPhone 8'),
-                              Property(name='device_operating_system', value='13.2.2 (17B102)'),
-                              Property(name='device_platform', value='iOS Simulator'),
-                              Property(name='ended_time', value='2020-10-29T15:35:53'),
-                              Property(name='started_time', value='2020-10-29T15:33:18'),
-                              Property(name='title', value='Testing project banaan with scheme banaan')], testcases=[
-                TestCase(classname='banaanUITests', name='testUIExample()', assertions=None, status='Success',
-                         time=1.7065880298614502, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanUITests', name='testUIFailExample()', assertions=None, status='Failure',
-                         time=2.6687620878219604, error=None,
-                         failure=Failure(message='failed - Bad UI', type='Assertion Failure',
-                                         failure_description='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 failed - Bad UI\nStart Test at 2020-10-29 15:34:26.057\nSet Up\n    Open io.codemagic.banaan\n        Launch io.codemagic.banaan\n            Terminate io.codemagic.banaan:57014\n            Setting up automation session\n            Wait for io.codemagic.banaan to idle\nAssertion Failure at banaanUITests.swift:40: failed - Bad UI\nTear Down'),
-                         skipped=None)]),
-        TestSuite(name='banaanTests', tests=5, disabled=0, errors=1, failures=1, package='banaanTests', skipped=1,
-                  time=0.35574495792388916, timestamp='2020-10-29T15:35:57',
-                  properties=[Property(name='device_architecture', value='x86_64'),
-                              Property(name='device_identifier', value='87895091-1524-455B-A549-12ADED0AD7F0'),
-                              Property(name='device_name', value='iPhone 8'),
-                              Property(name='device_operating_system', value='14.0 (18A372)'),
-                              Property(name='device_platform', value='iOS Simulator'),
-                              Property(name='ended_time', value='2020-10-29T15:35:57'),
-                              Property(name='started_time', value='2020-10-29T15:33:18'),
-                              Property(name='title', value='Testing project banaan with scheme banaan')], testcases=[
-                TestCase(classname='banaanTests', name='testExample()', assertions=None, status='Success',
-                         time=0.009827971458435059, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testExceptionExample()', assertions=None, status='Failure',
-                         time=0.08241903781890869,
-                         error=Error(message='failed: caught error: "badInput"', type='banaanTests.MyErrors',
-                                     error_description='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:50 failed: caught error: "badInput"\nThrown Error at banaanTests.swift:50: failed: caught error: "badInput"'),
-                         failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testFailExample()', assertions=None, status='Failure',
-                         time=0.0036939382553100586, error=None,
-                         failure=Failure(message="failed - This won't make the cut", type='Assertion Failure',
-                                         failure_description="/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:44 failed - This won't make the cut\nAssertion Failure at banaanTests.swift:44: failed - This won't make the cut"),
-                         skipped=None),
-                TestCase(classname='banaanTests', name='testPerformanceExample()', assertions=None, status='Success',
-                         time=0.2537109851837158, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanTests', name='testSkippedExample()', assertions=None, status='Skipped',
-                         time=0.006093025207519531, error=None, failure=None, skipped=Skipped(
-                        message='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 Test skipped - This test is skipped'))]),
-        TestSuite(name='banaanUITests', tests=2, disabled=0, errors=0, failures=1, package='banaanUITests', skipped=0,
-                  time=5.046915054321289, timestamp='2020-10-29T15:35:57',
-                  properties=[Property(name='device_architecture', value='x86_64'),
-                              Property(name='device_identifier', value='87895091-1524-455B-A549-12ADED0AD7F0'),
-                              Property(name='device_name', value='iPhone 8'),
-                              Property(name='device_operating_system', value='14.0 (18A372)'),
-                              Property(name='device_platform', value='iOS Simulator'),
-                              Property(name='ended_time', value='2020-10-29T15:35:57'),
-                              Property(name='started_time', value='2020-10-29T15:33:18'),
-                              Property(name='title', value='Testing project banaan with scheme banaan')], testcases=[
-                TestCase(classname='banaanUITests', name='testUIExample()', assertions=None, status='Success',
-                         time=1.7833280563354492, error=None, failure=None, skipped=None),
-                TestCase(classname='banaanUITests', name='testUIFailExample()', assertions=None, status='Failure',
-                         time=3.26358699798584, error=None,
-                         failure=Failure(message='failed - Bad UI', type='Assertion Failure',
-                                         failure_description='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 failed - Bad UI\nStart Test at 2020-10-29 15:34:42.837\nSet Up\n    Open io.codemagic.banaan\n        Launch io.codemagic.banaan\n            Terminate io.codemagic.banaan:57051\n            Setting up automation session\n            Wait for io.codemagic.banaan to idle\nAssertion Failure at banaanUITests.swift:40: failed - Bad UI\nTear Down'),
-                         skipped=None)])])
+    return TestSuites(
+        name='',
+        test_suites=[
+            TestSuite(
+                name='banaanTests',
+                tests=5,
+                disabled=0,
+                errors=1,
+                failures=1,
+                package='banaanTests',
+                skipped=1,
+                time=0.31836485862731934,
+                timestamp='2020-10-29T15:35:53',
+                properties=[
+                    Property(name='device_architecture', value='x86_64'),
+                    Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
+                    Property(name='device_name', value='iPhone 8'),
+                    Property(name='device_operating_system', value='13.2.2 (17B102)'),
+                    Property(name='device_platform', value='iOS Simulator'),
+                    Property(name='ended_time', value='2020-10-29T15:35:53'),
+                    Property(name='started_time', value='2020-10-29T15:33:18'),
+                    Property(name='title', value='Testing project banaan with scheme banaan'),
+                ],
+                testcases=[
+                    TestCase(
+                        classname='banaanTests',
+                        name='testExample()',
+                        assertions=None,
+                        status='Success',
+                        time=0.002252936363220215,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testExceptionExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=0.02912592887878418,
+                        error=Error(
+                            message=(
+                                'failed: caught error: "The operation couldn’t be completed. '
+                                '(banaanTests.MyErrors error 0.)"'
+                            ),
+                            type='banaanTests.MyErrors',
+                            error_description=(
+                                'failed: caught error: "The operation couldn’t be completed. '
+                                '(banaanTests.MyErrors error 0.)"\n'
+                                'Thrown Error: failed: caught error: '
+                                '"The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"'
+                            ),
+                        ),
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testFailExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=0.03098905086517334,
+                        error=None,
+                        failure=Failure(
+                            message="failed - This won't make the cut",
+                            type='Assertion Failure',
+                            failure_description=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:44 '
+                                "failed - This won't make the cut\n"
+                                "Assertion Failure at banaanTests.swift:44: failed - This won't make the cut"
+                            ),
+                        ),
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testPerformanceExample()',
+                        assertions=None,
+                        status='Success',
+                        time=0.2531629800796509,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testSkippedExample()',
+                        assertions=None,
+                        status='Skipped',
+                        time=0.0028339624404907227,
+                        error=None,
+                        failure=None,
+                        skipped=Skipped(
+                            message=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 '
+                                'Test skipped - This test is skipped'
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+            TestSuite(
+                name='banaanUITests',
+                tests=2,
+                disabled=0,
+                errors=0,
+                failures=1,
+                package='banaanUITests',
+                skipped=0,
+                time=4.375350117683411,
+                timestamp='2020-10-29T15:35:53',
+                properties=[
+                    Property(name='device_architecture', value='x86_64'),
+                    Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
+                    Property(name='device_name', value='iPhone 8'),
+                    Property(name='device_operating_system', value='13.2.2 (17B102)'),
+                    Property(name='device_platform', value='iOS Simulator'),
+                    Property(name='ended_time', value='2020-10-29T15:35:53'),
+                    Property(name='started_time', value='2020-10-29T15:33:18'),
+                    Property(name='title', value='Testing project banaan with scheme banaan'),
+                ],
+                testcases=[
+                    TestCase(
+                        classname='banaanUITests',
+                        name='testUIExample()',
+                        assertions=None,
+                        status='Success',
+                        time=1.7065880298614502,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanUITests',
+                        name='testUIFailExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=2.6687620878219604,
+                        error=None,
+                        failure=Failure(
+                            message='failed - Bad UI',
+                            type='Assertion Failure',
+                            failure_description=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 '
+                                'failed - Bad UI\n'
+                                'Start Test at 2020-10-29 15:34:26.057\n'
+                                'Set Up\n'
+                                '    Open io.codemagic.banaan\n'
+                                '        Launch io.codemagic.banaan\n'
+                                '            Terminate io.codemagic.banaan:57014\n'
+                                '            Setting up automation session\n'
+                                '            Wait for io.codemagic.banaan to idle\n'
+                                'Assertion Failure at banaanUITests.swift:40: failed - Bad UI\n'
+                                'Tear Down'
+                            ),
+                        ),
+                        skipped=None,
+                    ),
+                ],
+            ),
+            TestSuite(
+                name='banaanTests',
+                tests=5,
+                disabled=0,
+                errors=1,
+                failures=1,
+                package='banaanTests',
+                skipped=1,
+                time=0.35574495792388916,
+                timestamp='2020-10-29T15:35:57',
+                properties=[
+                    Property(name='device_architecture', value='x86_64'),
+                    Property(name='device_identifier', value='87895091-1524-455B-A549-12ADED0AD7F0'),
+                    Property(name='device_name', value='iPhone 8'),
+                    Property(name='device_operating_system', value='14.0 (18A372)'),
+                    Property(name='device_platform', value='iOS Simulator'),
+                    Property(name='ended_time', value='2020-10-29T15:35:57'),
+                    Property(name='started_time', value='2020-10-29T15:33:18'),
+                    Property(name='title', value='Testing project banaan with scheme banaan'),
+                ],
+                testcases=[
+                    TestCase(
+                        classname='banaanTests',
+                        name='testExample()',
+                        assertions=None,
+                        status='Success',
+                        time=0.009827971458435059,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testExceptionExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=0.08241903781890869,
+                        error=Error(
+                            message='failed: caught error: "badInput"',
+                            type='banaanTests.MyErrors',
+                            error_description=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:50 '
+                                'failed: caught error: "badInput"\n'
+                                'Thrown Error at banaanTests.swift:50: failed: caught error: "badInput"'
+                            ),
+                        ),
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testFailExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=0.0036939382553100586,
+                        error=None,
+                        failure=Failure(
+                            message="failed - This won't make the cut",
+                            type='Assertion Failure',
+                            failure_description=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/'
+                                "ios-test2Tests/banaanTests.swift:44 failed - This won't make the cut\n"
+                                "Assertion Failure at banaanTests.swift:44: failed - This won't make the cut"
+                            ),
+                        ),
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testPerformanceExample()',
+                        assertions=None,
+                        status='Success',
+                        time=0.2537109851837158,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanTests',
+                        name='testSkippedExample()',
+                        assertions=None,
+                        status='Skipped',
+                        time=0.006093025207519531,
+                        error=None,
+                        failure=None,
+                        skipped=Skipped(
+                            message=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 '
+                                'Test skipped - This test is skipped'
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+            TestSuite(
+                name='banaanUITests',
+                tests=2,
+                disabled=0,
+                errors=0,
+                failures=1,
+                package='banaanUITests',
+                skipped=0,
+                time=5.046915054321289,
+                timestamp='2020-10-29T15:35:57',
+                properties=[
+                    Property(name='device_architecture', value='x86_64'),
+                    Property(name='device_identifier', value='87895091-1524-455B-A549-12ADED0AD7F0'),
+                    Property(name='device_name', value='iPhone 8'),
+                    Property(name='device_operating_system', value='14.0 (18A372)'),
+                    Property(name='device_platform', value='iOS Simulator'),
+                    Property(name='ended_time', value='2020-10-29T15:35:57'),
+                    Property(name='started_time', value='2020-10-29T15:33:18'),
+                    Property(name='title', value='Testing project banaan with scheme banaan'),
+                ],
+                testcases=[
+                    TestCase(
+                        classname='banaanUITests',
+                        name='testUIExample()',
+                        assertions=None,
+                        status='Success',
+                        time=1.7833280563354492,
+                        error=None,
+                        failure=None,
+                        skipped=None,
+                    ),
+                    TestCase(
+                        classname='banaanUITests',
+                        name='testUIFailExample()',
+                        assertions=None,
+                        status='Failure',
+                        time=3.26358699798584,
+                        error=None,
+                        failure=Failure(
+                            message='failed - Bad UI',
+                            type='Assertion Failure',
+                            failure_description=(
+                                '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 '
+                                'failed - Bad UI\n'
+                                'Start Test at 2020-10-29 15:34:42.837\n'
+                                'Set Up\n'
+                                '    Open io.codemagic.banaan\n'
+                                '        Launch io.codemagic.banaan\n'
+                                '            Terminate io.codemagic.banaan:57051\n'
+                                '            Setting up automation session\n'
+                                '            Wait for io.codemagic.banaan to idle\n'
+                                'Assertion Failure at banaanUITests.swift:40: failed - Bad UI\n'
+                                'Tear Down'
+                            ),
+                        ),
+                        skipped=None,
+                    ),
+                ],
+            ),
+        ],
+    )
 
 
 @pytest.fixture()

--- a/tests/models/simulator/test_runtime.py
+++ b/tests/models/simulator/test_runtime.py
@@ -82,7 +82,7 @@ def test_equality_to_invalid_type(compare_to):
     with pytest.raises(ValueError) as exception_info:
         _ = Runtime('iOS 1') == compare_to
     error = exception_info.value
-    assert str(error) == f"Cannot compare {Runtime.__name__} with {compare_to.__class__.__name__}"
+    assert str(error) == f'Cannot compare {Runtime.__name__} with {compare_to.__class__.__name__}'
 
 
 def test_total_ordering():
@@ -110,6 +110,6 @@ def test_total_ordering():
         'tvOS 7.2.1',
         'tvOS 4.1',
         'watchOS 7.2',
-        'iOS 2.10'
+        'iOS 2.10',
     ], key=Runtime)
     assert ordered == expected_ordering

--- a/tests/models/test_code_sign_entitlements.py
+++ b/tests/models/test_code_sign_entitlements.py
@@ -5,12 +5,12 @@ import pytest
 from codemagic.models import CodeSignEntitlements
 
 _expected_entitlements = {
-    "application-identifier": "X8NNQ9CYL2.io.codemagic.capybara",
-    "com.apple.developer.team-identifier": "X8NNQ9CYL2",
-    "get-task-allow": True,
-    "keychain-access-groups": [
-        "X8NNQ9CYL2.io.codemagic.capybara"
-    ]
+    'application-identifier': 'X8NNQ9CYL2.io.codemagic.capybara',
+    'com.apple.developer.team-identifier': 'X8NNQ9CYL2',
+    'get-task-allow': True,
+    'keychain-access-groups': [
+        'X8NNQ9CYL2.io.codemagic.capybara',
+    ],
 }
 
 

--- a/tests/models/test_table.py
+++ b/tests/models/test_table.py
@@ -1,7 +1,7 @@
-from codemagic.models.table import Table
+from codemagic.models.table import Header
 from codemagic.models.table import Line
 from codemagic.models.table import Spacer
-from codemagic.models.table import Header
+from codemagic.models.table import Table
 
 _EXPECTED_DEFAULT_RENDER = """\
 ┌───────────────────────┐

--- a/tests/models/test_table.py
+++ b/tests/models/test_table.py
@@ -3,7 +3,7 @@ from codemagic.models.table import Line
 from codemagic.models.table import Spacer
 from codemagic.models.table import Header
 
-_EXPECTED_DEFAULT_RENDER = '''\
+_EXPECTED_DEFAULT_RENDER = """\
 ┌───────────────────────┐
 │        Header         │
 ├─────────────┬─────────┤
@@ -16,17 +16,17 @@ _EXPECTED_DEFAULT_RENDER = '''\
 ├─────────────┬─────────┤
 │  row_4      │  key_4  │
 └─────────────┴─────────┘
-'''
+"""
 
-_EXPECTED_HEADERLESS_TABLE = '''\
+_EXPECTED_HEADERLESS_TABLE = """\
 ┌─────────┬─────────┐
 │  row_1  │  key_1  │
 │  row_2  │  key_2  │
 └─────────┴─────────┘
-'''
+"""
 
 
-_EXPECTED_CUSTOM_TABLE_1 = '''\
+_EXPECTED_CUSTOM_TABLE_1 = """\
 +---------------------------+
 |          Header           |
 +---------------+-----------+
@@ -39,9 +39,9 @@ _EXPECTED_CUSTOM_TABLE_1 = '''\
 +---------------+-----------+
 | < row_4     > | < key_4 > |
 +---------------+-----------+
-'''
+"""
 
-_EXPECTED_CUSTOM_TABLE_2 = '''\
+_EXPECTED_CUSTOM_TABLE_2 = """\
 ooooooooooooooooooooooooo
 o        Header         o
 ooooooooooooooooooooooooo
@@ -52,7 +52,7 @@ o  row_3      o  key_3  o
 ooooooooooooooooooooooooo
 o       Subheader       o
 ooooooooooooooooooooooooo
-'''
+"""
 
 
 def test_default_table():

--- a/tests/models/test_xcode.py
+++ b/tests/models/test_xcode.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import pytest
 
-
 from codemagic.models import Xcode
 
 

--- a/tests/models/xctests/test_converter.py
+++ b/tests/models/xctests/test_converter.py
@@ -28,47 +28,133 @@ def _mock_get_object(_xcresult: pathlib.Path, object_id: str) -> Dict[str, Any]:
 
 @pytest.fixture()
 def testsuite_properties():
-    return [Property(name='device_architecture', value='x86_64'),
-            Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
-            Property(name='device_name', value='iPhone 8'),
-            Property(name='device_operating_system', value='13.2.2 (17B102)'),
-            Property(name='device_platform', value='iOS Simulator'),
-            Property(name='ended_time', value='2020-10-29T15:35:53'),
-            Property(name='started_time', value='2020-10-29T15:33:18'),
-            Property(name='title', value='Testing project banaan with scheme banaan')]
+    return [
+        Property(name='device_architecture', value='x86_64'),
+        Property(name='device_identifier', value='7C2AC071-3FAE-4370-81D8-079BC87CC391'),
+        Property(name='device_name', value='iPhone 8'),
+        Property(name='device_operating_system', value='13.2.2 (17B102)'),
+        Property(name='device_platform', value='iOS Simulator'),
+        Property(name='ended_time', value='2020-10-29T15:35:53'),
+        Property(name='started_time', value='2020-10-29T15:33:18'),
+        Property(name='title', value='Testing project banaan with scheme banaan'),
+    ]
 
 
 @pytest.fixture()
 def expected_unit_testcases():
-    return [TestCase(classname='banaanTests', name='testExample()', assertions=None, status='Success',
-                     time=0.002252936363220215, error=None, failure=None, skipped=None),
-            TestCase(classname='banaanTests', name='testExceptionExample()', assertions=None, status='Failure',
-                     time=0.02912592887878418, error=Error(
-                    message='failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"',
-                    type='banaanTests.MyErrors',
-                    error_description='failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"\nThrown Error: failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"'),
-                     failure=None, skipped=None),
-            TestCase(classname='banaanTests', name='testFailExample()', assertions=None, status='Failure',
-                     time=0.03098905086517334, error=None,
-                     failure=Failure(message="failed - This won't make the cut", type='Assertion Failure',
-                                     failure_description="/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:44 failed - This won't make the cut\nAssertion Failure at banaanTests.swift:44: failed - This won't make the cut"),
-                     skipped=None),
-            TestCase(classname='banaanTests', name='testPerformanceExample()', assertions=None, status='Success',
-                     time=0.2531629800796509, error=None, failure=None, skipped=None),
-            TestCase(classname='banaanTests', name='testSkippedExample()', assertions=None, status='Skipped',
-                     time=0.0028339624404907227, error=None, failure=None, skipped=Skipped(
-                    message='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 Test skipped - This test is skipped'))]
+    return [
+        TestCase(
+            classname='banaanTests',
+            name='testExample()',
+            assertions=None,
+            status='Success',
+            time=0.002252936363220215,
+            error=None,
+            failure=None,
+            skipped=None,
+        ),
+        TestCase(
+            classname='banaanTests',
+            name='testExceptionExample()',
+            assertions=None, status='Failure',
+            time=0.02912592887878418,
+            error=Error(
+                message='failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"',
+                type='banaanTests.MyErrors',
+                error_description=(
+                    'failed: caught error: "The operation couldn’t be completed. (banaanTests.MyErrors error 0.)"\n'
+                    'Thrown Error: failed: caught error: "The operation couldn’t be completed. '
+                    '(banaanTests.MyErrors error 0.)"'
+                ),
+            ),
+            failure=None,
+            skipped=None,
+        ),
+        TestCase(
+            classname='banaanTests',
+            name='testFailExample()',
+            assertions=None,
+            status='Failure',
+            time=0.03098905086517334,
+            error=None,
+            failure=Failure(
+                message="failed - This won't make the cut", type='Assertion Failure',
+                failure_description=(
+                    '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:44 failed - '
+                    "This won't make the cut\n"
+                    "Assertion Failure at banaanTests.swift:44: failed - This won't make the cut"
+                ),
+            ),
+            skipped=None,
+        ),
+        TestCase(
+            classname='banaanTests',
+            name='testPerformanceExample()',
+            assertions=None,
+            status='Success',
+            time=0.2531629800796509,
+            error=None,
+            failure=None,
+            skipped=None,
+        ),
+        TestCase(
+            classname='banaanTests',
+            name='testSkippedExample()',
+            assertions=None,
+            status='Skipped',
+            time=0.0028339624404907227,
+            error=None,
+            failure=None,
+            skipped=Skipped(
+                message=(
+                    '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2Tests/banaanTests.swift:34 Test skipped'
+                    ' - This test is skipped'
+                ),
+            ),
+        ),
+    ]
 
 
 @pytest.fixture()
 def expected_ui_testcases():
-    return [TestCase(classname='banaanUITests', name='testUIExample()', assertions=None, status='Success',
-                     time=1.7065880298614502, error=None, failure=None, skipped=None),
-            TestCase(classname='banaanUITests', name='testUIFailExample()', assertions=None, status='Failure',
-                     time=2.6687620878219604, error=None,
-                     failure=Failure(message='failed - Bad UI', type='Assertion Failure',
-                                     failure_description='/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 failed - Bad UI\nStart Test at 2020-10-29 15:34:26.057\nSet Up\n    Open io.codemagic.banaan\n        Launch io.codemagic.banaan\n            Terminate io.codemagic.banaan:57014\n            Setting up automation session\n            Wait for io.codemagic.banaan to idle\nAssertion Failure at banaanUITests.swift:40: failed - Bad UI\nTear Down'),
-                     skipped=None)]
+    return [
+        TestCase(
+            classname='banaanUITests',
+            name='testUIExample()',
+            assertions=None,
+            status='Success',
+            time=1.7065880298614502,
+            error=None,
+            failure=None,
+            skipped=None,
+        ),
+        TestCase(
+            classname='banaanUITests',
+            name='testUIFailExample()',
+            assertions=None,
+            status='Failure',
+            time=2.6687620878219604,
+            error=None,
+            failure=Failure(
+                message='failed - Bad UI',
+                type='Assertion Failure',
+                failure_description=(
+                    '/Users/priit/nevercode/banaan-ios/ios-test2/ios-test2UITests/banaanUITests.swift:40 failed'
+                    ' - Bad UI\n'
+                    'Start Test at 2020-10-29 15:34:26.057\n'
+                    'Set Up\n'
+                    '    Open io.codemagic.banaan\n'
+                    '        Launch io.codemagic.banaan\n'
+                    '            Terminate io.codemagic.banaan:57014\n'
+                    '            Setting up automation session\n'
+                    '            Wait for io.codemagic.banaan to idle\n'
+                    'Assertion Failure at banaanUITests.swift:40: failed - Bad UI\n'
+                    'Tear Down'
+                ),
+            ),
+            skipped=None,
+        ),
+    ]
 
 
 @mock.patch.object(XcResultTool, 'get_object', _mock_get_object)

--- a/tests/tools/test_android_app_bundle.py
+++ b/tests/tools/test_android_app_bundle.py
@@ -72,7 +72,7 @@ def test_build_apks_signing_info_args(android_app_bundle, cli_argument_group):
     with mock.patch.object(AndroidAppBundle, '_build_apk_set_archive', mock_build_apk_set_archive):
         built_apks = android_app_bundle.build_apks(
             pathlib.Path('android_app_bundle.aab'),
-            **signing_info_kwargs
+            **signing_info_kwargs,
         )
     assert built_apks == [pathlib.Path('android_app_bundle-signed.apks')]
 

--- a/tests/utilities/test_levenshtein_distance.py
+++ b/tests/utilities/test_levenshtein_distance.py
@@ -4,64 +4,64 @@ from codemagic.utilities.levenshtein_distance import levenshtein_distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("", "", 0),
-    ("a", "", 1),
-    ("", "a", 1),
-    ("abc", "", 3),
-    ("", "abc", 3),
+    ('', '', 0),
+    ('a', '', 1),
+    ('', 'a', 1),
+    ('abc', '', 3),
+    ('', 'abc', 3),
 ])
 def test_levenshtein_distance_on_empty_strings(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("", "", 0),
-    ("a", "a", 0),
-    ("abc", "abc", 0),
+    ('', '', 0),
+    ('a', 'a', 0),
+    ('abc', 'abc', 0),
 ])
 def test_levenshtein_distance_on_equal_strings(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("", "a", 1),
-    ("a", "ab", 1),
-    ("b", "ab", 1),
-    ("ac", "abc", 1),
-    ("abcdefg", "xabxcdxxefxgx", 6),
+    ('', 'a', 1),
+    ('a', 'ab', 1),
+    ('b', 'ab', 1),
+    ('ac', 'abc', 1),
+    ('abcdefg', 'xabxcdxxefxgx', 6),
 ])
 def test_levenshtein_distance_on_inserts(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("a", "", 1),
-    ("ab", "a", 1),
-    ("ab", "b", 1),
-    ("abc", "ac", 1),
-    ("xabxcdxxefxgx", "abcdefg", 6),
+    ('a', '', 1),
+    ('ab', 'a', 1),
+    ('ab', 'b', 1),
+    ('abc', 'ac', 1),
+    ('xabxcdxxefxgx', 'abcdefg', 6),
 ])
 def test_levenshtein_distance_on_removals(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("a", "b", 1),
-    ("ab", "ac", 1),
-    ("ac", "bc", 1),
-    ("abc", "axc", 1),
-    ("xabxcdxxefxgx", "1ab2cd34ef5g6", 6),
+    ('a', 'b', 1),
+    ('ab', 'ac', 1),
+    ('ac', 'bc', 1),
+    ('abc', 'axc', 1),
+    ('xabxcdxxefxgx', '1ab2cd34ef5g6', 6),
 ])
 def test_levenshtein_distance_on_substitutions(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance
 
 
 @pytest.mark.parametrize('s1, s2, distance', [
-    ("example", "samples", 3),
-    ("sturgeon", "urgently", 6),
-    ("levenshtein", "frankenstein", 6),
-    ("distance", "difference", 5),
-    ("java was neat", "scala is great", 7),
+    ('example', 'samples', 3),
+    ('sturgeon', 'urgently', 6),
+    ('levenshtein', 'frankenstein', 6),
+    ('distance', 'difference', 5),
+    ('java was neat', 'scala is great', 7),
 ])
 def test_levenshtein_distance_on_all_operations(s1, s2, distance):
     assert levenshtein_distance(s1, s2) == distance


### PR DESCRIPTION
Implement automatic code In order to make code review process easier.

Added two automatic checks to CI pipeline:
- `flake8` code fromatting checks with `flake8_quotes`, `flake8_commas` and `pep8-naming` extensions,
- `isort` imports ordering checks.

Existing codebase was updated with minimal changes to pass the checks.