### PR TITLE
Feature: add new action `app-store-connect get-profile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
+Version 0.6.0
+-------------
+
+**New features**
+
+- Add action `get-profile` to `app-store-connect` to show provisioning profile based on resource identifier.
+
+**Development / Docs**
+
+- Add documentation for new action `app-store-connect get-profile`.
+- Add `SERVICES` as valid value to `--platform` option in `app-store-connect` actions. 
+- Update `--profile` option default values for action `xcode-project use-profiles`.
+
 Version 0.5.9
 -------------
 
-**Improvements**
+**Fixes**
 
-- Bugfix: Accept `SERVICES` as a valid [Bundle Identifier platform](https://developer.apple.com/documentation/appstoreconnectapi/bundleidplatform).
+- Accept `SERVICES` as a valid [Bundle Identifier platform](https://developer.apple.com/documentation/appstoreconnectapi/bundleidplatform).
 
 Version 0.5.8
 -------------

--- a/docs/app-store-connect/create-bundle-id.md
+++ b/docs/app-store-connect/create-bundle-id.md
@@ -30,7 +30,7 @@ Identifier of the Bundle ID
 
 
 Name of the Bundle ID. If the resource is being created, the default will be deduced from given Bundle ID identifier.
-##### `--platform=IOS | MAC_OS | UNIVERSAL`
+##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`

--- a/docs/app-store-connect/fetch-signing-files.md
+++ b/docs/app-store-connect/fetch-signing-files.md
@@ -31,7 +31,7 @@ app-store-connect fetch-signing-files [-h] [--log-stream STREAM] [--no-color] [-
 Identifier of the Bundle ID
 ### Optional arguments for action `fetch-signing-files`
 
-##### `--platform=IOS | MAC_OS | UNIVERSAL`
+##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`

--- a/docs/app-store-connect/get-profile.md
+++ b/docs/app-store-connect/get-profile.md
@@ -14,6 +14,7 @@ app-store-connect get-profile [-h] [--log-stream STREAM] [--no-color] [--version
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
+    [--save]
     PROFILE_RESOURCE_ID
 ```
 ### Required arguments for action `get-profile`
@@ -22,6 +23,12 @@ app-store-connect get-profile [-h] [--log-stream STREAM] [--no-color] [--version
 
 
 Alphanumeric ID value of the Profile
+### Optional arguments for action `get-profile`
+
+##### `--save`
+
+
+Whether to save the resources to disk. See PROFILES_DIRECTORY and CERTIFICATES_DIRECTORY for more information.
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/list-bundle-ids.md
+++ b/docs/app-store-connect/list-bundle-ids.md
@@ -29,7 +29,7 @@ Identifier of the Bundle ID
 
 
 Name of the Bundle ID. If the resource is being created, the default will be deduced from given Bundle ID identifier.
-##### `--platform=IOS | MAC_OS | UNIVERSAL`
+##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform

--- a/docs/app-store-connect/list-devices.md
+++ b/docs/app-store-connect/list-devices.md
@@ -20,7 +20,7 @@ app-store-connect list-devices [-h] [--log-stream STREAM] [--no-color] [--versio
 ```
 ### Optional arguments for action `list-devices`
 
-##### `--platform=IOS | MAC_OS | UNIVERSAL`
+##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -22,7 +22,7 @@ Path to Xcode project (\*.xcodeproj). Can be either a path literal, or a glob pa
 ##### `--profile=PROFILE_PATHS`
 
 
-Path to provisioning profile. Can be either a path literal, or a glob pattern to match provisioning profiles. Multiple arguments. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles/*.mobileprovision`
+Path to provisioning profile. Can be either a path literal, or a glob pattern to match provisioning profiles. Multiple arguments. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles/*.mobileprovision, $HOME/Library/MobileDevice/Provisioning Profiles/*.provisionprofile`
 ##### `--export-options-plist=EXPORT_OPTIONS_PATH`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.5.9'
+__version__ = '0.6.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -505,13 +505,21 @@ class AppStoreConnect(cli.CliApp):
             self._save_profile(profile)
         return profile
 
-    @cli.action('get-profile', ProfileArgument.PROFILE_RESOURCE_ID)
-    def get_profile(self, profile_resource_id: ResourceId, should_print: bool = True) -> Profile:
+    @cli.action('get-profile',
+                ProfileArgument.PROFILE_RESOURCE_ID,
+                CommonArgument.SAVE)
+    def get_profile(self,
+                    profile_resource_id: ResourceId,
+                    save: bool = False,
+                    should_print: bool = True) -> Profile:
         """
         Get specified Profile from Apple Developer portal
         """
 
-        return self._get_resource(profile_resource_id, self.api_client.profiles, should_print)
+        profile = self._get_resource(profile_resource_id, self.api_client.profiles, should_print)
+        if save:
+            self._save_profile(profile)
+        return profile
 
     @cli.action('delete-profile',
                 ProfileArgument.PROFILE_RESOURCE_ID,


### PR DESCRIPTION
Add action to get single provisioning profile information using `app-store-connect`.

**New actions:**
- `app-store-connect get-profile`

**Example executions of new actions**

- Get profile information by resource ID and save it to disk

```bash
> app-store-connect get-profile 5GJJFH4V5F --save  
Get Profile 5GJJFH4V5F
-- Profile --
Id: 5GJJFH4V5F
Type: profiles
Name: io codemagic capybara cbbdeb5a-a7bf-4ebc-921c-e1ae756b69c1 ios_app_development 1619508881
Platform: IOS
Uuid: 603669b0-1807-404f-9f04-7c7798b05274
Created date: 2021-04-27 07:34:41+00:00
State: ACTIVE
Type: IOS_APP_DEVELOPMENT
Expiration date: 2022-04-27 07:34:41+00:00
Content: "..."
Saved Profile IOS_APP_DEVELOPMENT profile 603669b0-1807-404f-9f04-7c7798b05274 to '/Users/priit/Library/MobileDevice/Provisioning Profiles/IOS_APP_DEVELOPMENT_profile_603669b0_1807_404f_9f04_7c7798b05274_fj8szcqy.mobileprovision'
```
