### PR TITLE
Update error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.8.2
+-------------
+
+**Improvements**
+
+- Explicitly mention "certificate" in `app-store-connect` error messages when `--certificate-key` is missing to avoid confusion with App Store Connect API key `--private-key`.
+
 Version 0.8.1
 -------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Various utilities to simplify your builds at [codemagic.io](https://codemagic.io)
+# Codemagic CLI Tools
+
+Command line utilities for managing mobile app builds, code signing, and deployment. These power mobile app builds at [codemagic.io](https://codemagic.io).
 
 # Installing
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -388,7 +388,7 @@ class AppStoreConnect(cli.CliApp,
 
         private_key = _get_certificate_key(certificate_key, certificate_key_password)
         if private_key is None:
-            raise AppStoreConnectError('Cannot create resource without private key')
+            raise AppStoreConnectError('Cannot create resource without certificate private key')
 
         csr = Certificate.create_certificate_signing_request(private_key)
         csr_content = Certificate.get_certificate_signing_request_content(csr)
@@ -419,7 +419,7 @@ class AppStoreConnect(cli.CliApp,
 
         private_key = _get_certificate_key(certificate_key, certificate_key_password)
         if save and private_key is None:
-            raise AppStoreConnectError('Cannot save resource without private key')
+            raise AppStoreConnectError('Cannot save resource without certificate private key')
         else:
             assert private_key is not None
 
@@ -464,7 +464,7 @@ class AppStoreConnect(cli.CliApp,
 
         private_key = _get_certificate_key(certificate_key, certificate_key_password)
         if save and private_key is None:
-            raise AppStoreConnectError('Cannot create or save resource without private key')
+            raise AppStoreConnectError('Cannot create or save resource without certificate private key')
 
         if profile_type:
             certificate_type = CertificateType.from_profile_type(profile_type)
@@ -676,7 +676,7 @@ class AppStoreConnect(cli.CliApp,
 
         private_key = _get_certificate_key(certificate_key, certificate_key_password)
         if private_key is None:
-            raise AppStoreConnectError(f'Cannot save {SigningCertificate.s} without private key')
+            raise AppStoreConnectError(f'Cannot save {SigningCertificate.s} without certificate private key')
 
         bundle_ids = self._get_or_create_bundle_ids(
             bundle_id_identifier,


### PR DESCRIPTION
These error messages are returned when `--certificate-key` is not provided. This is really easy to confuse with App Store Connect `--private-key`, which can mislead users.

I've also updated the README to make it clear these tools are useful outside of codemagic.io.