### PR TITLE
Bugfix: Fix submitting builds to TestFlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.7.7
+-------------
+
+**Fixes**
+
+- Before creating Beta App Review Submission (submitting build to TestFlight) as part of `app-store-connect publish`, wait until the uploaded build processing completes. 
+
 Version 0.7.6
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.7.6'
+__version__ = '0.7.7'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -44,6 +44,9 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
             self, build_id: ResourceId, should_print: bool = True) -> AppStoreVersionSubmission:
         ...
 
+    def get_build(self, build_id: ResourceId, should_print: bool = True) -> Build:
+        ...
+
     def get_build_pre_release_version(self, build_id: ResourceId, should_print: bool = True) -> PreReleaseVersion:
         ...
 

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -14,6 +14,16 @@ from ..arguments import BuildArgument
 
 class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
+    @cli.action('get',
+                BuildArgument.BUILD_ID_RESOURCE_ID,
+                action_group=AppStoreConnectActionGroup.BUILDS)
+    def get_build(self, build_id: ResourceId, should_print: bool = True) -> Build:
+        """
+        Get information about a specific build
+        """
+
+        return self._get_resource(build_id, self.api_client.builds, should_print)
+
     @cli.action('pre-release-version',
                 BuildArgument.BUILD_ID_RESOURCE_ID,
                 action_group=AppStoreConnectActionGroup.BUILDS)


### PR DESCRIPTION
Once builds are uploaded to App Store Connect it can take quite a bit of time until they are properly processed for next steps
such as creating Beta App Review Submission. Add simple retrying logic to wait until builds are processed.

Example output from the updated action:

```shell
> app-store-connect publish --path ~/Downloads/banaan.ipa --testflight                                                                             1 ↵
Publish "/Users/priit/Downloads/banaan.ipa" to App Store Connect
App name: Banaan
Bundle identifier: io.codemagic.banaan
Certificate expires: 2022-05-14T04:35:20.000+0000
Distribution type: App Store
Min os version: 10.1
Provisioned devices: N/A
Provisions all devices: No
Supported platforms: iPhoneOS
Version code: 1.0.56
Version: 1.0

Validate "/Users/priit/Downloads/banaan.ipa" for App Store Connect
{
    "tool-version": "4.050.1210",
    "tool-path": "/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework",
    "success-message": "No errors validating archive at '/Users/priit/Downloads/banaan.ipa'.",
    "os-version": "11.2.3"
}
No errors validating archive at '/Users/priit/Downloads/banaan.ipa'.

Upload "/Users/priit/Downloads/banaan.ipa" to App Store Connect
{
    "tool-version": "4.050.1210",
    "tool-path": "/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework",
    "success-message": "No errors uploading '/Users/priit/Downloads/banaan.ipa'",
    "os-version": "11.2.3"
}
No errors uploading '/Users/priit/Downloads/banaan.ipa'

Find application entry from App Store Connect for uploaded binary
Found 1 App matching specified filters: bundleId=io.codemagic.banaan.
-- App --
Id: 1481211155
Type: apps
Bundle id: io.codemagic.banaan
Name: Banaan Codemagic
Primary locale: en-GB
Sku: banaanike
Available in new territories: False
Is or ever was made for kids: False

Find freshly uploaded build
Get Builds for App 1481211155
Found 7 Builds for App
Did not find build matching uploaded version yet, it might be still processing. Waiting 30 seconds to try again
...
Get Builds for App 1481211155
Found 8 Builds for App
Get Pre Release Versions for Build 0e793249-5584-4a13-8a1a-bd349c986820
Build 0e793249-5584-4a13-8a1a-bd349c986820 is still being processed, wait 30 seconds and check again
...
Get Build 0e793249-5584-4a13-8a1a-bd349c986820
Processing build 0e793249-5584-4a13-8a1a-bd349c986820 is completed

Published build is
-- Build --
Id: 0e793249-5584-4a13-8a1a-bd349c986820
Type: builds
Expired: False
Icon asset token: 
        Template url: https://is1-ssl.mzstatic.com/image/thumb/Purple115/v4/b9/bc/3c/b9bc3cbf-77a3-5067-afb2-1df9519c8925/Icon-83.5@2x.png.png/{w}x{h}bb.{f}
        Height: 167
        Width: 167
Min os version: 10.1
Processing state: VALID
Version: 1.0.56
Uses non exempt encryption: False
Uploaded date: 2021-06-10 08:27:00-07:00
Expiration date: 2021-09-08 08:27:00-07:00
-- Pre Release Version --
Id: c35a61b4-e6bb-4e93-bfed-b7655be3cca5
Type: preReleaseVersions
Platform: IOS
Version: 1.0
Creating new Beta App Review Submission: build: 0e793249-5584-4a13-8a1a-bd349c986820
-- Beta App Review Submission (Created) --
Id: 0e793249-5584-4a13-8a1a-bd349c986820
Type: betaAppReviewSubmissions
Beta review state: WAITING_FOR_REVIEW
Created Beta App Review Submission 0e793249-5584-4a13-8a1a-bd349c986820
```

Result in App Store Connect:
<img width="1487" alt="Screenshot 2021-06-10 at 18 34 58" src="https://user-images.githubusercontent.com/2756611/121554180-97d1c680-ca1a-11eb-819c-97d37e14fb41.png">
