### PR TITLE
Bugfix: ValueError on get latest build number in case of no builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version 0.7.4
 
 - Do not fail actions `app-store-connect get-latest-app-store-build-number` and `app-store-connect get-latest-testflight-build-number` in case no builds were found for specified constraints. 
 
+**Development / Docs**
+
+- Split monolith`AppStoreConnect` tool tests file into smaller chunks in separate test module.
+
 Version 0.7.3
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.7.4
+-------------
+
+**Fixes**
+
+- Do not fail actions `app-store-connect get-latest-app-store-build-number` and `app-store-connect get-latest-testflight-build-number` in case no builds were found for specified constraints. 
+
 Version 0.7.3
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.7.3'
+__version__ = '0.7.4'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -223,7 +223,9 @@ class AppStoreConnect(cli.CliApp,
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @classmethod
-    def _get_latest_build_number(cls, builds: List[Build]) -> str:
+    def _get_latest_build_number(cls, builds: List[Build]) -> Optional[str]:
+        if not builds:
+            return None
         most_recent_build = max(builds, key=lambda b: LooseVersion(b.attributes.version))
         version = most_recent_build.attributes.version
         cls.echo(version)
@@ -237,7 +239,7 @@ class AppStoreConnect(cli.CliApp,
                                           application_id: ResourceId,
                                           version_string: Optional[str] = None,
                                           platform: Optional[Platform] = None,
-                                          should_print: bool = False) -> str:
+                                          should_print: bool = False) -> Optional[str]:
         """
         Get latest App Store build number for the given application
         """
@@ -260,7 +262,7 @@ class AppStoreConnect(cli.CliApp,
                                            application_id: ResourceId,
                                            pre_release_version: Optional[str] = None,
                                            platform: Optional[Platform] = None,
-                                           should_print: bool = False) -> str:
+                                           should_print: bool = False) -> Optional[str]:
         """
         Get latest Testflight build number for the given application
         """

--- a/tests/tools/app_store_connect/conftest.py
+++ b/tests/tools/app_store_connect/conftest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from codemagic.tools.app_store_connect import AppStoreConnect
+from codemagic.tools.app_store_connect import AppStoreConnectArgument
+from codemagic.tools.app_store_connect import Types
+
+
+@pytest.fixture(autouse=True)
+def register_args(cli_argument_group):
+    for arg in AppStoreConnect.CLASS_ARGUMENTS:
+        arg.register(cli_argument_group)
+
+
+@pytest.fixture()
+def namespace_kwargs():
+    ns_kwargs = {
+        'action': 'list-devices',
+        AppStoreConnectArgument.CERTIFICATES_DIRECTORY.key:
+            AppStoreConnectArgument.CERTIFICATES_DIRECTORY.get_default(),
+        AppStoreConnectArgument.PROFILES_DIRECTORY.key: AppStoreConnectArgument.PROFILES_DIRECTORY.get_default(),
+        AppStoreConnectArgument.LOG_REQUESTS.key: True,
+        AppStoreConnectArgument.JSON_OUTPUT.key: False,
+        AppStoreConnectArgument.ISSUER_ID.key: Types.IssuerIdArgument('issuer-id'),
+        AppStoreConnectArgument.KEY_IDENTIFIER.key: Types.KeyIdentifierArgument('key-identifier'),
+        AppStoreConnectArgument.PRIVATE_KEY.key: Types.PrivateKeyArgument('-----BEGIN PRIVATE KEY-----'),
+    }
+    for arg in AppStoreConnect.CLASS_ARGUMENTS:
+        if not hasattr(arg.type, 'environment_variable_key'):
+            continue
+        os.environ.pop(arg.type.environment_variable_key, None)
+    return ns_kwargs

--- a/tests/tools/app_store_connect/test_from_cli_args.py
+++ b/tests/tools/app_store_connect/test_from_cli_args.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import pathlib
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
@@ -11,32 +10,6 @@ import pytest
 from codemagic.tools.app_store_connect import AppStoreConnect
 from codemagic.tools.app_store_connect import AppStoreConnectArgument
 from codemagic.tools.app_store_connect import Types
