### PR TITLE
Improvement: add support for Path objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.4.9
+-------------
+**Improvements**
+
+- Improvement: add Path objects support for the serialization.
+
 Version 0.4.8
 -------------
 **Improvements**

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.4.8'
+__version__ = '0.4.9'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/json_serializable.py
+++ b/src/codemagic/models/json_serializable.py
@@ -1,5 +1,6 @@
 import json
 from abc import abstractmethod
+from pathlib import Path
 from typing import Dict
 
 _json_encoder_default = json.JSONEncoder.default
@@ -11,6 +12,8 @@ class JsonSerializableMeta(type):
     def default(json_encoder, obj) -> Dict:
         if isinstance(obj, JsonSerializable):
             return obj.dict()
+        elif isinstance(obj, Path):
+            return str(obj)
         else:
             return _json_encoder_default(json_encoder, obj)
 


### PR DESCRIPTION
[Error](https://nevercode.slack.com/archives/CD7DHMETH/p1621425012020700)


```
Traceback (most recent call last):
  File "kombu/serialization.py", line 50, in _reraise_errors
  File "kombu/serialization.py", line 221, in dumps
  File "kombu/utils/json.py", line 69, in dumps
  File "json/__init__.py", line 234, in dumps
  File "json/encoder.py", line 199, in encode
  File "json/encoder.py", line 257, in iterencode
  File "kombu/utils/json.py", line 59, in default
  File "codemagic/models/json_serializable.py", line 15, in default
  File "json/encoder.py", line 179, in default
TypeError: Object of type PosixPath is not JSON serializable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "build/build_action_manager.py", line 41, in run_actions
  File "build/build_action_manager.py", line 158, in _run_action
  File "build/main.py", line 608, in run_fetch_and_scan_steps
  File "utils/decorators.py", line 35, in timed
  File "build/main.py", line 292, in scan
  File "build/models/api.py", line 68, in create_configs
  File "celery/app/task.py", line 425, in delay
  File "celery/app/task.py", line 564, in apply_async
  File "celery/app/base.py", line 771, in send_task
  File "celery/app/amqp.py", line 550, in send_task_message
  File "kombu/messaging.py", line 167, in publish
  File "kombu/messaging.py", line 252, in _prepare
  File "kombu/serialization.py", line 221, in dumps
  File "contextlib.py", line 131, in __exit__
  File "kombu/serialization.py", line 54, in _reraise_errors
  File "vine/five.py", line 194, in reraise
  File "kombu/serialization.py", line 50, in _reraise_errors
  File "kombu/serialization.py", line 221, in dumps
  File "kombu/utils/json.py", line 69, in dumps
  File "json/__init__.py", line 234, in dumps
  File "json/encoder.py", line 199, in encode
  File "json/encoder.py", line 257, in iterencode
  File "kombu/utils/json.py", line 59, in default
  File "codemagic/models/json_serializable.py", line 15, in default
  File "json/encoder.py", line 179, in default
kombu.exceptions.EncodeError: Object of type PosixPath is not JSON serializable
```
