### PR TITLE
Bugfix: App Store Connect publishing without API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.7.3
+-------------
+
+**Fixes**
+
+- Do not require App Store Connect API keys for `app-store-connect publish` unless `--testflight` option is specified as binary upload can be done with Apple ID and App Specific password only.
+
 Version 0.7.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
To just validate and upload application package to App Store Connect we don't need App Store Connect API key in case Apple ID and password are provided for publishing. However, as it is currently implemented, as soon as binary upload is completed with `altool`, the tool tries to locate the build from App Store Connect, which was just created, but this will require interacting with App Store Connect API which is not possible using Apple ID and password. Make sure not to call App Store Connect API in case submitting to TestFlight with `--testflight` option is not specified.