### PR TITLE
Bugfix: CLI argument error messages on invalid enum inputs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.8.4
+-------------
+
+**Development / Docs**
+
+- Do not use runtime enum definition generation during argument parsing.
+- Fix error messages for invalid enumeration values.
+
 Version 0.8.3
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -27,17 +27,20 @@ class ResourceEnumMeta(enum.EnumMeta):
                 raise
             logger = log.get_logger(cls, log_to_stream=False)
             logger.warning('Undefined Resource enumeration: %s', ve)
-            enum_class = _ResourceEnum(f'Graceful{cls.__name__}', {value: value})
-            return enum_class(value)
+            try:
+                enum_class = ResourceEnum(f'Graceful{cls.__name__}', {value: value})
+                return enum_class(value)
+            except TypeError:
+                raise ve
 
 
-class _ResourceEnum(enum.Enum, metaclass=ResourceEnumMeta):
+class ResourceEnum(enum.Enum, metaclass=ResourceEnumMeta):
 
     def __str__(self):
         return str(self.value)
 
 
-class AppStoreState(_ResourceEnum):
+class AppStoreState(ResourceEnum):
     DEVELOPER_REMOVED_FROM_SALE = 'DEVELOPER_REMOVED_FROM_SALE'
     DEVELOPER_REJECTED = 'DEVELOPER_REJECTED'
     IN_REVIEW = 'IN_REVIEW'
@@ -57,28 +60,28 @@ class AppStoreState(_ResourceEnum):
     REPLACED_WITH_NEW_VERSION = 'REPLACED_WITH_NEW_VERSION'
 
 
-class BetaReviewState(_ResourceEnum):
+class BetaReviewState(ResourceEnum):
     APPROVED = 'APPROVED'
     IN_REVIEW = 'IN_REVIEW'
     REJECTED = 'REJECTED'
     WAITING_FOR_REVIEW = 'WAITING_FOR_REVIEW'
 
 
-class BuildProcessingState(_ResourceEnum):
+class BuildProcessingState(ResourceEnum):
     PROCESSING = 'PROCESSING'
     FAILED = 'FAILED'
     INVALID = 'INVALID'
     VALID = 'VALID'
 
 
-class BundleIdPlatform(_ResourceEnum):
+class BundleIdPlatform(ResourceEnum):
     IOS = 'IOS'
     MAC_OS = 'MAC_OS'
     UNIVERSAL = 'UNIVERSAL'
     SERVICES = 'SERVICES'
 
 
-class CapabilityOptionKey(_ResourceEnum):
+class CapabilityOptionKey(ResourceEnum):
     XCODE_5 = 'XCODE_5'
     XCODE_6 = 'XCODE_6'
     COMPLETE_PROTECTION = 'COMPLETE_PROTECTION'
@@ -86,18 +89,18 @@ class CapabilityOptionKey(_ResourceEnum):
     PROTECTED_UNTIL_FIRST_USER_AUTH = 'PROTECTED_UNTIL_FIRST_USER_AUTH'
 
 
-class CapabilitySettingAllowedInstance(_ResourceEnum):
+class CapabilitySettingAllowedInstance(ResourceEnum):
     ENTRY = 'ENTRY'
     SINGLE = 'SINGLE'
     MULTIPLE = 'MULTIPLE'
 
 
-class CapabilitySettingKey(_ResourceEnum):
+class CapabilitySettingKey(ResourceEnum):
     ICLOUD_VERSION = 'ICLOUD_VERSION'
     DATA_PROTECTION_PERMISSION_LEVEL = 'DATA_PROTECTION_PERMISSION_LEVEL'
 
 
-class CapabilityType(_ResourceEnum):
+class CapabilityType(ResourceEnum):
     ACCESS_WIFI_INFORMATION = 'ACCESS_WIFI_INFORMATION'
     APP_GROUPS = 'APP_GROUPS'
     APPLE_PAY = 'APPLE_PAY'
@@ -123,7 +126,7 @@ class CapabilityType(_ResourceEnum):
     WIRELESS_ACCESSORY_CONFIGURATION = 'WIRELESS_ACCESSORY_CONFIGURATION'
 
 
-class CertificateType(_ResourceEnum):
+class CertificateType(ResourceEnum):
     DEVELOPER_ID_APPLICATION = 'DEVELOPER_ID_APPLICATION'
     DEVELOPER_ID_KEXT = 'DEVELOPER_ID_KEXT'
     DEVELOPMENT = 'DEVELOPMENT'
@@ -156,12 +159,12 @@ class CertificateType(_ResourceEnum):
             raise ValueError(f'Certificate type for profile type {profile_type} is unknown')
 
 
-class ContentRightsDeclaration(_ResourceEnum):
+class ContentRightsDeclaration(ResourceEnum):
     DOES_NOT_USE_THIRD_PARTY_CONTENT = 'DOES_NOT_USE_THIRD_PARTY_CONTENT'
     USES_THIRD_PARTY_CONTENT = 'USES_THIRD_PARTY_CONTENT'
 
 
