### PR TITLE
Fix google failure failure when no release name provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.8
+-------------
+
+**Improvements**
+
+- Bugfix: Allow Google Play releases with no name provided in `google-play` tool.
+
 Version 0.5.7
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.7'
+__version__ = '0.5.8'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -33,10 +33,17 @@ class CountryTargeting(Resource):
 
 @dataclass
 class Release(Resource):
-    _OMIT_IF_NONE_KEYS = ('userFraction', 'countryTargeting', 'inAppUpdatePriority', 'versionCodes', 'releaseNotes')
+    _OMIT_IF_NONE_KEYS = (
+        'name',
+        'userFraction',
+        'countryTargeting',
+        'inAppUpdatePriority',
+        'versionCodes',
+        'releaseNotes',
+    )
 
-    name: str
     status: ReleaseStatus
+    name: str = None
     userFraction: Optional[float] = None
     countryTargeting: Optional[CountryTargeting] = None
     inAppUpdatePriority: Optional[int] = None

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -43,7 +43,7 @@ class Release(Resource):
     )
 
     status: ReleaseStatus
-    name: str = None
+    name: Optional[str] = None
     userFraction: Optional[float] = None
     countryTargeting: Optional[CountryTargeting] = None
     inAppUpdatePriority: Optional[int] = None

--- a/tests/google_play/resources/test_resource_print.py
+++ b/tests/google_play/resources/test_resource_print.py
@@ -10,14 +10,14 @@ def test_track_string(api_track):
     expected_output = dedent("""
         Track: internal
         Releases: [
-            Name: 29 (1.0.29)
             Status: draft
+            Name: 29 (1.0.29)
             Version codes: [
                 29
             ]
 
-            Name: trying2
             Status: completed
+            Name: trying2
             Version codes: [
                 26
             ]


### PR DESCRIPTION
A draft release without name set and without uploaded binaries won't have name. So need to set `name` as an optional field.

Tested, it's fine.
```bash
> google-play get-latest-build-number --package-name <app_id> -v --log-api-calls --json
[14:47:30] INFO  > Create an edit for the package "<app_id>"
[14:47:31] INFO  > {
    "id": "13756145079442875546",
    "expiryTimeSeconds": "1619099251"
}
[14:47:31] INFO  > Get information about the track "internal" for the package "<app_id>"
[14:47:32] INFO  > {
    "track": "internal",
    "releases": [
        {
            "status": "draft"
        },
        {
            "status": "completed",
            "name": "201 (1.9.1)",
            "versionCodes": [
                "201"
            ],
            "releaseNotes": [
                {
                    "language": "en-US",
                    "text": "<app_id>"
                }
            ]
        }
    ]
}
[14:47:32] INFO  > Latest version code for internal track: 201
[14:47:32] INFO  > Get information about the track "alpha" for the package "<app_id>"
[14:47:32] INFO  > {
...
```