### PR TITLE
Fix macos profiles extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.5.5
 
 **Improvements**
 
-- Bugfix: export OSX related profiles with `.provisionprofile` extension instead of `.mobileprovision`.
+- Bugfix: export MacOS application's provisioning profiles with `.provisionprofile` extension instead of `.mobileprovision`.
 
 Version 0.5.4
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.5
+-------------
+
+**Improvements**
+
+- Bugfix: export OSX related profiles with `.provisionprofile` extension instead of `.mobileprovision`.
+
 Version 0.5.4
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -171,14 +171,15 @@ class ProfileType(_ResourceEnum):
     def is_development_type(self) -> bool:
         return self.value.endswith('_DEVELOPMENT')
 
+    @property
+    def is_macos_profile(self) -> bool:
+        return self.value.startswith('MAC_')
+
     def devices_not_allowed(self) -> bool:
         return not self.devices_allowed()
 
     def devices_allowed(self) -> bool:
         return self.is_development_type or self.is_ad_hoc_type
-
-    def is_macos_profile(self) -> bool:
-        return self.value.startswith('MAC_')
 
 
 class ReleaseType(_ResourceEnum):

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -177,6 +177,9 @@ class ProfileType(_ResourceEnum):
     def devices_allowed(self) -> bool:
         return self.is_development_type or self.is_ad_hoc_type
 
+    def is_macos_profile(self) -> bool:
+        return self.value.startswith('MAC_')
+
 
 class ReleaseType(_ResourceEnum):
     MANUAL = 'MANUAL'

--- a/src/codemagic/apple/resources/profile.py
+++ b/src/codemagic/apple/resources/profile.py
@@ -52,14 +52,7 @@ class Profile(Resource):
 
     @property
     def profile_extension(self) -> str:
-        if self.attributes.profileType in [
-            ProfileType.MAC_APP_DEVELOPMENT,
-            ProfileType.MAC_APP_DIRECT,
-            ProfileType.MAC_APP_STORE,
-            ProfileType.MAC_CATALYST_APP_DEVELOPMENT,
-            ProfileType.MAC_CATALYST_APP_DIRECT,
-            ProfileType.MAC_CATALYST_APP_STORE,
-        ]:
+        if self.attributes.profileType.is_macos_profile:
             return '.provisionprofile'
         return '.mobileprovision'
 

--- a/src/codemagic/apple/resources/profile.py
+++ b/src/codemagic/apple/resources/profile.py
@@ -51,5 +51,18 @@ class Profile(Resource):
         return f'{self.attributes.profileType} profile {self.attributes.uuid}'
 
     @property
+    def profile_extension(self) -> str:
+        if self.attributes.profileType in [
+            ProfileType.MAC_APP_DEVELOPMENT,
+            ProfileType.MAC_APP_DIRECT,
+            ProfileType.MAC_APP_STORE,
+            ProfileType.MAC_CATALYST_APP_DEVELOPMENT,
+            ProfileType.MAC_CATALYST_APP_DIRECT,
+            ProfileType.MAC_CATALYST_APP_STORE,
+        ]:
+            return '.provisionprofile'
+        return '.mobileprovision'
+
+    @property
     def profile_content(self) -> bytes:
         return b64decode(self.attributes.profileContent)

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -750,7 +750,8 @@ class AppStoreConnect(cli.CliApp):
         return pathlib.Path(tf.name)
 
     def _save_profile(self, profile: Profile) -> pathlib.Path:
-        profile_path = self._get_unique_path(f'{profile.get_display_info()}.mobileprovision', self.profiles_directory)
+        profile_path = self._get_unique_path(
+            f'{profile.get_display_info()}{profile.profile_extension}', self.profiles_directory)
         profile_path.write_bytes(profile.profile_content)
         self.printer.log_saved(profile, profile_path)
         return profile_path


### PR DESCRIPTION
macOS related profiles should be exported with `.provisionprofile` extension, not `.mobileprovision`.

When trying to use `.mobileprovision` profile on macOS the next error is encountered:

```
DVTProvisioningProfileManager: Failed to load profile "/Users/builder/Library/MobileDevice/Provisioning Profiles/6FE7F7F2-8D73-4800-9AC6-060836455F5D.mobileprovision" (Error Domain=DVTProvisioningProfileProviderErrorDomain Code=2 "Failed to load profile data." UserInfo={NSLocalizedDescription=Failed to load profile data., NSLocalizedRecoverySuggestion=Profile "macos desktop distribution" (07b29e64-4690-4180-aecd-777cdeaa49db) has unsupported platforms "macOS". Profiles with the "mobileprovision" file extension should have one of "tvOS", "watchOS", or "iOS".})
```

Example of usage (correct profile extension is used):

```bash
> app-store-connect fetch-signing-files "io.codemagic.macosDesktop" --platform MAC_OS --type MAC_APP_STORE
Found 1 Bundle ID matching specified filters: identifier=io.codemagic.macosDesktop, platform=MAC_OS.
Found 2 Signing Certificates matching specified filters: certificateType=MAC_APP_DISTRIBUTION.
Filtered out 1 Signing Certificate for given private key
Get Profiles for Bundle ID BD6WV4X4RK
Found 1 Profile for Bundle ID matching specified filters: profileState=ACTIVE, profileType=MAC_APP_STORE.
Filtered out 1 Profile that contain certificate(s) NEVERCODE LTD [12FFF6D43D46E2FD4B56F79AA964CEBA]
MAC verified OK
Saved Signing Certificate MAC_APP_DISTRIBUTION certificate 12FFF6D43D46E2FD4B56F79AA964CEBA to /Users/stas/Library/MobileDevice/Certificates/MAC_APP_DISTRIBUTION_certificate_12FFF6D43D46E2FD4B56F79AA964CEBA_sp_f2bum.p12
Saved Profile MAC_APP_STORE profile 18d7434f-07d2-4204-a7b6-dce865fcf298 to '/Users/stas/Library/MobileDevice/Provisioning Profiles/MAC_APP_STORE_profile_18d7434f_07d2_4204_a7b6_dce865fcf298_6fcowp90.provisionprofile'
```