-
-
-@pytest.fixture(autouse=True)
-def register_args(cli_argument_group):
-    for arg in AppStoreConnect.CLASS_ARGUMENTS:
-        arg.register(cli_argument_group)
-
-
-@pytest.fixture()
-def namespace_kwargs():
-    ns_kwargs = {
-        'action': 'list-devices',
-        AppStoreConnectArgument.CERTIFICATES_DIRECTORY.key:
-            AppStoreConnectArgument.CERTIFICATES_DIRECTORY.get_default(),
-        AppStoreConnectArgument.PROFILES_DIRECTORY.key: AppStoreConnectArgument.PROFILES_DIRECTORY.get_default(),
-        AppStoreConnectArgument.LOG_REQUESTS.key: True,
-        AppStoreConnectArgument.JSON_OUTPUT.key: False,
-        AppStoreConnectArgument.ISSUER_ID.key: Types.IssuerIdArgument('issuer-id'),
-        AppStoreConnectArgument.KEY_IDENTIFIER.key: Types.KeyIdentifierArgument('key-identifier'),
-        AppStoreConnectArgument.PRIVATE_KEY.key: Types.PrivateKeyArgument('-----BEGIN PRIVATE KEY-----'),
-    }
-    for arg in AppStoreConnect.CLASS_ARGUMENTS:
-        if not hasattr(arg.type, 'environment_variable_key'):
-            continue
-        os.environ.pop(arg.type.environment_variable_key, None)
-    return ns_kwargs
 
 
 def _test_missing_argument(argument, _namespace_kwargs):
