### PR TITLE
Bugfix: non-integer version codes in latest build numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.7.2
+-------------
+
+**Fixes**
+
+- Support non-integer (dot-separated versions such as 10.14.1) version codes for `app-store-connect get-latest-app-store-build-number` and `app-store-connect get-latest-testflight-build-number`.
+
 Version 0.7.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import tempfile
 import time
+from distutils.version import LooseVersion
 from functools import lru_cache
 from typing import Iterator
 from typing import List
@@ -222,13 +223,11 @@ class AppStoreConnect(cli.CliApp,
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @classmethod
-    def _get_latest_build_number(cls, builds: List[Build]) -> Optional[int]:
-        try:
-            latest_build_number = max(int(build.attributes.version) for build in builds)
-        except ValueError:
-            return None
-        cls.echo(str(latest_build_number))
-        return latest_build_number
+    def _get_latest_build_number(cls, builds: List[Build]) -> str:
+        most_recent_build = max(builds, key=lambda b: LooseVersion(b.attributes.version))
+        version = most_recent_build.attributes.version
+        cls.echo(version)
+        return version
 
     @cli.action('get-latest-app-store-build-number',
                 AppArgument.APPLICATION_ID_RESOURCE_ID,
@@ -238,7 +237,7 @@ class AppStoreConnect(cli.CliApp,
                                           application_id: ResourceId,
                                           version_string: Optional[str] = None,
                                           platform: Optional[Platform] = None,
-                                          should_print: bool = False) -> Optional[int]:
+                                          should_print: bool = False) -> str:
         """
         Get latest App Store build number for the given application
         """
@@ -261,7 +260,7 @@ class AppStoreConnect(cli.CliApp,
                                            application_id: ResourceId,
                                            pre_release_version: Optional[str] = None,
                                            platform: Optional[Platform] = None,
-                                           should_print: bool = False) -> Optional[int]:
+                                           should_print: bool = False) -> str:
         """
         Get latest Testflight build number for the given application
         """


### PR DESCRIPTION
Actions `app-store-connect get-latest-app-store-build-number` and `app-store-connect get-latest-testflight-build-number` are unable to return the latest build number if some of the matched builds have non-integer version. For example latest TestFlight build number for given TestFlight submission is ought to be 10.7.4.1:
![Screenshot 2021-05-28 at 17 13 29](https://user-images.githubusercontent.com/2756611/120169647-d8566680-c208-11eb-8b18-4927dd240414.png)
But
```shell
> app-store-connect get-latest-testflight-build-number 1531514033 --pre-release-version=2.0.1
Found 2 Builds matching specified filters: app=1531514033, version=2.0.1.
```
exists without returning/outputting any build numbers. 