### PR TITLE
Resolve default locale from applicaiton test information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.8.4
+-------------
+
+**Features**
+
+- Remove default value from `--locale` option for actions `app-store-connect beta-build-localizations create` and `app-store-connect publish`. In case it is not provided, resolve the default locale value from related application's primary test information.
+
 Version 0.8.3
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Version 0.8.4
 
 - Remove default value from `--locale` option for actions `app-store-connect beta-build-localizations create` and `app-store-connect publish`. In case it is not provided, resolve the default locale value from related application's primary test information.
 
+**Development / Docs**
+
+- Update `app-store-connect publish` action docs.
+- Update `app-store-connect beta-build-localizations create` action docs.
+
 Version 0.8.3
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 0.8.4
 **Features**
 
 - Remove default value from `--locale` option for actions `app-store-connect beta-build-localizations create` and `app-store-connect publish`. In case it is not provided, resolve the default locale value from related application's primary test information.
+- Make `app-store-connect beta-build-localizations create` more forgiving and allow the cases when beta build localization already exists for the locale. On such occasions just update the resource.
 
 **Development / Docs**
 

--- a/docs/app-store-connect/beta-build-localizations/create.md
+++ b/docs/app-store-connect/beta-build-localizations/create.md
@@ -14,9 +14,9 @@ app-store-connect beta-build-localizations create [-h] [--log-stream STREAM] [--
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
+    [--locale LOCALE_DEFAULT]
     [--whats-new WHATS_NEW]
     BUILD_ID_RESOURCE_ID
-    --locale LOCALE
 ```
 ### Required arguments for action `create`
 
@@ -24,12 +24,12 @@ app-store-connect beta-build-localizations create [-h] [--log-stream STREAM] [--
 
 
 Alphanumeric ID value of the Build
+### Optional arguments for action `create`
+
 ##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
 
 
-The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes
-### Optional arguments for action `create`
-
+The locale code name for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale from test information is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes
 ##### `--whats-new, -n=WHATS_NEW`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -18,7 +18,7 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [--apple-id APPLE_ID]
     [--password APP_SPECIFIC_PASSWORD]
     [--testflight]
-    [--locale LOCALE_OPTIONAL_WITH_DEFAULT]
+    [--locale LOCALE_DEFAULT]
     [--whats-new WHATS_NEW]
     [--skip-package-validation]
     [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT]
@@ -44,7 +44,7 @@ Submit an app for Testflight beta app review to allow external testing
 ##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
 
 
-The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes. Default:&nbsp;`en-US`
+The locale code name for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale from test information is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes
 ##### `--whats-new, -n=WHATS_NEW`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/beta_app_localization.py
+++ b/src/codemagic/apple/resources/beta_app_localization.py
@@ -22,6 +22,10 @@ class BetaAppLocalization(Resource):
         privacyPolicyUrl: Optional[str]
         tvOsPrivacyPolicy: Optional[str]
 
+        def __post_init__(self):
+            if isinstance(self.locale, str):
+                self.locale = Locale(self.locale)
+
     @dataclass
     class Relationships(Resource.Relationships):
         app: Relationship

--- a/src/codemagic/apple/resources/beta_app_review_submission.py
+++ b/src/codemagic/apple/resources/beta_app_review_submission.py
@@ -16,6 +16,10 @@ class BetaAppReviewSubmission(Resource):
     class Attributes(Resource.Attributes):
         betaReviewState: BetaReviewState
 
+        def __post_init__(self):
+            if isinstance(self.betaReviewState, str):
+                self.betaReviewState = BetaReviewState(self.betaReviewState)
+
     @dataclass
     class Relationships(Resource.Relationships):
         build: Relationship

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -48,7 +48,7 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
     def create_beta_build_localization(
             self,
             build_id: ResourceId,
-            locale: Locale,
+            locale: Optional[Locale],
             whats_new: Optional[Types.WhatsNewArgument] = None,
             should_print: bool = True) -> BetaBuildLocalization:
         ...

--- a/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
@@ -31,7 +31,7 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
     @cli.action('list',
                 BuildArgument.BUILD_ID_RESOURCE_ID,
-                BuildArgument.LOCALE_OPTIONAL,
+                BuildArgument.LOCALE,
                 action_group=AppStoreConnectActionGroup.BETA_BUILDS_LOCALIZATIONS)
     def list_beta_build_localizations(
             self,
@@ -55,12 +55,15 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
     def create_beta_build_localization(
             self,
             build_id: ResourceId,
-            locale: Locale,
+            locale: Optional[Locale] = None,
             whats_new: Optional[Types.WhatsNewArgument] = None,
             should_print: bool = True) -> BetaBuildLocalization:
         """
         Create a beta build localization
         """
+        if locale is None:
+            locale = self._get_default_locale(build_id)
+
         return self._create_resource(
             self.api_client.beta_build_localizations,
             should_print,
@@ -98,3 +101,9 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             should_print,
             whats_new=whats_new.value if whats_new else None,
         )
+
+    def _get_default_locale(self, build_id: ResourceId) -> Locale:
+        app = self.api_client.builds.read_app(build_id)
+        beta_app_localizations = self.api_client.apps.list_beta_app_localizations(app)
+        default_beta_app_localization = beta_app_localizations[0]
+        return default_beta_app_localization.attributes.locale

--- a/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
@@ -31,7 +31,7 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
     @cli.action('list',
                 BuildArgument.BUILD_ID_RESOURCE_ID,
-                BuildArgument.LOCALE,
+                BuildArgument.LOCALE_OPTIONAL,
                 action_group=AppStoreConnectActionGroup.BETA_BUILDS_LOCALIZATIONS)
     def list_beta_build_localizations(
             self,
@@ -49,7 +49,7 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
     @cli.action('create',
                 BuildArgument.BUILD_ID_RESOURCE_ID,
-                BuildArgument.LOCALE,
+                BuildArgument.LOCALE_DEFAULT,
                 BuildArgument.WHATS_NEW,
                 action_group=AppStoreConnectActionGroup.BETA_BUILDS_LOCALIZATIONS)
     def create_beta_build_localization(

--- a/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
@@ -62,7 +62,9 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         Create a beta build localization
         """
         if locale is None:
-            locale = self._get_default_locale(build_id)
+            app = self.api_client.builds.read_app(build_id)
+            locale = self._get_application_default_locale(app.id)
+            self.logger.info('Using application %s primary locale %s for beta build localization')
 
         return self._create_resource(
             self.api_client.beta_build_localizations,
@@ -102,8 +104,7 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             whats_new=whats_new.value if whats_new else None,
         )
 
-    def _get_default_locale(self, build_id: ResourceId) -> Locale:
-        app = self.api_client.builds.read_app(build_id)
-        beta_app_localizations = self.api_client.apps.list_beta_app_localizations(app)
+    def _get_application_default_locale(self, app_id: ResourceId) -> Locale:
+        beta_app_localizations = self.api_client.apps.list_beta_app_localizations(app_id)
         default_beta_app_localization = beta_app_localizations[0]
         return default_beta_app_localization.attributes.locale

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -36,7 +36,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 PublishArgument.APPLE_ID,
                 PublishArgument.APP_SPECIFIC_PASSWORD,
                 PublishArgument.SUBMIT_TO_TESTFLIGHT,
-                BuildArgument.LOCALE,
+                BuildArgument.LOCALE_DEFAULT,
                 BuildArgument.WHATS_NEW,
                 PublishArgument.SKIP_PACKAGE_VALIDATION,
                 PublishArgument.MAX_BUILD_PROCESSING_WAIT,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -36,7 +36,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 PublishArgument.APPLE_ID,
                 PublishArgument.APP_SPECIFIC_PASSWORD,
                 PublishArgument.SUBMIT_TO_TESTFLIGHT,
-                BuildArgument.LOCALE_OPTIONAL_WITH_DEFAULT,
+                BuildArgument.LOCALE,
                 BuildArgument.WHATS_NEW,
                 PublishArgument.SKIP_PACKAGE_VALIDATION,
                 PublishArgument.MAX_BUILD_PROCESSING_WAIT,
@@ -46,7 +46,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 apple_id: Optional[str] = None,
                 app_specific_password: Optional[Types.AppSpecificPassword] = None,
                 submit_to_testflight: Optional[bool] = None,
-                locale: Locale = BuildArgument.LOCALE_OPTIONAL_WITH_DEFAULT.get_default(),
+                locale: Optional[Locale] = None,
                 whats_new: Optional[Types.WhatsNewArgument] = None,
                 skip_package_validation: Optional[bool] = None,
                 max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None) -> None:
@@ -115,7 +115,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
     def _submit_build_to_testflight(
         self,
         ipa: Ipa,
-        locale: Locale,
+        locale: Optional[Locale],
         whats_new: Optional[Types.WhatsNewArgument],
         max_processing_minutes: int,
     ):
@@ -123,7 +123,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         app = self._get_uploaded_build_application(ipa)
         build, pre_release_version = self._get_uploaded_build(app, ipa)
 
-        if locale and whats_new:
+        if whats_new:
             self.create_beta_build_localization(build.id, locale, whats_new)
 
         self._assert_app_has_testflight_information(app)

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -370,19 +370,10 @@ class BuildArgument(cli.Argument):
             'betabuildlocalizationcreaterequest/data/attributes'
         ),
         argparse_kwargs={
-            'required': True,
+            'required': False,
             'choices': list(Locale),
         },
     )
-    LOCALE_OPTIONAL = LOCALE.duplicate(argparse_kwargs={
-        'required': False,
-        'choices': list(Locale),
-    })
-    LOCALE_OPTIONAL_WITH_DEFAULT = LOCALE.duplicate(argparse_kwargs={
-        'required': False,
-        'choices': list(Locale),
-        'default': Locale('en-US'),
-    })
     WHATS_NEW = cli.ArgumentProperties(
         key='whats_new',
         flags=('--whats-new', '-n'),

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -360,7 +360,7 @@ class BuildArgument(cli.Argument):
         type=ResourceId,
         description='Alphanumeric ID value of the Beta Build Localization',
     )
-    LOCALE = cli.ArgumentProperties(
+    LOCALE_OPTIONAL = cli.ArgumentProperties(
         key='locale',
         flags=('--locale', '-l'),
         type=Locale,
@@ -373,6 +373,14 @@ class BuildArgument(cli.Argument):
             'required': False,
             'choices': list(Locale),
         },
+    )
+    LOCALE_DEFAULT = LOCALE_OPTIONAL.duplicate(
+        description=(
+            'The locale code name for displaying localized "What\'s new" content in TestFlight. '
+            "In case not provided, application's primary locale from test information is used instead. "
+            'Learn more from https://developer.apple.com/documentation/appstoreconnectapi/'
+            'betabuildlocalizationcreaterequest/data/attributes'
+        ),
     )
     WHATS_NEW = cli.ArgumentProperties(
         key='whats_new',


### PR DESCRIPTION
Actions `app-store-connect publish` and `app-store-connect beta-build-localizations create` defined a hardcoded default value `en-US` for `--locale` option. However, not all application entries in App Store Connect have `en-US` as the primary localization, which makes this decision kind or arbitrary. In order to better suit actual user needs and make the tool more user-friendly, omit default value entirely and when adding testing/what's new notes to build, find out what the application's primary test information locale is, and reuse that value.

Additionally, beta build localization resource is automatically created for default locale soon after the build itself is submitted to App Store Connect. In that case we just need to modify the resource. To better accomodate such case, make `app-store-connect beta-build-localizations create` a little less strict by allowing also locales as input that already have this resource. In this case just modify existing resource instead of failing the create request with `409` response.

Altogether new usage is as follows:
```bash
$ app-store-connect beta-build-localizations create b48608c6-47f2-439e-9d77-951390a4be89 --whats-new 'Exciting new features'
Using application Banaan Codemagic primary locale en-GB for beta build localization
Modify Beta Build Localization 4d4fe826-7b13-4096-afe3-cbe76098ce3b
Successfully modified Beta Build Localization 4d4fe826-7b13-4096-afe3-cbe76098ce3b
-- Beta Build Localization --
Id: 4d4fe826-7b13-4096-afe3-cbe76098ce3b
Type: betaBuildLocalizations
Locale: en-GB
Whats new: Exciting new features
```

