### PR TITLE
Bugfix: Create provisioning profile fails for some profile types due to included devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.4.9
+-------------
+**Improvements**
+
+- Bugfix: Fix check for profiles types that have devices allowed. Allow specifying devices only for ad hoc and development provisioning profiles.
+
 Version 0.4.8
 -------------
 **Improvements**

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -163,11 +163,19 @@ class ProfileType(_ResourceEnum):
     TVOS_APP_INHOUSE = 'TVOS_APP_INHOUSE'
     TVOS_APP_STORE = 'TVOS_APP_STORE'
 
+    @property
+    def is_ad_hoc_type(self) -> bool:
+        return self.value.endswith('_ADHOC')
+
+    @property
+    def is_development_type(self) -> bool:
+        return self.value.endswith('_DEVELOPMENT')
+
     def devices_not_allowed(self) -> bool:
-        return self in (ProfileType.IOS_APP_STORE, ProfileType.IOS_APP_INHOUSE)
+        return not self.devices_allowed()
 
     def devices_allowed(self) -> bool:
-        return not self.devices_not_allowed()
+        return self.is_development_type or self.is_ad_hoc_type
 
 
 class ReleaseType(_ResourceEnum):

--- a/tests/apple/resources/enums/test_profile_type.py
+++ b/tests/apple/resources/enums/test_profile_type.py
@@ -1,0 +1,23 @@
+import pytest
+
+from codemagic.apple.resources import ProfileType
+
+
+@pytest.mark.parametrize('profile_type, should_be_allowed', [
+    (ProfileType.IOS_APP_ADHOC, True),
+    (ProfileType.IOS_APP_DEVELOPMENT, True),
+    (ProfileType.IOS_APP_INHOUSE, False),
+    (ProfileType.IOS_APP_STORE, False),
+    (ProfileType.MAC_APP_DEVELOPMENT, True),
+    (ProfileType.MAC_APP_DIRECT, False),
+    (ProfileType.MAC_APP_STORE, False),
+    (ProfileType.MAC_CATALYST_APP_DEVELOPMENT, True),
+    (ProfileType.MAC_CATALYST_APP_DIRECT, False),
+    (ProfileType.MAC_CATALYST_APP_STORE, False),
+    (ProfileType.TVOS_APP_ADHOC, True),
+    (ProfileType.TVOS_APP_DEVELOPMENT, True),
+    (ProfileType.TVOS_APP_INHOUSE, False),
+    (ProfileType.TVOS_APP_STORE, False),
+])
+def test_devices_allowed(profile_type, should_be_allowed):
+    assert profile_type.devices_allowed() is should_be_allowed


### PR DESCRIPTION
Only development and ad hoc provisioning profiles allow specifying concrete devices in them, and as such previous implementation had flaws in it since only profiles with types `IOS_APP_STORE` and `IOS_APP_INHOUSE` excluded device listings.

This lead to `409` responses from [App Store Connect API Create Profile](https://developer.apple.com/documentation/appstoreconnectapi/create_a_profile) endpoint. For example:

```python
[08:48:05 02-03-2021] INFO  resource_printer.py:72 > Creating new Profile: name: 'profile name', profile type: TVOS_APP_STORE, bundle id: 1IAVWZM6EV, certificates: ['13CO2HS7YE']
[08:48:05 02-03-2021] INFO  api_session.py:32 > >>> POST https://api.appstoreconnect.apple.com/v1/profiles {
    "data": {
        "type": "profiles",
        "attributes": {
            "name": "profile name",
            "profileType": "TVOS_APP_STORE"
        },
        "relationships": {
            "bundleId": {
                "data": {
                    "id": "1IAVWZM6EV",
                    "type": "bundleIds"
                }
            },
            "certificates": {
                "data": [
                    {
                        "id": "13CO2HS7YE",
                        "type": "certificates"
                    }
                ]
            },
            "devices": {
                "data": [
                    {
                        "id": "KFYTTBM8B0",
                        "type": "devices"
                    },
                ]
            }
        }
    }
}
[08:48:05 02-03-2021] INFO  api_session.py:22 > <<< 409 {
    "errors": [
        {
            "id": "dc51f683-8775-4e7c-a322-59117a854d59",
            "status": "409",
            "code": "ENTITY_ERROR.RELATIONSHIP.NOT_ALLOWED",
            "title": "A relationship in the provided entity is not allowed for this request",
            "detail": "No devices can be associated to Provisioning Profiles for the App Store."
        }
    ]
}
[08:48:05 02-03-2021] ERROR cli_app.py:118 >  POST https://api.appstoreconnect.apple.com/v1/profiles returned 409: A relationship in the provided entity is not allowed for this request - No devices can be associated to Provisioning Profiles for the App Store.
```