-class DeviceClass(_ResourceEnum):
+class DeviceClass(ResourceEnum):
     APPLE_TV = 'APPLE_TV'
     APPLE_WATCH = 'APPLE_WATCH'
     IPAD = 'IPAD'
@@ -170,24 +173,24 @@ class DeviceClass(_ResourceEnum):
     MAC = 'MAC'
 
 
-class DeviceStatus(_ResourceEnum):
+class DeviceStatus(ResourceEnum):
     DISABLED = 'DISABLED'
     ENABLED = 'ENABLED'
 
 
-class Platform(_ResourceEnum):
+class Platform(ResourceEnum):
     IOS = 'IOS'
     MAC_OS = 'MAC_OS'
     TV_OS = 'TV_OS'
 
 
-class ProfileState(_ResourceEnum):
+class ProfileState(ResourceEnum):
     ACTIVE = 'ACTIVE'
     INVALID = 'INVALID'
     EXPIRED = 'EXPIRED'  # Undocumented Profile State
 
 
-class ProfileType(_ResourceEnum):
+class ProfileType(ResourceEnum):
     IOS_APP_ADHOC = 'IOS_APP_ADHOC'
     IOS_APP_DEVELOPMENT = 'IOS_APP_DEVELOPMENT'
     IOS_APP_INHOUSE = 'IOS_APP_INHOUSE'
@@ -222,13 +225,13 @@ class ProfileType(_ResourceEnum):
         return self.is_development_type or self.is_ad_hoc_type
 
 
-class ReleaseType(_ResourceEnum):
+class ReleaseType(ResourceEnum):
     MANUAL = 'MANUAL'
     AFTER_APPROVAL = 'AFTER_APPROVAL'
     SCHEDULED = 'SCHEDULED'
 
 
-class ResourceType(_ResourceEnum):
+class ResourceType(ResourceEnum):
     APPS = 'apps'
     APP_STORE_VERSIONS = 'appStoreVersions'
     APP_STORE_VERSION_SUBMISSIONS = 'appStoreVersionSubmissions'
@@ -245,7 +248,7 @@ class ResourceType(_ResourceEnum):
     PROFILES = 'profiles'
 
 
-class Locale(_ResourceEnum):
+class Locale(ResourceEnum):
     """
     Referenced in https://developer.apple.com/documentation/appstoreconnectapi/betaapplocalization/attributes#discussion
     """

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -167,10 +167,24 @@ class CliApp(metaclass=abc.ABCMeta):
         return os.environ.get('_CLI_INVOCATION') == 'true'
 
     @classmethod
+    def _resolve_cli_invocation_arg(cls):
+        from codemagic.apple.resources.enums import ResourceEnumMeta
+
+        parser = cls._setup_cli_options()
+        # Turn off graceful enumeration fallback to get proper error messages
+        ResourceEnumMeta.graceful_fallback = False
+        try:
+            args = parser.parse_args()
+        finally:
+            ResourceEnumMeta.graceful_fallback = True
+
+        return parser, args
+
+    @classmethod
     def invoke_cli(cls) -> NoReturn:
         os.environ['_CLI_INVOCATION'] = 'true'
-        parser = cls._setup_cli_options()
-        args = parser.parse_args()
+
+        parser, args = cls._resolve_cli_invocation_arg()
         cls._setup_logging(args)
 
         cls._log_cli_invoke_started()

--- a/src/codemagic/google_play/resources/enums.py
+++ b/src/codemagic/google_play/resources/enums.py
@@ -1,19 +1,19 @@
 import enum
 
 
-class _ResourceEnum(enum.Enum):
+class ResourceEnum(enum.Enum):
     def __str__(self):
         return str(self.value)
 
 
-class TrackName(_ResourceEnum):
+class TrackName(ResourceEnum):
     INTERNAL = 'internal'
     ALPHA = 'alpha'
     BETA = 'beta'
     PRODUCTION = 'production'
 
 
-class ReleaseStatus(_ResourceEnum):
+class ReleaseStatus(ResourceEnum):
     STATUS_UNSPECIFIED = 'statusUnspecified'
     DRAFT = 'draft'
     IN_PROGRESS = 'inProgress'

