### PR TITLE
Feature: Add option to configure max allowed duration for build processing by Apple for TestFlight submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Version 0.8.3
+-------------
+
+**Features**
+
+- Add `--max-build-processing-wait` option to configure maximum time that `app-store-connect publish` will wait for the package to be processed before failing the TestFlight submission.
+- Improve error message when waiting for package to be processed times out during TestFlight submission as part of `app-store-connect publish`.
+
+**Development / Docs**
+
+- Show default values for arguments of type `TypedCliArgument`. 
+
 Version 0.8.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -62,6 +62,11 @@ class Types:
         argument_type = bool
         environment_variable_key = 'APP_STORE_CONNECT_SKIP_PACKAGE_VALIDATION'
 
+    class MaxBuildProcessingWait(cli.TypedCliArgument[int]):
+        argument_type = int
+        environment_variable_key = 'APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT'
+        default_value = 20
+
 
 _API_DOCS_REFERENCE = f'Learn more at {AppStoreConnectApiClient.API_KEYS_DOCS_URL}.'
 
@@ -268,6 +273,19 @@ class PublishArgument(cli.Argument):
         argparse_kwargs={
             'required': False,
             'action': 'store_true',
+        },
+    )
+    MAX_BUILD_PROCESSING_WAIT = cli.ArgumentProperties(
+        key='max_build_processing_wait',
+        flags=('--max-build-processing-wait',),
+        type=Types.MaxBuildProcessingWait,
+        description=(
+            'Maximum amount of minutes to wait for the freshly uploaded build to be processed by '
+            'Apple and retry submitting the build for beta review. If the processing is not finished '
+            'within the specified timeframe, further submission will be terminated'
+        ),
+        argparse_kwargs={
+            'required': False,
         },
     )
 


### PR DESCRIPTION
After uploading binaries to App Store Connect it can take a while before builds are completely processed and can be submitted to external testing in TestFlight. There used to be a fixed 10 minute timeout for waiting until the build processing completes by Apple, but in practise ofterntimes it is not enough. This pull request bumps the default timeout to 20 minutes and adds configuration option to either decrease or increase this value by either using
- command line option `--max-build-processing-wait <minutes>`,
- or specifying environment variable `APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT=<minutes>`.

Example build in [Codemagic](https://codemagic.io) using [this](https://github.com/priitlatt/banaan-ios/blob/f5ea5bc26554c53b10722c10bf0a310918132703/codemagic.yaml) configuration:
![Screenshot 2021-06-17 at 14 38 01](https://user-images.githubusercontent.com/2756611/122389688-da932180-cf79-11eb-8634-e33955580e57.png)
