### PR TITLE
Feature: Add option to strictly match bundle ID identifier for app-store-connect actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.3
+-------------
+
+**Improvements**
+
+- Feature: Add option to strictly match bundle IDs by the identifier for `app-store-connect` actions `fetch-signing-files` and `list-bundle-ids` using flag `--strict-match-identifier`.
+
 Version 0.5.2
 -------------
 

--- a/docs/app-store-connect/fetch-signing-files.md
+++ b/docs/app-store-connect/fetch-signing-files.md
@@ -19,6 +19,7 @@ app-store-connect fetch-signing-files [-h] [--log-stream STREAM] [--no-color] [-
     [--certificate-key-password PRIVATE_KEY_PASSWORD]
     [--p12-password P12_CONTAINER_PASSWORD]
     [--type PROFILE_TYPE]
+    [--strict-match-identifier]
     [--create]
     BUNDLE_ID_IDENTIFIER
 ```
@@ -50,6 +51,10 @@ If provided, the saved p12 container will be encrypted using this password. Used
 
 
 Type of the provisioning profile. Default:&nbsp;`IOS_APP_DEVELOPMENT`
+##### `--strict-match-identifier`
+
+
+Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.com.extension`
 ##### `--create`
 
 

--- a/docs/app-store-connect/fetch-signing-files.md
+++ b/docs/app-store-connect/fetch-signing-files.md
@@ -54,7 +54,7 @@ Type of the provisioning profile. Default:&nbsp;`IOS_APP_DEVELOPMENT`
 ##### `--strict-match-identifier`
 
 
-Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.com.extension`
+Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.app.extension`
 ##### `--create`
 
 

--- a/docs/app-store-connect/list-bundle-ids.md
+++ b/docs/app-store-connect/list-bundle-ids.md
@@ -17,6 +17,7 @@ app-store-connect list-bundle-ids [-h] [--log-stream STREAM] [--no-color] [--ver
     [--bundle-id-identifier BUNDLE_ID_IDENTIFIER_OPTIONAL]
     [--name BUNDLE_ID_NAME]
     [--platform PLATFORM_OPTIONAL]
+    [--strict-match-identifier]
 ```
 ### Optional arguments for action `list-bundle-ids`
 
@@ -32,6 +33,10 @@ Name of the Bundle ID. If the resource is being created, the default will be ded
 
 
 Bundle ID platform
+##### `--strict-match-identifier`
+
+
+Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.com.extension`
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/list-bundle-ids.md
+++ b/docs/app-store-connect/list-bundle-ids.md
@@ -36,7 +36,7 @@ Bundle ID platform
 ##### `--strict-match-identifier`
 
 
-Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.com.extension`
+Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.app.extension`
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -34,7 +34,7 @@ Custom options for generated export options as JSON string. For example '{"uploa
 ##### `--warn-only`
 
 
-Show warning when profiles can not be applied to an Xcode project(s) instead of failing the action
+Show warning when profiles cannot be applied to any of the Xcode projects instead of fully failing the action
 ### Common options
 
 ##### `-h, --help`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -243,6 +243,17 @@ class BundleIdArgument(cli.Argument):
             'choices': list(BundleIdPlatform),
         },
     )
+    IDENTIFIER_STRICT_MATCH = cli.ArgumentProperties(
+        key='bundle_id_identifier_strict_match',
+        flags=('--strict-match-identifier',),
+        type=bool,
+        description=(
+            'Only match Bundle IDs that have exactly the same identifier specified by '
+            '`BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches '
+            'Bundle IDs with identifier such as `com.example.com.extension`'
+        ),
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
 
 
 class DeviceArgument(cli.Argument):

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -250,7 +250,7 @@ class BundleIdArgument(cli.Argument):
         description=(
             'Only match Bundle IDs that have exactly the same identifier specified by '
             '`BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches '
-            'Bundle IDs with identifier such as `com.example.com.extension`'
+            'Bundle IDs with identifier such as `com.example.app.extension`'
         ),
         argparse_kwargs={'required': False, 'action': 'store_true'},
     )

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -279,19 +279,26 @@ class AppStoreConnect(cli.CliApp):
     @cli.action('list-bundle-ids',
                 BundleIdArgument.BUNDLE_ID_IDENTIFIER_OPTIONAL,
                 BundleIdArgument.BUNDLE_ID_NAME,
-                BundleIdArgument.PLATFORM_OPTIONAL)
+                BundleIdArgument.PLATFORM_OPTIONAL,
+                BundleIdArgument.IDENTIFIER_STRICT_MATCH)
     def list_bundle_ids(self,
                         bundle_id_identifier: Optional[str] = None,
                         bundle_id_name: Optional[str] = None,
                         platform: Optional[BundleIdPlatform] = None,
+                        bundle_id_identifier_strict_match: bool = False,
                         should_print: bool = True) -> List[BundleId]:
         """
         List Bundle IDs from Apple Developer portal matching given constraints
         """
 
         bundle_id_filter = self.api_client.bundle_ids.Filter(
-            identifier=bundle_id_identifier, name=bundle_id_name, platform=platform)
+            identifier=bundle_id_identifier,
+            name=bundle_id_name,
+            platform=platform,
+        )
         bundle_ids = self._list_resources(bundle_id_filter, self.api_client.bundle_ids, should_print)