@@ -145,55 +118,3 @@ def _do_private_key_assertions(private_key_value, moc_appstore_api_client, cli_n
     _, _, private_key_arg = moc_appstore_api_client.call_args[0]
     assert isinstance(private_key_arg, str)
     assert private_key_arg == private_key_value
-
-
-def test_publish_action_without_app_store_connect_key(namespace_kwargs):
-    namespace_kwargs.update({
-        AppStoreConnectArgument.ISSUER_ID.key: None,
-        AppStoreConnectArgument.KEY_IDENTIFIER.key: None,
-        AppStoreConnectArgument.PRIVATE_KEY.key: None,
-        'action': 'publish',
-    })
-    cli_args = argparse.Namespace(**namespace_kwargs)
-    _ = AppStoreConnect.from_cli_args(cli_args)
-
-
-@pytest.mark.parametrize('missing_argument', [
-    AppStoreConnectArgument.ISSUER_ID,
-    AppStoreConnectArgument.KEY_IDENTIFIER,
-    AppStoreConnectArgument.PRIVATE_KEY,
-])
-def test_publish_action_without_app_store_connect_key_testflight_submit(missing_argument, namespace_kwargs):
-    namespace_kwargs.update({missing_argument.key: None, 'action': 'publish'})
-    cli_args = argparse.Namespace(**namespace_kwargs)
-    app_store_connect = AppStoreConnect.from_cli_args(cli_args)
-    with pytest.raises(argparse.ArgumentError) as error_info:
-        app_store_connect.publish(
-            application_package_path_patterns=[pathlib.Path('path.pattern')],
-            submit_to_testflight=True,
-        )
-    assert missing_argument.flag in error_info.value.argument_name
-
-
-@mock.patch('codemagic.tools._app_store_connect.actions.publish_action.Altool')
-def test_publish_action_with_username_and_password(_mock_altool, namespace_kwargs):
-    namespace_kwargs.update({
-        AppStoreConnectArgument.ISSUER_ID.key: None,
-        AppStoreConnectArgument.KEY_IDENTIFIER.key: None,
-        AppStoreConnectArgument.PRIVATE_KEY.key: None,
-        'action': 'publish',
-    })
-
-    cli_args = argparse.Namespace(**namespace_kwargs)
-    with mock.patch.object(AppStoreConnect, 'find_paths') as mock_find_paths, \
-         mock.patch.object(AppStoreConnect, '_get_publishing_application_packages') as mock_get_packages:
-        mock_get_packages.return_value = []
-        mock_find_paths.return_value = []
-
-        patterns = [pathlib.Path('path.pattern')]
-        AppStoreConnect.from_cli_args(cli_args).publish(
-            application_package_path_patterns=patterns,
-            apple_id='name@example.com',
-            app_specific_password=Types.AppSpecificPassword('xxxx-yyyy-zzzz-wwww'),
-        )
-        mock_get_packages.assert_called_with(patterns)

--- a/tests/tools/app_store_connect/test_get_latest_build_number.py
+++ b/tests/tools/app_store_connect/test_get_latest_build_number.py
@@ -1,0 +1,38 @@
+import dataclasses
+import uuid
+from unittest import mock
+
+import pytest
+
+from codemagic.apple.resources import Build
+from codemagic.apple.resources import ResourceType
+from codemagic.tools.app_store_connect import AppStoreConnect
+
+
+def _mock_echo(*_args, **_kwargs):
+    pass
+
+
+def _get_build(version) -> Build:
+    attributes = {f.name: None for f in dataclasses.fields(Build.Attributes)}
+    attributes['version'] = version
+    return Build({
+        'attributes': attributes,
+        'id': str(uuid.uuid4()),
+        'links': {'self': None},
+        'type': ResourceType.BUILDS.value,
+    })
+
+
+@pytest.mark.parametrize('versions, expected_latest_build_number', [
+    ([], None),
+    (['1.0.1', '2', '0.1'], '2'),
+    (['2.0', '2'], '2.0'),
+    (['11', '13', '14', '15', '12'], '15'),
+    (['13.0.1.2.3.4.5'], '13.0.1.2.3.4.5'),
+])
+@mock.patch.object(AppStoreConnect, 'echo', _mock_echo)
+def test_get_latest_build_number(versions, expected_latest_build_number):
+    builds = list(map(_get_build, versions))
+    latest_build_number = AppStoreConnect._get_latest_build_number(builds)
+    assert latest_build_number == expected_latest_build_number

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import pathlib
+from unittest import mock
+
+import pytest
+
+from codemagic.tools.app_store_connect import AppStoreConnect
+from codemagic.tools.app_store_connect import AppStoreConnectArgument
+from codemagic.tools.app_store_connect import Types
+
+
+def test_publish_action_without_app_store_connect_key(namespace_kwargs):
+    namespace_kwargs.update({
+        AppStoreConnectArgument.ISSUER_ID.key: None,
+        AppStoreConnectArgument.KEY_IDENTIFIER.key: None,
+        AppStoreConnectArgument.PRIVATE_KEY.key: None,
+        'action': 'publish',
+    })
+    cli_args = argparse.Namespace(**namespace_kwargs)
+    _ = AppStoreConnect.from_cli_args(cli_args)
+
+
+@pytest.mark.parametrize('missing_argument', [
+    AppStoreConnectArgument.ISSUER_ID,
+    AppStoreConnectArgument.KEY_IDENTIFIER,
+    AppStoreConnectArgument.PRIVATE_KEY,
+])
+def test_publish_action_without_app_store_connect_key_testflight_submit(missing_argument, namespace_kwargs):
+    namespace_kwargs.update({missing_argument.key: None, 'action': 'publish'})
+    cli_args = argparse.Namespace(**namespace_kwargs)
+    app_store_connect = AppStoreConnect.from_cli_args(cli_args)
+    with pytest.raises(argparse.ArgumentError) as error_info:
+        app_store_connect.publish(
+            application_package_path_patterns=[pathlib.Path('path.pattern')],
+            submit_to_testflight=True,
+        )
+    assert missing_argument.flag in error_info.value.argument_name
+
+
+@mock.patch('codemagic.tools._app_store_connect.actions.publish_action.Altool')
+def test_publish_action_with_username_and_password(_mock_altool, namespace_kwargs):
+    namespace_kwargs.update({
+        AppStoreConnectArgument.ISSUER_ID.key: None,
+        AppStoreConnectArgument.KEY_IDENTIFIER.key: None,
+        AppStoreConnectArgument.PRIVATE_KEY.key: None,
+        'action': 'publish',
+    })
+
+    cli_args = argparse.Namespace(**namespace_kwargs)
+    with mock.patch.object(AppStoreConnect, 'find_paths') as mock_find_paths, \
+            mock.patch.object(AppStoreConnect, '_get_publishing_application_packages') as mock_get_packages:
+        mock_get_packages.return_value = []
+        mock_find_paths.return_value = []
+
+        patterns = [pathlib.Path('path.pattern')]
+        AppStoreConnect.from_cli_args(cli_args).publish(
+            application_package_path_patterns=patterns,
+            apple_id='name@example.com',
+            app_specific_password=Types.AppSpecificPassword('xxxx-yyyy-zzzz-wwww'),
+        )
+        mock_get_packages.assert_called_with(patterns)


### PR DESCRIPTION
In case there are no builds maching the constraints given to actions `app-store-connect get-latest-app-store-build-number` and `app-store-connect get-latest-testflight-build-number` they fail with `ValueError`:

```python
[11:51:05 02-06-2021] ERROR cli_app.py:113 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 188, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 156, in _invoke_action
    return cli_action(**action_args)
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 441, in wrapper
    return func(*args, **kwargs)
  File "/Users/priit/nevercode/cli-tools/src/codemagic/tools/app_store_connect.py", line 275, in get_latest_testflight_build_number
    return self._get_latest_build_number(builds)
  File "/Users/priit/nevercode/cli-tools/src/codemagic/tools/app_store_connect.py", line 227, in _get_latest_build_number
    most_recent_build = max(builds, key=lambda b: LooseVersion(b.attributes.version))
ValueError: max() arg is an empty sequence
```

As no matching builds is a legitimate use case of those actions, make the latest build number return value optional and handle the cases where no builds are found. 