### PR TITLE
Allow to not fail the `use-profiles` action when profile(s) can't be applied to a project(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.1
+-------------
+
+**Improvements**
+
+- Feature: add the `warn-only` flag to `xcode-project use-profiles` to not fail the action when profile(s) can't be applied to an Xcode project(s)
+
 Version 0.5.0
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.5.1
 
 **Improvements**
 
-- Feature: add the `warn-only` flag to `xcode-project use-profiles` to not fail the action when profile(s) can't be applied to an Xcode project(s)
+- Feature: add the `warn-only` flag to `xcode-project use-profiles` not to fail the action when profiles can't be applied to any of the Xcode projects
 
 Version 0.5.0
 -------------

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -11,6 +11,7 @@ xcode-project use-profiles [-h] [--log-stream STREAM] [--no-color] [--version] [
     [--profile PROFILE_PATHS]
     [--export-options-plist EXPORT_OPTIONS_PATH]
     [--custom-export-options CUSTOM_EXPORT_OPTIONS]
+    [--warn-only]
 ```
 ### Optional arguments for action `use-profiles`
 
@@ -30,6 +31,10 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 
 
 Custom options for generated export options as JSON string. For example '{"uploadBitcode": false, "uploadSymbols": false}'.
+##### `--warn-only`
+
+
+Show warning when profiles can not be applied to an Xcode project(s) instead of failing the action
 ### Common options
 
 ##### `-h, --help`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -88,8 +88,8 @@ class XcodeProjectArgument(cli.Argument):
         flags=('--warn-only',),
         type=bool,
         description=(
-            'Show warning when profiles can not be applied to an Xcode project(s) '
-            'instead of failing the action'
+            'Show warning when profiles cannot be applied to any of the Xcode projects '
+            'instead of fully failing the action'
         ),
         argparse_kwargs={'required': False, 'action': 'store_true'},
     )

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -83,6 +83,16 @@ class XcodeProjectArgument(cli.Argument):
             'default': (ProvisioningProfile.DEFAULT_LOCATION / '*.mobileprovision',),
         },
     )
+    WARN_ONLY = cli.ArgumentProperties(
+        key='warn_only',
+        flags=('--warn-only',),
+        type=bool,
+        description=(
+            'Show warning when profiles can not be applied to an Xcode project(s) '
+            'instead of failing the action'
+        ),
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
 
 
 class ExportIpaArgument(cli.Argument):


### PR DESCRIPTION
Use case is when some `node_modules` or other dependency has an xcode project which can't be signed.
In such case instead of specifying the exact project, user can use the `--warn-only` flag.

Not outputting the exception to warning since it's quite long.