### PR TITLE
Add option to group CLI actions into groups

### DIFF
--- a/doc.py
+++ b/doc.py
@@ -167,7 +167,7 @@ class ToolDocumentationGenerator:
                 optional_args=action_args_serializer.optional_args,
             )
 
-        return list(map(_serialize_action, tool.get_class_cli_actions()))
+        return list(map(_serialize_action, tool.iter_class_cli_actions()))
 
     @classmethod
     def _serialize_default_options(cls, tool: cli.CliApp) -> List[SerializedArgument]:
@@ -187,7 +187,7 @@ class ToolDocumentationGenerator:
             description=tool.__doc__,
             formatter_class=cli.cli_help_formatter.CliHelpFormatter,
         )
-        tool.get_default_cli_options(parser)
+        tool.set_default_cli_options(parser)
         return list(map(_serialize_option, parser._actions))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ force_single_line=True
 [flake8]
 max_line_length=120
 per-file-ignores =
+    # E402 module level import not at top of file
+    doc.py:E402
     # F401 imported but unused
     __init__.py:F401
     src/codemagic/apple/resources/__init__.py:F401

--- a/src/codemagic/cli/__init__.py
+++ b/src/codemagic/cli/__init__.py
@@ -1,3 +1,5 @@
+from .action_group import ActionGroup
+from .action_group import ActionGroupProperties
 from .argument import Argument
 from .argument import ArgumentProperties
 from .argument import CommonArgumentTypes

--- a/src/codemagic/cli/action_group.py
+++ b/src/codemagic/cli/action_group.py
@@ -1,0 +1,11 @@
+import enum
+from typing import NamedTuple
+
+
+class ActionGroupProperties(NamedTuple):
+    name: str
+    description: str
+
+
+class ActionGroup(ActionGroupProperties, enum.Enum):
+    ...

--- a/src/codemagic/cli/argument/action_callable.py
+++ b/src/codemagic/cli/argument/action_callable.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Callable
+from typing import Optional
 from typing import Sequence
 
 if TYPE_CHECKING:
+    from ..action_group import ActionGroup
     from .argument import Argument
 
 
 class ActionCallable:
-    is_cli_action: bool
+    action_group: Optional[ActionGroup]
     action_name: str
     arguments: Sequence[Argument]
+    is_cli_action: bool
+    is_deprecated: bool
     __name__: str
     __call__: Callable

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -229,7 +229,7 @@ class CliApp(metaclass=abc.ABCMeta):
             attr = getattr(cls, attr_name)
             if not callable(attr) or not getattr(attr, 'is_cli_action', False):
                 continue
-            if include_all or getattr(attr, 'action_group', None) is action_group:
+            if include_all or getattr(attr, 'action_group') is action_group:
                 yield attr
 
     def iter_cli_actions(self, action_group: Optional[ActionGroup] = None) -> Iterable[ActionCallable]:


### PR DESCRIPTION
Currently each tool has a flat actions structure, which means that only invocations such as
```bash
app-store-connect action-a <action args>
app-store-connect action-b <action args>
```
are possible, but it would be nice to have option to group commands into categories and interact with them by subcommands such as
```bash
app-store-connect action-group-a subaction-a <action args>
app-store-connect action-group-a subaction-b <action args>
app-store-connect action-group-b subaction-a <action args>
app-store-connect action-group-c subaction-c <action args>
```

This comes in handy since tools such as [app-store-connect](https://github.com/codemagic-ci-cd/cli-tools/tree/v0.5.2/docs/app-store-connect) are already getting rather cluttered by current flat approach and there are more actions coming in.

This PR addresses this problem by adding capabilities to define action groups in addition to current approach. Example usage based is as follows based on `AppStoreConnect` class. First define the groups that you want to use:
```python
class AppStoreConnectActionGroup(cli.ActionGroup):
    CERTIFICATES = cli.ActionGroupProperties(
        name='certificates',
        description='Create, download, and revoke signing certificates for app development and distribution'

    )
    PROFILES = cli.ActionGroupProperties(
        name='profiles',
        description='Create, delete, and download provisioning profiles that enable app installations for development and distribution',
    )
```
Then when defining the action specify desired group in action decorator by keyword argument:
```python
class AppStoreConnect(cli.CliApp):
    ...

    @cli.action('delete', ProfileArgument.PROFILE_RESOURCE_ID, action_group=AppStoreConnectActionGroup.PROFILES)
    def delete_profile(self, profile_resource_id: ResourceId) -> None:
        """ Delete specified Profile from Apple Developer portal """
        ...

    @cli.action('get', ProfileArgument.PROFILE_RESOURCE_ID, action_group=AppStoreConnectActionGroup.PROFILES)
    def get_profile(self, profile_resource_id: ResourceId) -> Profile:
        """ Get specified Profile details from Apple Developer portal """

    @cli.action('delete', CertificateArgument.CERTIFICATE_RESOURCE_ID, action_group=AppStoreConnectActionGroup.CERTIFICATES)
    def delete_certificate(self, certificate_resource_id: ResourceId) -> None:
        """
        Delete specified Certificate from Apple Developer portal
        """
        ...
```
Those will generate mappings for CLI invocations
```bash
app-store-connect profiles delete
app-store-connect profiles get
app-store-connect certificates delete
```
Of course `-h/--help` works as expected for subcommands too.