### PR TITLE
Macos signing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ Version 0.5.7
 
 **Improvements**
 
-- Bugfix: list MacOS application's codesigning certificates as well in `keychain list-certificates`.
-- Bugfix: in `xcode-project use-profiles` search for provision profiles with `.provisionprofile` extension as well.
-- Bugfix: handle provisioning profiles entitlements keys with prefixes e.g. `com.apple.application-identifier`
-- Bugfix: do not default to iphoneos sdk when setting code signing information
+- Bugfix: Include MacOS application's codesigning certificates in `keychain list-certificates` output.
+- Bugfix: Include provisioning profiles with `.provisionprofile` extension in in `xcode-project use-profiles` search.
+- Bugfix: handle provisioning profiles entitlements keys with prefixes e.g. `com.apple.application-identifier`.
+- Bugfix: Improve SDK detection when setting code signing infortmation on Xcode projects instead of always defaulting to `iphoneos` .
 
 Version 0.5.6
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.5.6
 
 **Improvements**
 
-- Bugfix: list MacOS application's codesigning certificates as well.
+- Bugfix: list MacOS application's codesigning certificates as well in `keychain list-certificates`.
 
 Version 0.5.5
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.6
+-------------
+
+**Improvements**
+
+- Bugfix: list MacOS application's codesigning certificates as well.
+
 Version 0.5.5
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.5.6
+Version 0.5.7
 -------------
 
 **Improvements**
@@ -7,6 +7,13 @@ Version 0.5.6
 - Bugfix: in `xcode-project use-profiles` search for provision profiles with `.provisionprofile` extension as well.
 - Bugfix: handle provisioning profiles entitlements keys with prefixes e.g. `com.apple.application-identifier`
 - Bugfix: do not default to iphoneos sdk when setting code signing information
+
+Version 0.5.6
+-------------
+
+**Improvements**
+
+- CI pipeline: Use GitHub CLI tools for releases
 
 Version 0.5.5
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Version 0.5.6
 **Improvements**
 
 - Bugfix: list MacOS application's codesigning certificates as well in `keychain list-certificates`.
+- Bugfix: in `xcode-project use-profiles` search for provision profiles with `.provisionprofile` extension as well.
+- Bugfix: handle provisioning profiles entitlements keys with prefixes e.g. `com.apple.application-identifier`
+- Bugfix: do not default to iphoneos sdk when setting code signing information
 
 Version 0.5.5
 -------------

--- a/bin/code_signing_manager.rb
+++ b/bin/code_signing_manager.rb
@@ -424,15 +424,11 @@ class CodeSigningManager
     build_configuration.build_settings["CODE_SIGN_STYLE"] = "Manual"
     build_configuration.build_settings["PROVISIONING_PROFILE_SPECIFIER"] = profile['name']
 
-    is_code_signing_identity_set = false
+    build_configuration.build_settings["CODE_SIGN_IDENTITY"] = profile["certificate_common_name"]
     build_configuration.build_settings.each do |build_setting, _value|
       if build_setting.start_with? "CODE_SIGN_IDENTITY[sdk="
         build_configuration.build_settings[build_setting] = profile["certificate_common_name"]
-        is_code_signing_identity_set = true
       end
-    end
-    unless is_code_signing_identity_set
-      build_configuration.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = profile["certificate_common_name"]
     end
   end
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2,36 +2,24 @@ workflows:
   release:
     environment:
       vars:
