### PR TITLE
Improve help messages and online documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Version 0.8.0
 - Add action `app-store-connect beta-build-localizations list` to list localized "What's new" notes filtered by Build ID and locale code 
 - Add action `app-store-connect beta-build-localizations get` to retrieve localized "What's new" notes by its ID
 
+**Development / Docs**
+
+- Fix `--testflight` option description for `app-store-connect publish` action.
+
 Version 0.7.5
 -------------
 

--- a/docs/app-store-connect/beta-build-localizations/create.md
+++ b/docs/app-store-connect/beta-build-localizations/create.md
@@ -14,9 +14,9 @@ app-store-connect beta-build-localizations create [-h] [--log-stream STREAM] [--
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    [-n WHATS_NEW]
+    [--whats-new WHATS_NEW]
     BUILD_ID_RESOURCE_ID
-    -l LOCALE
+    --locale LOCALE
 ```
 ### Required arguments for action `create`
 
@@ -24,13 +24,13 @@ app-store-connect beta-build-localizations create [-h] [--log-stream STREAM] [--
 
 
 Alphanumeric ID value of the Build
-##### `-l, --locale=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes
 ### Optional arguments for action `create`
 
-##### `-n, --whats-new=WHATS_NEW`
+##### `--whats-new, -n=WHATS_NEW`
 
 
 Describe the changes and additions to the build and indicate the features you would like your users to tests. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_WHATS_NEW`. Alternatively to entering` WHATS_NEW `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.

--- a/docs/app-store-connect/beta-build-localizations/list.md
+++ b/docs/app-store-connect/beta-build-localizations/list.md
@@ -14,7 +14,7 @@ app-store-connect beta-build-localizations list [-h] [--log-stream STREAM] [--no
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    [-l LOCALE_OPTIONAL]
+    [--locale LOCALE_OPTIONAL]
     BUILD_ID_RESOURCE_ID
 ```
 ### Required arguments for action `list`
@@ -25,7 +25,7 @@ app-store-connect beta-build-localizations list [-h] [--log-stream STREAM] [--no
 Alphanumeric ID value of the Build
 ### Optional arguments for action `list`
 
-##### `-l, --locale=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/docs/app-store-connect/beta-build-localizations/modify.md
+++ b/docs/app-store-connect/beta-build-localizations/modify.md
@@ -14,7 +14,7 @@ app-store-connect beta-build-localizations modify [-h] [--log-stream STREAM] [--
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    [-n WHATS_NEW]
+    [--whats-new WHATS_NEW]
     BETA_BUILD_LOCALIZATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `modify`
@@ -25,7 +25,7 @@ app-store-connect beta-build-localizations modify [-h] [--log-stream STREAM] [--
 Alphanumeric ID value of the Beta Build Localization
 ### Optional arguments for action `modify`
 
-##### `-n, --whats-new=WHATS_NEW`
+##### `--whats-new, -n=WHATS_NEW`
 
 
 Describe the changes and additions to the build and indicate the features you would like your users to tests. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_WHATS_NEW`. Alternatively to entering` WHATS_NEW `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -15,11 +15,11 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--path APPLICATION_PACKAGE_PATH_PATTERNS]
-    [-u APPLE_ID]
-    [-p APP_SPECIFIC_PASSWORD]
-    [-t]
-    [-l LOCALE_OPTIONAL_WITH_DEFAULT]
-    [-n WHATS_NEW]
+    [--apple-id APPLE_ID]
+    [--password APP_SPECIFIC_PASSWORD]
+    [--testflight]
+    [--locale LOCALE_OPTIONAL_WITH_DEFAULT]
+    [--whats-new WHATS_NEW]
     [--skip-package-validation]
 ```
 ### Optional arguments for action `publish`
@@ -28,23 +28,23 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
 
 
 Path to artifact (\*.ipa or \*.pkg). Can be either a path literal, or a glob pattern to match projects in working directory. Multiple arguments. Default:&nbsp;`**/*.ipa, **/*.pkg`
-##### `-u, --apple-id=APPLE_ID`
+##### `--apple-id, -u=APPLE_ID`
 
 
 App Store Connect username used for application package validation and upload if App Store Connect API key is not specified
-##### `-p, --password=APP_SPECIFIC_PASSWORD`
+##### `--password, -p=APP_SPECIFIC_PASSWORD`
 
 
 App-specific password used for application package validation and upload if App Store Connect API Key is not specified. Used together with --apple-id and should match pattern `abcd-abcd-abcd-abcd`. Create an app-specific password in the Security section of your Apple ID account. Learn more from https://support.apple.com/en-us/HT204397. If not given, the value will be checked from environment variable `APP_SPECIFIC_PASSWORD`. Alternatively to entering` APP_SPECIFIC_PASSWORD `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
-##### `-t, --testflight`
+##### `--testflight, -t`
 
 
 Submit an app for Testflight beta app review to allow external testing
-##### `-l, --locale=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes. Default:&nbsp;`en-US`
-##### `-n, --whats-new=WHATS_NEW`
+##### `--whats-new, -n=WHATS_NEW`
 
 
 Describe the changes and additions to the build and indicate the features you would like your users to tests. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_WHATS_NEW`. Alternatively to entering` WHATS_NEW `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -225,7 +225,7 @@ class PublishArgument(cli.Argument):
     )
     SUBMIT_TO_TESTFLIGHT = cli.ArgumentProperties(
         key='submit_to_testflight',
-        flags=('-t', '--testflight'),
+        flags=('--testflight', '-t'),
         type=bool,
         description='Submit an app for Testflight beta app review to allow external testing',
         argparse_kwargs={
@@ -235,7 +235,7 @@ class PublishArgument(cli.Argument):
     )
     APPLE_ID = cli.ArgumentProperties(
         key='apple_id',
-        flags=('-u', '--apple-id'),
+        flags=('--apple-id', '-u'),
         description=(
             'App Store Connect username used for application package validation '
             'and upload if App Store Connect API key is not specified'
@@ -244,7 +244,7 @@ class PublishArgument(cli.Argument):
     )
     APP_SPECIFIC_PASSWORD = cli.ArgumentProperties(
         key='app_specific_password',
-        flags=('-p', '--password'),
+        flags=('--password', '-p'),
         type=Types.AppSpecificPassword,
         description=(
             'App-specific password used for application package validation '
@@ -344,7 +344,7 @@ class BuildArgument(cli.Argument):
     )
     LOCALE = cli.ArgumentProperties(
         key='locale',
-        flags=('-l', '--locale'),
+        flags=('--locale', '-l'),
         type=Locale,
         description=(
             'The locale code name for displaying localized "What\'s new" content in TestFlight. '
@@ -367,7 +367,7 @@ class BuildArgument(cli.Argument):
     })
     WHATS_NEW = cli.ArgumentProperties(
         key='whats_new',
-        flags=('-n', '--whats-new'),
+        flags=('--whats-new', '-n'),
         type=Types.WhatsNewArgument,
         description=(
             'Describe the changes and additions to the build and indicate '

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -87,7 +87,7 @@ def test_publish_action_with_localization_and_no_testflight_submission(publishin
             whats_new=Types.WhatsNewArgument("What's new"),
         )
 
-    assert str(error_info.value) == 'argument -n/--whats-new: --testflight is required for submitting notes'
+    assert str(error_info.value) == 'argument --whats-new/-n: --testflight is required for submitting notes'
 
 
 def test_publish_action_testflight_with_localization(publishing_namespace_kwargs):


### PR DESCRIPTION
Currently help messages often use the shorthand flags for examples, but they are not always self-explanatory and can cause confusion. With the changes introduced in this pull request we now show the long version of CLI flag first in help messages and online documentation to reduce ambiguity. For example use `--testflight` instead of `-t` in help messages.