### PR TITLE
Feature: Add option to filter builds with app-store-connect by platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.4
+-------------
+
+**Improvements**
+
+- Feature: Add option `--platform` to specify the platform for `app-store-connect` actions `get-latest-app-store-build-number` and `get-latest-testflight-build-number`.
+
 Version 0.5.3
 -------------
 

--- a/docs/app-store-connect/get-latest-app-store-build-number.md
+++ b/docs/app-store-connect/get-latest-app-store-build-number.md
@@ -15,6 +15,7 @@ app-store-connect get-latest-app-store-build-number [-h] [--log-stream STREAM] [
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--app-store-version APP_STORE_VERSION]
+    [--platform PLATFORM]
     APPLICATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `get-latest-app-store-build-number`
@@ -29,6 +30,10 @@ Application Apple ID. An automatically generated ID assigned to your app
 
 
 Version of the build published to App Store that identifies an iteration of the bundle. The string can only contain one to three groups of numeric characters (0-9) separated by period in the format [Major].[Minor].[Patch]. For example `3.2.46`
+##### `--platform=IOS | MAC_OS | TV_OS`
+
+
+Apple operating systems
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/get-latest-testflight-build-number.md
+++ b/docs/app-store-connect/get-latest-testflight-build-number.md
@@ -15,6 +15,7 @@ app-store-connect get-latest-testflight-build-number [-h] [--log-stream STREAM] 
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--pre-release-version PRE_RELEASE_VERSION]
+    [--platform PLATFORM]
     APPLICATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `get-latest-testflight-build-number`
@@ -29,6 +30,10 @@ Application Apple ID. An automatically generated ID assigned to your app
 
 
 Version of the build published to Testflight that identifies an iteration of the bundle. The string can only contain one to three groups of numeric characters (0-9) separated by period in the format [Major].[Minor].[Patch]. For example `3.2.46`
+##### `--platform=IOS | MAC_OS | TV_OS`
+
+
+Apple operating systems
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/versioning/app_store_versions.py
+++ b/src/codemagic/apple/app_store_connect/versioning/app_store_versions.py
@@ -8,6 +8,7 @@ from typing import TypeVar
 from codemagic.apple.app_store_connect.resource_manager import ResourceManager
 from codemagic.apple.resources import AppStoreVersion
 from codemagic.apple.resources import Build
+from codemagic.apple.resources import Platform
 from codemagic.apple.resources import Resource
 from codemagic.apple.resources import ResourceId
 
@@ -26,6 +27,7 @@ class AppStoreVersions(ResourceManager[AppStoreVersion]):
 
     @dataclass
     class Filter(ResourceManager.Filter):
+        platform: Optional[Platform] = None
         version_string: Optional[str] = None
 
     @classmethod

--- a/src/codemagic/apple/app_store_connect/versioning/pre_release_versions.py
+++ b/src/codemagic/apple/app_store_connect/versioning/pre_release_versions.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 from codemagic.apple.app_store_connect.resource_manager import ResourceManager
 from codemagic.apple.resources import Build
+from codemagic.apple.resources import Platform
 from codemagic.apple.resources import PreReleaseVersion
 from codemagic.apple.resources import Resource
 from codemagic.apple.resources import ResourceId
@@ -27,6 +28,7 @@ class PreReleaseVersions(ResourceManager[PreReleaseVersion]):
     @dataclass
     class Filter(ResourceManager.Filter):
         app: Optional[ResourceId] = None
+        platform: Optional[Platform] = None
         version: Optional[str] = None
 
     @classmethod

--- a/src/codemagic/apple/resources/app_store_version.py
+++ b/src/codemagic/apple/resources/app_store_version.py
@@ -42,7 +42,7 @@ class AppStoreVersion(Resource):
 
     @dataclass
     class Relationships(Resource.Relationships):
-        _OMIT_IF_NONE_KEYS = ('app',)
+        _OMIT_IF_NONE_KEYS = ('app', 'appVersionExperiments')
 
         ageRatingDeclaration: Relationship
         appStoreReviewDetail: Relationship