-        GH_USER: priitlatt
-        GH_PAT: Encrypted(Z0FBQUFBQmZSUTdyUkh3cW83TVRjMUZ6a3pndFR5SWJnUHR2YlpPYlNLamxaY0xLenluQks5aVdlUVNaRktDN0J5NnE1Yk5KZ2ExaC1OQ1R3SXdxQmdaTTVHQ3d4ZVhYdVNNMEw4dURQcGZacy1mR1BGOXZlRm1YZFUwM2Q1cnptYTkzbEl0eVhOb3g=)
+        GITHUB_TOKEN: Encrypted(Z0FBQUFBQmdkQXVZLUN0STF4WlBpMEFmc2V5Z2FmMi00bWtUeUFMREJxejNpaW85c3FwcWZsaU51a3BYWlcyc3FPbTlLM2dZeXgzdHY1VnRlX0RVZERmQlhiSlhzQ055YVgwV1R3MXV5N1dobHY5UnhkeHhadWw4cjFsUkNXTUxuTHlxWkduU3JEOHE=)
         GOOGLE_CLIENT_SECRET: Encrypted(Z0FBQUFBQmQzbWh3dHNnNU5PV3g4SXpLaXhMbENiVkZKSXk1YVl4YmRPLTZoU29DMmU2NGJNNHpjQWthSTFjTWR4a091Q2FWQlpfMGw5emcxZkM3eUtQSW9QckpwWjl1cWItanJub2FFVWU5VXdTeS12VjNzLTZzamk3cE5PbWhma1J0d2dHaGduQ0JKeHVyVXN0TkkyNlVFOGFVQ3dBakRKMkN2T2Rva3BFUHM1cER5UTFGUzJtNGVRS3d0VFAyMkRyUjRLUkpRbXA4Y2VGdE82aWk4VlR0aXVicDQyU0ZrbmdKRzNkNWd1UGgwQ0lBbUt1Q19PRXZyZzF6Q3hQb2Vyd045aTM0R1BacTFDVmFkODRiSU5wbDNrVHZDaDNWYS1EOTF3QW5XNHdENjh2anNrWXdvbU1ZdFdmeFhWQlJWMVBXdzRVd0hsLVRKc0xIYmhLMEVjQlVZSV9kQTVmelI0SzRJbGZYMnk0R19UcmRPX0M5ZHJvcXd0X3UzNzJxTkhuUGFFTzNXNmhVUVluR3JzZ29PbzZvUzBzQ1ZJc3Z4STVDSnA4SkI4RHJXa2o3VEM2TUdvWFB6Y2VLUGM3SENDaVFvNFM0ZkpLTU1Nb0Z3NEJvWmpaNTRoeWQ2LUN4d2NnaENYaWNLaHZYTlBubEdPN1F6VzQ1WXQ2RXd0QXlZVE4wdVpXdkowWWExQm5rR2pCZ2tlQlVUSmQzdTg1WndzMmxpdnN1MkhNbFN2ZGhmeUNFUlJLZmNMRmhzYXFQTFJPTTVtTURxaDF1Qjh1SHVuajA5SnZTYVJGS2VFTFdKLU1HQ0hPMFU0TTJTWHhRRmJqemlOc0pyS0Zad1VnM2lvV1UtQVFBLWFpVWpkbm1RRm5jSGpqM3lhcUxNejZlUGRpc0lCVUk0eWc3RzFWZG1JMXJ6R0R6aTNnSnYtT0daNUl3QjNKVzhiRXJsVXdOMmY0NVM1N0U0YjAxeEJwa09xdnlwaWpPYmdreVBCX05lRVF4T0dkUktSWXU5TmFsdVF6RTlyZ2FkQWZrUDN0aHNUeTA5R0VRd1RqejBLdVNucXFkdTY2d2dpRWJUeW1FcDBnbFdXalMyeVY4RktubWZwRHF5YlU2SUVwampNRUNXYWwxcGwySDBXeDhkZzJQTWxMNzR5eHZBcm1vNndDZTQxMmpZUER6Qk5jWWtGTW5aNUVyZFdQS1V2MG5CQmVUMmJDc0NsSmNKOWotSUM5M3psSFlmNjJLeTFnNHIxRDNUR0JldjJHbmVLZjVpSWNfYkJxUFB1czlmcnNqMG1EVG5wMXRVaTdyc1RVdjV4U0NvUWJCZnlZQ1A4R2JaYllmVWZNUXE5YnM2NElvSjk2TlZ1bnBWTWE1VmdKT1NLa0FSLVRfNzQ0ZVJqcm9NamhRU0lhanpPUEMzaVdheVZfZWtvREdDM3pnRlBvOVMwLXBodG9GeVJYVkVRYl9ULVJ1N1dqRnBMUldCcTFfWE81OTZtVFg4R09QY2VWTEM3SS16Z2lhMHZ6ZG1NMkpta0h5ODZjYXI2ejJoT1RlV2g1V2NaZVJjMGZaei0xVHNqMm8tYUMwYmltNHdsSndia3dlOU9TYXd0LXBDd29XcE5KNERudHJWbE1fbHlqbVc2LXB3N25HaUNBQU1QdjduTGRQTU10ZS1BZkRnMENodk9GMkFuZWw5dGQzRmVFOWx0UzNZTmRLbjRLdEFFNlE4dGExcEIxMmRVZ1RsVHJIQ0lZbFFzWWhHVy1PSG91UklVa3JBeFpDSDJwZHUtWk5BQnY5TDNMTDBSNm9lejRrRFZxY29ueUhEQUJNVmF6Zll1bWVzVmlRNnFwZ21aa2tXMTNfWE1uQkZYU3FycE9Fa0Z4OV9tSXVZbWFIY3VyUjBFWGdRMFB0UG90WHlIWHZILW5kcF9rVDVQNDZScWEwbkZPYVVNbWhCWG93VjVNX0tTcGVkU0hlSE9mMFlMNm95YTVoQkFsdTBSSWEzTHZRbnJfNVR6YmJXRXdGSnEtMlAwc1ZsTnJ4QlFpZ3hsOWFqaG9KSngzX240eVI5aWxSYlFMSmM5X0JCN2xqTk9sNV9jMGN3RU1GRVFINU9VenVyWXB3TzZCb1ZDdkZhemFXWldmN1BobGpsaU1kcjNQQTVMdk4yOGZXSkRmdHdQOU9NaGlQdnB6UlYxeW9hekFkLTE5dnNUd1Q2S09Eb0JSQlV2c2oxemNTMHNiQ1V2NG14aWh4LWZxa2FVTGw3WFY2dl8yWTc4Q0dhUUFTQ2NXRDkzR3BfUy1OTE1XcTVYRzRTRk00T1pzcDliVmFBQ0dHb3YwQ19CdUtzYnd6ZTUxV3FKaHc0am9yZTFFOWNVdEVvbkJzSDhkYWxLTzMzdzNmNFo5dzdxRmJUc3pRdWtSWk8zTklYazYwZVdVU05YOFZUYl9MMTRFT3g5S0QtalZiYUdLeWh4ODBCa0xHcmVjc3ZxYngwRmxwNlE5WmdpRHM2ZjQ2RVhlYkp6VUluYnBrSEp0NW5RUTZMbDlic2NQN05CSDVlaEw0SzdiR1JnQVhHbkhzT0d3LU9sbV95ZEdIbklWT3hUOUlnWGkzdUhOTnI4aWVJT2twYWZvbXVqZTEwZlFkV2VIdlp3VEZObDUtcS03emd3OG5wM2RLbllYVXd5Rk5yRExzdHZtNGxFd0hGYXhRMVN3Yk4ycEVsc3VNUG52aGN6d1l0ekc4YXBSUGJOT0hnN2dzeUlxaHFyazhHMVIyQWpWdG9DN3ZSTWg0dDdjNG1qUERfUk9tTHpHdWlsaTZraDhxQVJhb051a1ROSjYyWTRSRkVGMktGRDFacVNfSDljYXVnZ3ZsSzVRb1RESk50QnRJWEVvQjF3TC1naWdILVdORmpnVlJSaTRIOFRacGtzeXJEbGVwcnJGODNJLXlvV3l3ZnlNYmdsNDFONlpvcFNUVjdpRmdyYnVhRkVKWTZVQUxob1ZDYk1WdzZ3aVdTMUZCaTZTSURtLTJLYWhnbVozUnk0WXdqTlRqWnp0bjFpMFE5UGQ3V0d3TDkzOGJYaGlScC1vaExVVkloRTdKM3lCdU9NS09tRVBxVUN3ei04MmNsRTlpUDMzdURwMVdfUE1Fdmo1Q1dCTGp4dkNnOVJYVEY4MVBZbHdHVWxUQTZPaTBKYlA4cTlOc2EyV0pJcmZQX0hiblZfSkdRT1NFSzRNN3VWeHFEWmZqTjlLd0pCdTY3SHR6LU94Tml5V2RnekFUbmQtUFotcXFwc1RuMGFaQ0liQl9aWnd2QXJ4YVhLSHExdmVhenNOTVNqMDFYalo2cmJLOVBQYWNFcG5MbGNpTzk1LWtSSWNxYTlwQzJFdktuRDNjekxRaTV6SFdRSDhBU3NlV1cxc3VmeVFVNkU5azJwSU5uSTdXR0Z1MkM5eFg4R2ZrRGJmN2dXcEJUeXhCYkJIM2hCcTRzaUhsTlVwR2Q0bFN2Ml9QRlNmanRVa08wTjN3WUFtc29BWlpvRldjM3JrNHdlV3JrR1RwU3JQZWtHWjR6aTZENldQLTBSQVVVSjBteVJzMmxpUS1NOF92ZVFBeFNoZ2t4aDJONHJ2QkFGek11LUdxYUt3aHg0VHkyTE9MX3dTNTZvSWVmeTA5MDVFcUltb0VWeUtuUTZiV3ZtdG5xOFNHcjlPenR1MGFDWHBiOGlha2JQeTFDQzRWQ2tCVnFwYzNuY0pUbGNRbGtKdFo1Tjl1ZHRvR2RJOHFCU1Z1UUhWbmRLWFlEVHNibzc1S0FxLWpKS2FZaVllVkVLOGJwNnNWbGs5d2ZvbWl0aFdxSjE2VlBxNFJLc24xejR3WHFNUVB1TTM1SjRRUVU2YmlHT1RuWHJpZGd4YV9xNFBKM1hTdGM3WFRKWFcwNVBrSFk3cHc5d1NHbzlYeFo0WDMza244N1psWm9mbEpROC1zbW50MllxLVN5R1BIemh2dGh0NUpSRmp0bHRvdnlRcWdKWWlOWjBmdnE1NlJpUmM4am91bHFTNmdwNEkzOXhEMUtSWk9ILVNOLWJxWDF0XzdNY0JWUzdwZF9kc0tMMHN1ZE0zck5FbnA1dGV4dVA0RnBLYWY4UFdtQndndkh1V3NTMVMxU1pRNW15VWNCZFJXYkdBQk96czVpMDM0WjUwVVczTzBhaXNSUUJvTEhvMTFaUndlTmJjZ05waWxtUzJzZ1hnQ1BMR1NKLWxBcmgwei1OcHpzOERodks2WDdaYWVOc1ZGLUIteWJfRFFDZUtRMWx3d2xRTF9RTlNmOUxIZVk4ZWlaRmdhT0JhYmIyWndxVVl2VmUyTXJjbXJYWTN4TUNOVWRhbzIxc3pDeUF4T1dKLU9UUjl3V1praG5lNkhYZGctZnB4MTNOa1FTUXBWLTRSWTRueFNlN3d0RG4zc3lOUTdJOEo3eGotdDBOdlhDdEN1MGpmTnU4azVibE5EcUxOMExUQkQzMExfdk1mMVpoU1FfSm1zXzRsd0QtdEpWazFEV0xMN3dzMHpMYjRWc0xpNlpsYTV3Si1CdWJNWng1NkVUbEZPeENLZE5wM29XR0k4clVtN0VNLW9OTW9ZMlQxbGxuOW5HNUxzdHU3WkZkRDRXMTAxaGFsNHY5WjhMd3pkU2ttUjZrRGZWa1VWNEpudGI3YWhXcWxpSnYyZG1PRjJzR2FhNWNJSE1NT0lyWWlqRFcwbUE1aDJGbkhKakRyY3JHbzBuY1NOQ1FWVGZaS0ZEemFrUzFpb2toM1ZrVm50Ul9PUkgxMEhmSEttSDdSQ0xKV2NNbVN1cnp1X0lfNGFvZkViUGF6MjQzU1VaTGZ3TTZ3M0RNZThZMjRabXduN1JrUVZmeGMxYkswM1NmWXZHcjNKUkxHWTE4V0s2ekNxM1J2dTctajdWVmJMV1J6M0dqLWlnT25pc1RCaktnX1ZBaF9aTnhMTG5aOERiNnUyWXBkZXlleGN6VTI3NHhCOFpqUk9ValFSQ0N0d1l3LWpJVGtfLUpieUJJUTJ0QVpyQkduZWNzSl8wZ0xyRGRpWEFjOURaVmswd040SnFRYkZaSzQ2am9IVC1rQmh5ZXFBbTVYVmtfQS1aU1h2Mm51VjJJNFVkODRmd09XMzBnVGJqamluN3V4X1BfUFU4dlZ0SDV4QTRPSTVsdkJDb2VDRGpmdUMtWFVsQXFadnlZc204T2gtNFFVMVI3aW16MzhuVjJuVTR1ekVYN3pOaDNkVUJYLWMwelNlbnBhdzlaRGZiS3BuSTVlVEFJUXVlRUlFNGNwaFpwMFVjUzJwSnE0ZmFpckVDTkllb01fQWMyQVpoZXVueDRHMkhJbUhqNWMtY2dpU0xWSkhJUm14UGVuRDRsdnN4SWdldV9hRzhlQ0tCam1SUGN4a1Z4U0JLYkJjamoxVER3QXlFZmZac3V2SDUyanUxdFB3dWQyREtUOWNITnRLbUVUVHQ1UmVCWDY5TXl6WFRrNy1KX2xNOUFSVEpNRUIxVk54MW5xQ1hCSVFCS3NDVnlTVFZUQjlKekxRaFRZbnpNRWJHSjZEVXE1WTFyZXZwM0NRQW9lM1lpU0VXelNnX0N5U2p2QnhnUFBuWGVCZjBmTkxTalB5cldOQWNBZ0dTcGRveGpHQ1g0a3c4VGoxX3l3UDBzVjNBcjRkRHFjcTZPelRsN21kNUlSMk02b2NvUT09)