+        if bundle_id_identifier_strict_match:
+            bundle_ids = [bid for bid in bundle_ids if bid.attributes.identifier == bundle_id_identifier]
 
         return bundle_ids
 
@@ -571,6 +578,7 @@ class AppStoreConnect(cli.CliApp):
                 CertificateArgument.PRIVATE_KEY_PASSWORD,
                 CertificateArgument.P12_CONTAINER_PASSWORD,
                 ProfileArgument.PROFILE_TYPE,
+                BundleIdArgument.IDENTIFIER_STRICT_MATCH,
                 CommonArgument.CREATE_RESOURCE)
     def fetch_signing_files(self,
                             bundle_id_identifier: str,
@@ -579,6 +587,7 @@ class AppStoreConnect(cli.CliApp):
                             p12_container_password: str = '',
                             platform: BundleIdPlatform = BundleIdPlatform.IOS,
                             profile_type: ProfileType = ProfileType.IOS_APP_DEVELOPMENT,
+                            bundle_id_identifier_strict_match: bool = False,
                             create_resource: bool = False) -> Tuple[List[Profile], List[SigningCertificate]]:
         """
         Fetch provisioning profiles and code signing certificates
@@ -589,7 +598,12 @@ class AppStoreConnect(cli.CliApp):
         if private_key is None:
             raise AppStoreConnectError(f'Cannot save {SigningCertificate.s} without private key')
 
-        bundle_ids = self._get_or_create_bundle_ids(bundle_id_identifier, platform, create_resource)
+        bundle_ids = self._get_or_create_bundle_ids(
+            bundle_id_identifier,
+            platform,
+            create_resource,
+            bundle_id_identifier_strict_match,
+        )
         certificates = self._get_or_create_certificates(
             profile_type, certificate_key, certificate_key_password, create_resource)
         profiles = self._get_or_create_profiles(bundle_ids, certificates, profile_type, create_resource, platform)
@@ -598,9 +612,17 @@ class AppStoreConnect(cli.CliApp):
         self._save_profiles(profiles)
         return profiles, certificates
 
-    def _get_or_create_bundle_ids(
-            self, bundle_id_identifier: str, platform: BundleIdPlatform, create_resource: bool) -> List[BundleId]:
-        bundle_ids = self.list_bundle_ids(bundle_id_identifier, platform=platform, should_print=False)
+    def _get_or_create_bundle_ids(self,
+                                  bundle_id_identifier: str,
+                                  platform: BundleIdPlatform,
+                                  create_resource: bool,
+                                  strict_match: bool) -> List[BundleId]:
+        bundle_ids = self.list_bundle_ids(
+            bundle_id_identifier,
+            platform=platform,
+            bundle_id_identifier_strict_match=strict_match,
+            should_print=False,
+        )
         if not bundle_ids:
             if not create_resource:
                 raise AppStoreConnectError(f'Did not find {BundleId.s} with identifier {bundle_id_identifier}')


### PR DESCRIPTION
**Closes #63**

Define new option `--strict-match-identifier` for `app-store-connect` actions `fetch-signing-files` and `list-bundle-ids` to include only those bundle IDs whose identifier strictly matches given input.

**Example usage:**

- Without strictly matching
```bash
> app-store-connect list-bundle-ids --bundle-id-identifier io.codemagic.banaan
Found 2 Bundle IDs matching specified filters: identifier=io.codemagic.banaan.
-- Bundle ID --
Id: NLRN94JD59
Type: bundleIds
Identifier: io.codemagic.banaan
Name: banaan
Platform: IOS
Seed id: X8NNQ9CYL2
-- Bundle ID --
Id: R4FZDMGMBR
Type: bundleIds
Identifier: io.codemagic.banaan.Clip
Name: io codemagic banaan Clip
Platform: UNIVERSAL
Seed id: X8NNQ9CYL2
```

- With strict modifier
```bash
> app-store-connect list-bundle-ids --bundle-id-identifier io.codemagic.banaan --strict-match-identifier
Found 1 Bundle ID matching specified filters: identifier=io.codemagic.banaan.
-- Bundle ID --
Id: NLRN94JD59
Type: bundleIds
Identifier: io.codemagic.banaan
Name: banaan
Platform: IOS
Seed id: X8NNQ9CYL2
```