### PR TITLE
Bugfix: Include 'SERVICES' to BundleIdPlatform enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.5.9
+-------------
+
+**Improvements**
+
+- Bugfix: Accept `SERVICES` as a valid [Bundle Identifier platform](https://developer.apple.com/documentation/appstoreconnectapi/bundleidplatform).
+
 Version 0.5.8
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.8'
+__version__ = '0.5.9'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -41,6 +41,7 @@ class BundleIdPlatform(_ResourceEnum):
     IOS = 'IOS'
     MAC_OS = 'MAC_OS'
     UNIVERSAL = 'UNIVERSAL'
+    SERVICES = 'SERVICES'
 
 
 class CapabilityOptionKey(_ResourceEnum):


### PR DESCRIPTION
Responses to `GET https://api.appstoreconnect.apple.com/v1/bundleIds` include Bundle Identifiers whose platform is `SERVICES`:

```
{
    "type": "bundleIds",
    "id": "...",
    "attributes": {
        "name": "Sign in with Apple",
        "identifier": "...",
        "platform": "SERVICES",
        "seedId": "..."
    },
    "relationships": {
        ...
    },
    "links": {
        ...
    }
}
```

Such a value causes `ValueError` on model initializations:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/bundle_ids.py", line 104, in list
    return [bundle_id for bundle_id in bundle_ids if resource_filter.matches(bundle_id)]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/bundle_ids.py", line 104, in <listcomp>
    return [bundle_id for bundle_id in bundle_ids if resource_filter.matches(bundle_id)]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/bundle_ids.py", line 103, in <genexpr>
    bundle_ids = (BundleId(bundle_id) for bundle_id in self.client.paginate(url, params=params))
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 185, in __init__
    self.attributes = self._create_attributes(api_response)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 175, in _create_attributes
    return cls.Attributes(**api_response['attributes'])
  File "<string>", line 7, in __init__
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/bundle_id.py", line 24, in __post_init__
    self.platform = BundleIdPlatform(self.platform)
  File "/usr/local/lib/python3.8/enum.py", line 339, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.8/enum.py", line 663, in __new__
    raise ve_exc
ValueError: 'SERVICES' is not a valid BundleIdPlatform
```