-        REPOSITORY: codemagic-ci-cd/cli-tools
         PYPI_USER: __token__
         PYPI_TOKEN: Encrypted(Z0FBQUFBQmU2TTJqVVYxSy04cm1qOGJzUWhtekNRQ3lGNjdYUTFiUGwybHc2RENLVFo0SDVTVUhyR1JrMkMxckV3QnpFWWxWa0pZVXFsM29aM2djRThUYUlWMlNBMjdWaHQzSm16UjlTSVRocXpWenBhZ20tTjhPU1dZWFNwOHFEWUR3X2pBdC10eGV5cXNvSkpRV2djQncyMWgwdEZzMlhQRC1kcEw5VThTSTcxWUhKQnFrMU5Fc3gtQ29WSDhORHpyMmI1ODh0cFhwMXBhcGRpWDR2b0Q3ZFhBdVFQWlBKSjFxekloUERBV2g2S2piejhubWN5Y3VsOUdhai1xZXlvcWxsbHVSU1dOQ2hmak9jc0pGOXpBN1FYZ01HUzl6U3RTd2dwU1h4NXJBQzY1MmszeXlZS1NoNDhZNEdkMVZlTkZqQVVzRWVoSGRsLXhoRXZYMXd5V1B1U1h1UUdPNzRKcnh6REVxWVBtOVkwbXdJS3QxU1E4PQ==)
     name: Generate binary distribution wheel
     scripts:
-      - name: Tag version
-        script: git tag -a v$(python3 setup.py --version) -m "Release v$(python3 setup.py --version)"
       - name: Build wheel
         script: python3 setup.py sdist bdist_wheel
-      - name: Push tag
-        script: git push "https://$GH_USER:$GH_PAT@github.com/$REPOSITORY" --tags
-      - name: Prepare release metadata
+      - name: Draft GitHub release
         script: |
           TAG_NAME=v$(python3 setup.py --version)
           previous_version_line=$(grep -n "^Version " CHANGELOG.md | head -2 | tail -1 | cut -f1 -d:)
-          head -n "$(($previous_version_line - 1))" CHANGELOG.md | tail +3 > release_notes.txt
-          python3 -c "import json; json.dump({'tag_name': '$TAG_NAME', 'name': '$TAG_NAME', 'body': open('release_notes.txt').read().strip(), 'draft': True, 'prerelease': True}, open('release_payload.json', 'w'))"
-      - name: Draft a release
-        script: |
-          set -e
-
-          curl -u "$GH_USER":"$GH_PAT" --silent --fail -H 'Content-Type: application/json' -X POST --data "@release_payload.json" "https://api.github.com/repos/${REPOSITORY}/releases" > release_response.json
-          EDIT_URL=$(python3 -c "import json; print(json.load(open('release_response.json')).get('html_url').replace('/tag/', '/edit/'))")
-          FILE_NAME=$(cd dist && ls *.whl | tail -n1)
-          UPLOAD_URL=$(python3 -c "import json; print(json.load(open('release_response.json')).get('upload_url').replace('{?name,label}', '?name=$FILE_NAME'))")
-          curl -u "$GH_USER":"$GH_PAT" --silent --fail -H 'Content-Type: application/x-wheel+zip' -X POST "$UPLOAD_URL" --data-binary "@dist/$FILE_NAME" > /dev/null
-          echo "Draft release created. Finalize it at $EDIT_URL"
+          head -n "$(($previous_version_line - 1))" CHANGELOG.md | tail +3 > release_notes.md
+          gh release create "${TAG_NAME}" \
+              --title "${TAG_NAME}" \
+              --notes-file release_notes.md \
+              --draft \
+              dist/codemagic*.whl
       - name: Upload wheel
         script: |
           set -e
