### PR TITLE
Bugfix: Fix platform filter for listing bundle identifiers from App Store Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@ Version 0.4.8
 -------------
 **Improvements**
 
-- Improvement: add support for tvOS distribution certificates.
+- Bugfix: Fix platform filter for listing bundle identifiers using App Store Connect API.
+
+Version 0.4.8
+-------------
+**Improvements**
+
+- Improvement: Add support for tvOS distribution certificates.
 
 Version 0.4.7
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.4.8
+Version 0.4.9
 -------------
 **Improvements**
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import Type
 from typing import Union
 
@@ -37,6 +37,11 @@ class BundleIds(ResourceManager[BundleId]):
         name: Optional[str] = None
         platform: Optional[BundleIdPlatform] = None
         seed_id: Optional[str] = None
+
+        def matches(self, bundle_id: BundleId) -> bool:
+            # Double check that platform matches since this filter does not work on Apple's
+            # side as of 02.03.2021 and API 1.2. All other filters are applied as expected.
+            return self._field_matches(self.platform, bundle_id.attributes.platform)
 
     class Ordering(ResourceManager.Ordering):
         ID = 'id'
@@ -90,8 +95,9 @@ class BundleIds(ResourceManager[BundleId]):
         https://developer.apple.com/documentation/appstoreconnectapi/list_bundle_ids
         """
         params = {'sort': ordering.as_param(reverse), **resource_filter.as_query_params()}
-        bundle_ids = self.client.paginate(f'{self.client.API_URL}/bundleIds', params=params)
-        return [BundleId(bundle_id) for bundle_id in bundle_ids]
+        url = f'{self.client.API_URL}/bundleIds'
+        bundle_ids = (BundleId(bundle_id) for bundle_id in self.client.paginate(url, params=params))
+        return [bundle_id for bundle_id in bundle_ids if resource_filter.matches(bundle_id)]
 
     def read(self, bundle_id: Union[LinkedResourceData, ResourceId]) -> BundleId:
         """

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import Type
 from typing import Union
 

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -35,6 +35,30 @@ class BundleIdsTest(ResourceManagerTestsBase):
     def test_delete(self):
         self.api_client.bundle_ids.delete(ResourceId('US2AH335HU'))
 
+    def test_list_platform_constraint(self):
+        expected_platform = BundleIdPlatform.IOS
+        bundle_id_filter = self.api_client.bundle_ids.Filter(
+            platform=expected_platform,
+            identifier='io.codemagic.banaan'
+        )
+        bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
+        assert len(bundle_ids) == 1
+        bundle_id = bundle_ids[0]
+        assert isinstance(bundle_id, BundleId)
+        assert bundle_id.id == ResourceId('NLRN94JD59')
+        assert bundle_id.attributes.platform is expected_platform
+        assert bundle_id.type is ResourceType.BUNDLE_ID
+
+    def test_list_identifier_constraint(self):
+        expected_identifier = 'io.codemagic.banaan'
+        bundle_id_filter = self.api_client.bundle_ids.Filter(identifier=expected_identifier)
+        bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
+        assert len(bundle_ids) == 2
+        for bundle_id in bundle_ids:
+            assert isinstance(bundle_id, BundleId)
+            assert bundle_id.type is ResourceType.BUNDLE_ID
+            assert expected_identifier in bundle_id.attributes.identifier
+
     def test_list(self):
         bundle_ids = self.api_client.bundle_ids.list()
         assert len(bundle_ids) > 0

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -39,7 +39,7 @@ class BundleIdsTest(ResourceManagerTestsBase):
         expected_platform = BundleIdPlatform.IOS
         bundle_id_filter = self.api_client.bundle_ids.Filter(
             platform=expected_platform,
-            identifier='io.codemagic.banaan'
+            identifier='io.codemagic.banaan',
         )
         bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
         assert len(bundle_ids) == 1


### PR DESCRIPTION
App Store Connect's [List Bundle IDs](https://developer.apple.com/documentation/appstoreconnectapi/list_bundle_ids) API endpoint does not respect the value of `filter[platform]` query parameter and always returns bundle identifiers for all platforms. This leads to unexpected consequences and as such we need to do client side filtering in order to avoid this.