### PR TITLE
Bugfix: Make altool output parsing less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.7.6
+-------------
+
+**Fixes**
+
+- Make `altool` output parsing less strict. Do not fail `app-store-connect publish` action invocation if `altool` output cannot be interpreted. 
+
 Version 0.7.5
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.7.5'
+__version__ = '0.7.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
When we fail to parse the output of `altool` during `app-store-connect publish` call, then the full action can fail, which is not desirable:

```shell
> app-store-connect publish --path /Users/builder/clone/build/ios/ipa/banaan.ipa --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY

Publish "/Users/builder/clone/build/ios/ipa/banaan.ipa" to App Store Connect
App name: Banaan
Bundle identifier: io.codemagic.banaan
Certificate expires: 2022-05-14T14:35:20.000+0000
Distribution type: App Store
Min os version: 10.1
Provisioned devices: N/A
Provisions all devices: No
Supported platforms: iPhoneOS
Version code: 1.0.50
Version: 1.0

Validate "/Users/builder/clone/build/ios/ipa/banaan.ipa" for App Store Connect
Generated JWT: eyJhbGciOiJFUzI1NiIsImtpZCI6Ik5QU0M0MzVQMjkiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjE2MjMzMzI5MjYsImlzcyI6IjdkODEyZmUyLThhYmQtNDdjYS05ZDI3LTNlZDdlNjJkN2I2ZCIsImF1ZCI6ImFwcHN0b3JlY29ubmVjdC12MSIsImlhdCI6MTYyMzMzMTcyNn0.RScdHpB3vU8umoDH8JRDLEBvLC-A_fsi1b8KdCFXCScjQq_uy9BdsDMsOubf5wjj5cm2a4QAmevgtOe17xHRAA
{"tool-version":"4.029.1194","tool-path":"\/Applications\/Xcode-12.4.app\/Contents\/SharedFrameworks\/ContentDeliveryServices.framework\/Versions\/A\/Frameworks\/AppStoreService.framework","success-message":"No errors validating archive at '\/Users\/builder\/clone\/build\/ios\/ipa\/banaan.ipa'.","os-version":"10.15.5"}


Failed to load Altool result from process stdout
Failed to publish /Users/builder/clone/build/ios/ipa/banaan.ipa
```