@@ -48,5 +36,5 @@ workflows:
           python3 -m pip install --user --upgrade twine
           python3 -m twine upload dist/* --username $PYPI_USER --password $PYPI_TOKEN
     artifacts:
-      - dist/codemagic-*.whl
-      - dist/codemagic-*.tar.gz
+      - dist/codemagic*.whl
+      - dist/codemagic*.tar.gz

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -101,8 +101,15 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
         return development_certificate_pattern.match(self.common_name) is not None
 
     def is_code_signing_certificate(self) -> bool:
-        code_signing_certificate_pattern = re.compile(
-            r'^((Apple (Development|Distribution))|(iPhone (Developer|Distribution))):.*$')
+        code_signing_certificate_pattern = re.compile((
+            r'^('
+            r'(Apple (Development|Distribution))|'
+            r'(iPhone (Developer|Distribution))|'
+            r'(Developer ID Application)|'
+            r'(Mac Developer)|'
+            r'(3rd Party Mac Developer (Application|Installer))'
+            r'):.*$'))
+
         return code_signing_certificate_pattern.match(self.common_name) is not None
 
     def dict(self) -> Dict[str, Union[str, int, Dict[str, str], List[str]]]:

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -101,16 +101,14 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
         return development_certificate_pattern.match(self.common_name) is not None
 
     def is_code_signing_certificate(self) -> bool:
-        code_signing_certificate_pattern = re.compile((
-            r'^('
-            r'(Apple (Development|Distribution))|'
-            r'(iPhone (Developer|Distribution))|'
-            r'(Developer ID Application)|'
-            r'(Mac Developer)|'
-            r'(3rd Party Mac Developer (Application|Installer))'
-            r'):.*$'))
-
-        return code_signing_certificate_pattern.match(self.common_name) is not None
+        code_signing_certificate_patterns = (
+            re.compile(r'^Apple (Development|Distribution):.*$'),
+            re.compile(r'^iPhone (Developer|Distribution):.*$'),
+            re.compile(r'^Developer ID Application:.*$'),
+            re.compile(r'^Mac Developer:.*$'),
+            re.compile(r'^3rd Party Mac Developer (Application|Installer):.*$'),
+        )
+        return any(p.match(self.common_name) is not None for p in code_signing_certificate_patterns)
 
     def dict(self) -> Dict[str, Union[str, int, Dict[str, str], List[str]]]:
         return {

--- a/src/codemagic/models/provisioning_profile.py
+++ b/src/codemagic/models/provisioning_profile.py
@@ -79,7 +79,8 @@ class ProvisioningProfile(JsonSerializable, RunningCliAppMixin, StringConverterM
 
     @property
     def has_beta_entitlements(self) -> bool:
-        return self._plist.get('Entitlements', dict()).get('beta-reports-active', False)
+        entitlements = self._plist.get('Entitlements', dict())
+        return next((entitlements[key] for key in entitlements.keys() if 'beta-reports-active' in key), False)
 
     @property
     def provisioned_devices(self) -> List[str]:
@@ -91,7 +92,8 @@ class ProvisioningProfile(JsonSerializable, RunningCliAppMixin, StringConverterM
 
     @property
     def application_identifier(self) -> str:
-        return self._plist.get('Entitlements', dict()).get('application-identifier', '')
+        entitlements = self._plist.get('Entitlements', dict())
+        return next((entitlements[key] for key in entitlements.keys() if 'application-identifier' in key), '')
 
     @property
     def is_wildcard(self) -> bool:

--- a/src/codemagic/models/provisioning_profile.py
+++ b/src/codemagic/models/provisioning_profile.py
@@ -80,7 +80,10 @@ class ProvisioningProfile(JsonSerializable, RunningCliAppMixin, StringConverterM
     @property
     def has_beta_entitlements(self) -> bool:
         entitlements = self._plist.get('Entitlements', dict())
-        return next((entitlements[key] for key in entitlements.keys() if 'beta-reports-active' in key), False)
+        for key, value in entitlements.items():
+            if 'beta-reports-active' in key:
+                return value
+        return False
 
     @property
     def provisioned_devices(self) -> List[str]:
@@ -93,7 +96,10 @@ class ProvisioningProfile(JsonSerializable, RunningCliAppMixin, StringConverterM
     @property
     def application_identifier(self) -> str:
         entitlements = self._plist.get('Entitlements', dict())
-        return next((entitlements[key] for key in entitlements.keys() if 'application-identifier' in key), '')
+        for key, value in entitlements.items():
+            if 'application-identifier' in key:
+                return value
+        return ''
 
     @property
     def is_wildcard(self) -> bool:

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -80,7 +80,10 @@ class XcodeProjectArgument(cli.Argument):
             'required': False,
             'nargs': '+',
             'metavar': 'profile-path',
-            'default': (ProvisioningProfile.DEFAULT_LOCATION / '*.mobileprovision',),
+            'default': (
+                ProvisioningProfile.DEFAULT_LOCATION / '*.mobileprovision',
+                ProvisioningProfile.DEFAULT_LOCATION / '*.provisionprofile',
+            ),
         },
     )
     WARN_ONLY = cli.ArgumentProperties(

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -120,7 +120,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
 
         code_signing_settings_manager.notify_profile_usage()
         export_options = code_signing_settings_manager.generate_export_options(custom_export_options)
-        export_options.notify(Colors.GREEN('Generated options for exporting IPA'))
+        export_options.notify(Colors.GREEN('Generated options for exporting the project'))
         export_options.save(export_options_plist)
 
         self.logger.info(Colors.GREEN(f'Saved export options to {export_options_plist}'))


### PR DESCRIPTION
Changes required to be able to sign macOS apps:

1) list MacOS application's codesigning certificates as well in `keychain list-certificates`.
Mainly need to be used inside `xcode-project use-profiles`. So include `Developer ID`, `Mac Developer` and `3rd party Mac Developer Application/Installer` certificates.

2) in `xcode-project use-profiles` search for provision profiles with `.provisionprofile` extension as well.
add a second default path.

3) handle provisioning profiles entitlements keys with prefixes e.g. `com.apple.application-identifier`
macos profiles contain entitlements with `com.apple` prefix, need to handle it. Not sure it's the case with `beta-reports-active` as I didn't see it, but let's just have it.

```bash
	<key>Entitlements</key>
	<dict>
		<key>com.apple.developer.game-center</key>
		<true/>
		<key>com.apple.application-identifier</key>
		<string>X8NNQ9CYL2.io.codemagic.macosDesktop</string>
		...
```

4) do not default to iphoneos sdk when setting code signing information
The previous approach was to set all the specified as `CODE_SIGN_IDENTITY[sdk=...` platforms to the provided certificate, if no such then to set `CODE_SIGN_IDENTITY[sdk=iphoneos*]`.
This doesn't allow to use the certificate on other platforms. So the best way is to set default one (without specifying sdk).