@@ -54,3 +54,4 @@ class AppStoreVersion(Resource):
         routingAppCoverage: Relationship
 
         app: Optional[Relationship] = None
+        appVersionExperiments: Optional[Relationship] = None

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -8,6 +8,7 @@ from codemagic.apple.resources import BuildProcessingState
 from codemagic.apple.resources import BundleIdPlatform
 from codemagic.apple.resources import CertificateType
 from codemagic.apple.resources import DeviceStatus
+from codemagic.apple.resources import Platform
 from codemagic.apple.resources import ProfileState
 from codemagic.apple.resources import ProfileType
 from codemagic.apple.resources import ResourceId
@@ -445,4 +446,14 @@ class CommonArgument(cli.Argument):
             f'for more information.'
         ),
         argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
+    PLATFORM = cli.ArgumentProperties(
+        key='platform',
+        flags=('--platform',),
+        type=Platform,
+        description='Apple operating systems',
+        argparse_kwargs={
+            'required': False,
+            'choices': list(Platform),
+        },
     )

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -26,6 +26,7 @@ from codemagic.apple.resources import BundleIdPlatform
 from codemagic.apple.resources import CertificateType
 from codemagic.apple.resources import Device
 from codemagic.apple.resources import DeviceStatus
+from codemagic.apple.resources import Platform
 from codemagic.apple.resources import Profile
 from codemagic.apple.resources import ProfileState
 from codemagic.apple.resources import ProfileType
@@ -210,16 +211,18 @@ class AppStoreConnect(cli.CliApp):
 
     @cli.action('get-latest-app-store-build-number',
                 BuildArgument.APPLICATION_ID_RESOURCE_ID,
-                AppStoreVersionArgument.APP_STORE_VERSION)
+                AppStoreVersionArgument.APP_STORE_VERSION,
+                CommonArgument.PLATFORM)
     def get_latest_app_store_build_number(self,
                                           application_id: ResourceId,
                                           app_store_version: Optional[str] = None,
+                                          platform: Optional[Platform] = None,
                                           should_print: bool = False) -> Optional[int]:
         """
         Get latest App Store build number for the given application
         """
         versions_client = self.api_client.app_store_versions
-        versions_filter = versions_client.Filter(version_string=app_store_version)
+        versions_filter = versions_client.Filter(version_string=app_store_version, platform=platform)
         try:
             _versions, builds = versions_client.list_with_include(
                 application_id, Build, resource_filter=versions_filter)
@@ -231,16 +234,18 @@ class AppStoreConnect(cli.CliApp):
 
     @cli.action('get-latest-testflight-build-number',
                 BuildArgument.APPLICATION_ID_RESOURCE_ID,
-                BuildArgument.PRE_RELEASE_VERSION)
+                BuildArgument.PRE_RELEASE_VERSION,
+                CommonArgument.PLATFORM)
     def get_latest_testflight_build_number(self,
                                            application_id: ResourceId,
                                            pre_release_version: Optional[str] = None,
+                                           platform: Optional[Platform] = None,
                                            should_print: bool = False) -> Optional[int]:
         """
         Get latest Testflight build number for the given application
         """
         versions_client = self.api_client.pre_release_versions
-        versions_filter = versions_client.Filter(app=application_id, version=pre_release_version)
+        versions_filter = versions_client.Filter(app=application_id, platform=platform, version=pre_release_version)
         try:
             _versions, builds = versions_client.list_with_include(Build, resource_filter=versions_filter)
         except AppStoreConnectApiError as api_error:


### PR DESCRIPTION
In case several projects (for iOS, macOS, tvOS) are under the same application ID, then `app-store-connect` actions
- `get-latest-testflight-build-number`
- `get-latest-app-store-build-number`
fail to deliver the the expected result as you could need macOS version, but are returned iOS version instead. 

To deal with this issue, add `--platform` option to those actions to specif for which platform you want to obtain the version for.