### PR TITLE
Bugfix/list bundle ids filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+Version 0.4.9
+-------------
+**Improvements**
+
+- Bugfix: Fix platform filter for listing bundle identifiers using App Store Connect API.
+
 Version 0.4.8
 -------------
 **Improvements**
 
-- Improvement: add support for tvOS distribution certificates.
+- Improvement: Add support for tvOS distribution certificates.
 
 Version 0.4.7
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.4.10
+-------------
+**Improvements**
+
+- Bugfix: Fix regression introduced in 0.4.9 that excluded bundle identifiers with platform type `UNIVERSAL` from list bundle identifiers result in case platform filter (`IOS` or `MAC_OS`) was specified.    
+
 Version 0.4.9
 -------------
 **Improvements**

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.4.9'
+__version__ = '0.4.10'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -38,6 +38,11 @@ class BundleIds(ResourceManager[BundleId]):
         platform: Optional[BundleIdPlatform] = None
         seed_id: Optional[str] = None
 
+        def matches(self, bundle_id: BundleId) -> bool:
+            # Double check that platform matches since this filter does not work on Apple's
+            # side as of 02.03.2021 and API 1.2. All other filters are applied as expected.
+            return self._field_matches(self.platform, bundle_id.attributes.platform)
+
     class Ordering(ResourceManager.Ordering):
         ID = 'id'
         NAME = 'name'
@@ -90,8 +95,9 @@ class BundleIds(ResourceManager[BundleId]):
         https://developer.apple.com/documentation/appstoreconnectapi/list_bundle_ids
         """
         params = {'sort': ordering.as_param(reverse), **resource_filter.as_query_params()}
-        bundle_ids = self.client.paginate(f'{self.client.API_URL}/bundleIds', params=params)
-        return [BundleId(bundle_id) for bundle_id in bundle_ids]
+        url = f'{self.client.API_URL}/bundleIds'
+        bundle_ids = (BundleId(bundle_id) for bundle_id in self.client.paginate(url, params=params))
+        return [bundle_id for bundle_id in bundle_ids if resource_filter.matches(bundle_id)]
 
     def read(self, bundle_id: Union[LinkedResourceData, ResourceId]) -> BundleId:
         """

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -41,7 +41,11 @@ class BundleIds(ResourceManager[BundleId]):
         def matches(self, bundle_id: BundleId) -> bool:
             # Double check that platform matches since this filter does not work on Apple's
             # side as of 02.03.2021 and API 1.2. All other filters are applied as expected.
-            return self._field_matches(self.platform, bundle_id.attributes.platform)
+            # In case either platform 'IOS' or 'MAC_OS' is specified, then we need to also
+            # accept bundle ids with platform 'UNIVERSAL' since it covers both.
+            if not self.platform:
+                return True
+            return bundle_id.attributes.platform in (self.platform, BundleIdPlatform.UNIVERSAL)
 
     class Ordering(ResourceManager.Ordering):
         ID = 'id'

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -35,29 +35,20 @@ class BundleIdsTest(ResourceManagerTestsBase):
     def test_delete(self):
         self.api_client.bundle_ids.delete(ResourceId('US2AH335HU'))
 
-    def test_list_platform_constraint(self):
+    def test_list_identifier_and_platform_constraint(self):
+        expected_identifier = 'io.codemagic.banaan'
         expected_platform = BundleIdPlatform.IOS
         bundle_id_filter = self.api_client.bundle_ids.Filter(
+            identifier=expected_identifier,
             platform=expected_platform,
-            identifier='io.codemagic.banaan',
         )
-        bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
-        assert len(bundle_ids) == 1
-        bundle_id = bundle_ids[0]
-        assert isinstance(bundle_id, BundleId)
-        assert bundle_id.id == ResourceId('NLRN94JD59')
-        assert bundle_id.attributes.platform is expected_platform
-        assert bundle_id.type is ResourceType.BUNDLE_ID
-
-    def test_list_identifier_constraint(self):
-        expected_identifier = 'io.codemagic.banaan'
-        bundle_id_filter = self.api_client.bundle_ids.Filter(identifier=expected_identifier)
         bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
         assert len(bundle_ids) == 2
         for bundle_id in bundle_ids:
             assert isinstance(bundle_id, BundleId)
             assert bundle_id.type is ResourceType.BUNDLE_ID
             assert expected_identifier in bundle_id.attributes.identifier
+            assert bundle_id.attributes.platform in (expected_platform, BundleIdPlatform.UNIVERSAL)
 
     def test_list(self):
         bundle_ids = self.api_client.bundle_ids.list()

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -35,6 +35,30 @@ class BundleIdsTest(ResourceManagerTestsBase):
     def test_delete(self):
         self.api_client.bundle_ids.delete(ResourceId('US2AH335HU'))
 
+    def test_list_platform_constraint(self):
+        expected_platform = BundleIdPlatform.IOS
+        bundle_id_filter = self.api_client.bundle_ids.Filter(
+            platform=expected_platform,
+            identifier='io.codemagic.banaan',
+        )
+        bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
+        assert len(bundle_ids) == 1
+        bundle_id = bundle_ids[0]
+        assert isinstance(bundle_id, BundleId)
+        assert bundle_id.id == ResourceId('NLRN94JD59')
+        assert bundle_id.attributes.platform is expected_platform
+        assert bundle_id.type is ResourceType.BUNDLE_ID
+
+    def test_list_identifier_constraint(self):
+        expected_identifier = 'io.codemagic.banaan'
+        bundle_id_filter = self.api_client.bundle_ids.Filter(identifier=expected_identifier)
+        bundle_ids = self.api_client.bundle_ids.list(resource_filter=bundle_id_filter)
+        assert len(bundle_ids) == 2
+        for bundle_id in bundle_ids:
+            assert isinstance(bundle_id, BundleId)
+            assert bundle_id.type is ResourceType.BUNDLE_ID
+            assert expected_identifier in bundle_id.attributes.identifier
+
     def test_list(self):
         bundle_ids = self.api_client.bundle_ids.list()
         assert len(bundle_ids) > 0


### PR DESCRIPTION
Changes introduced in pull request #76 were reverted in f7d31c9 due to too strict filters. Namely, filtering solely on given platform type is not optimal since type `UNIVERSAL` matches everything and bundle identifiers with this platform type should always be included in the listing. This pull request restores changes introduced in #76 but in a slightly loosened fashion so that said universal type would always be accepted.