--- a/tests/apple/resources/enums/test_resource_enum.py
+++ b/tests/apple/resources/enums/test_resource_enum.py
@@ -1,0 +1,38 @@
+import pytest
+
+from codemagic.apple.resources.enums import ResourceEnum
+from codemagic.apple.resources.enums import ResourceEnumMeta
+
+
+class MockEnum(ResourceEnum):
+    A = 'A'
+    B = 'B'
+
+
+@pytest.mark.parametrize('enum_value', MockEnum.__members__.keys())
+def test_resource_enum(enum_value):
+    mock_enum = MockEnum(enum_value)
+    assert isinstance(mock_enum, MockEnum)
+    assert mock_enum.value == enum_value
+
+
+@pytest.mark.parametrize('enum_value', ('C', 'D', 'Lorem ipsum'))
+def test_resource_enum_graceful_fallback_on_strings(enum_value):
+    mock_enum = MockEnum(enum_value)
+    assert not isinstance(mock_enum, MockEnum)
+    assert MockEnum.__name__ in mock_enum.__class__.__name__
+    assert mock_enum.value == enum_value
+
+
+@pytest.mark.parametrize('enum_value', ((1, 2), 3.5, None, 4, 5, [], {}))
+def test_resource_enum_graceful_fallback_invalid_inputs(enum_value):
+    with pytest.raises(ValueError):
+        MockEnum(enum_value)
+
+
+@pytest.mark.parametrize('enum_value', ('C', 'D', 'Lorem ipsum'))
+def test_resource_enum_graceful_fallback_disabled(enum_value):
+    ResourceEnumMeta.graceful_fallback = False
+    with pytest.raises(ValueError):
+        MockEnum(enum_value)
+    ResourceEnumMeta.graceful_fallback = True


### PR DESCRIPTION
Due to changes introduced in PR #100 all enumeratations defined in `codemagic.apple.resources` are _loosely_ defined and all values are accepted as valid inputs. This causes CLI options with enum values to fall apart in case invalid enumeration is entered. For example:

```bash
$ app-store-connect publish --locale invalid-locale
usage: app-store-connect publish [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] [--path artifact-path [artifact-path ...]] [-u APPLE_ID]
                                 [-p APP_SPECIFIC_PASSWORD] [-t]
                                 [-l {da,de-DE,el,en-AU,en-CA,en-GB,en-US,es-ES,es-MX,fi,fr-CA,fr-FR,id,it,ja,ko,ms,nl-NL,no,pt-BR,pt-PT,ru,sv,th,tr,vi,zh-Hans,zh-Hant}] [-n WHATS_NEW]
                                 [--skip-package-validation] [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT] [--log-api-calls] [--json] [--issuer-id ISSUER_ID]
                                 [--key-id KEY_IDENTIFIER] [--private-key PRIVATE_KEY] [--certificates-dir CERTIFICATES_DIRECTORY] [--profiles-dir PROFILES_DIRECTORY]
app-store-connect publish: error: argument -l/--locale: invalid choice: <GracefulLocale.invalid-locale: 'invalid-locale'> (choose from <Locale.DA: 'da'>, <Locale.DE_DE: 'de-DE'>, <Locale.EL: 'el'>, <Locale.EN_AU: 'en-AU'>, <Locale.EN_CA: 'en-CA'>, <Locale.EN_GB: 'en-GB'>, <Locale.EN_US: 'en-US'>, <Locale.ES_ES: 'es-ES'>, <Locale.ES_MX: 'es-MX'>, <Locale.FI: 'fi'>, <Locale.FR_CA: 'fr-CA'>, <Locale.FR_FR: 'fr-FR'>, <Locale.ID: 'id'>, <Locale.IT: 'it'>, <Locale.JA: 'ja'>, <Locale.KO: 'ko'>, <Locale.MS: 'ms'>, <Locale.NL_NL: 'nl-NL'>, <Locale.NO: 'no'>, <Locale.PT_BR: 'pt-BR'>, <Locale.PT_PT: 'pt-PT'>, <Locale.RU: 'ru'>, <Locale.SV: 'sv'>, <Locale.TH: 'th'>, <Locale.TR: 'tr'>, <Locale.VI: 'vi'>, <Locale.ZH_HANS: 'zh-Hans'>, <Locale.ZH_HANT: 'zh-Hant'>)
```

Instead, we don't want that all values are supported for enumerations while CLI inputs are processed during program invocation. Desired result with the changes introduced in this pull request yields error message that is compatible with _normal_ enum values:

```bash
$ app-store-connect publish --locale invalid-locale
usage: app-store-connect publish [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] [--path artifact-path [artifact-path ...]] [--apple-id APPLE_ID]
                                    [--password APP_SPECIFIC_PASSWORD] [--testflight]
                                    [--locale {da,de-DE,el,en-AU,en-CA,en-GB,en-US,es-ES,es-MX,fi,fr-CA,fr-FR,id,it,ja,ko,ms,nl-NL,no,pt-BR,pt-PT,ru,sv,th,tr,vi,zh-Hans,zh-Hant}]
                                    [--whats-new WHATS_NEW] [--skip-package-validation] [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT] --kana {kikerikii,bagaak} [--log-api-calls]
                                    [--json] [--issuer-id ISSUER_ID] [--key-id KEY_IDENTIFIER] [--private-key PRIVATE_KEY] [--certificates-dir CERTIFICATES_DIRECTORY]
                                    [--profiles-dir PROFILES_DIRECTORY]
app-store-connect publish: error: argument --locale/-l: invalid Locale value: 'invalid-locale'
```