### PR TITLE
Bugfix: Allow passTypeId relationship for certificate resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.6.1
+-------------
+
+**Fixes**
+
+- Allow `passTypeId` relationship for [Certificate](https://developer.apple.com/documentation/appstoreconnectapi/certificate) model.
+
 Version 0.6.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/signing_certificate.py
+++ b/src/codemagic/apple/resources/signing_certificate.py
@@ -10,6 +10,7 @@ from OpenSSL import crypto
 
 from .bundle_id import BundleIdPlatform
 from .enums import CertificateType
+from .resource import Relationship
 from .resource import Resource
 
 
@@ -36,6 +37,12 @@ class SigningCertificate(Resource):
                 self.platform = BundleIdPlatform(self.platform)
             if isinstance(self.certificateType, str):
                 self.certificateType = CertificateType(self.certificateType)
+
+    @dataclass
+    class Relationships(Resource.Relationships):
+        _OMIT_IF_NONE_KEYS = ('passTypeId',)
+
+        passTypeId: Optional[Relationship]
 
     def get_display_info(self) -> str:
         return f'{self.attributes.certificateType} certificate {self.attributes.serialNumber}'


### PR DESCRIPTION
App Store Connect API responses that return [Certificate](https://developer.apple.com/documentation/appstoreconnectapi/certificate) resource are not including `passTypeId` relationship that we need to support.

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 188, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/usr/local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 156, in _invoke_action
    return cli_action(**action_args)
  File "/usr/local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 441, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 683, in fetch_signing_files
    certificates = self._get_or_create_certificates(
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 714, in _get_or_create_certificates
    certificates = self.list_certificates(
  File "/usr/local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 441, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 471, in list_certificates
    certificates = self._list_resources(certificate_filter, self.api_client.signing_certificates, should_print)
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/resource_manager_mixin.py", line 45, in _list_resources
    resources = resource_manager.list(resource_filter=resource_filter)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/signing_certificates.py", line 60, in list
    return [SigningCertificate(certificate) for certificate in certificates]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/signing_certificates.py", line 60, in <listcomp>
    return [SigningCertificate(certificate) for certificate in certificates]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 183, in __init__
    self.relationships = self._create_relationships(api_response)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 175, in _create_relationships
    return cls.Relationships(**api_response['relationships'])
TypeError: __init__() got an unexpected keyword argument 'passTypeId'
```