### PR TITLE
Feature: Support multiple beta build localizations for TestFlight publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+Version 0.8.5
+-------------
+
+**Features**
+
+- Make `--whats-new` option independent of `--testflight` for `app-store-connect publish` since submission to external beta review is not necessary to specify notes.
+- Make App Store Connect application entry default locale detection more robust by using `primaryLocale` attribute instead of using the first `betaAppLocalization` for that app.
+- Show more descriptive error messages for invalid inputs to CLI arguments that can be defined using `@env:<var_name>` and `@file:<file_path>` notations.
+- Add more blue and green colors to logs to indicate the start of an activity and completion of it.
+
+**Development / Docs**
+
+- Allow `str` input for `whats_new` arguments to actions defined in `BetaBuildLocalizationsActionGroup`.
+- Remove obsolete test which verified that `--whats-new` could only be used together with `--testflight`.
+- Update `app-store-connect publish` action docs.
+
 Version 0.8.4
 -------------
 

--- a/doc.py
+++ b/doc.py
@@ -62,6 +62,18 @@ class ArgumentsSerializer:
         self.required_args: List[SerializedArgument]
         self.optional_args: List[SerializedArgument]
 
+    @classmethod
+    def _replace_quotes(cls, description: str) -> str:
+        json_array = re.compile(r'"(\[[^\]]+\])"')
+        # Dummy handling for description containing JSON arrays as an examples
+        if not json_array.search(description):
+            return description.replace('"', '`')
+
+        before, array, after = json_array.split(description)
+        before = before.replace('"', '`')
+        after = after.replace('"', '`')
+        return f'{before}`{array}`{after}'
+
     def serialize(self) -> ArgumentsSerializer:
         def _serialize(arg) -> SerializedArgument:
             description = str_plain(arg._value_.description)
@@ -70,7 +82,8 @@ class ArgumentsSerializer:
                 description = str_plain(arg.get_description())
                 env_var = arg_type.__dict__.get('environment_variable_key')
                 if env_var:
-                    description = re.sub(f'({env_var}| {arg._name_} )', r'`\1`', description).replace('"', '`')
+                    description = re.sub(f'({env_var}| {arg._name_} )', r'`\1`', description)
+                    description = self._replace_quotes(description)
 
             kwargs = self._proccess_kwargs(getattr(arg._value_, 'argparse_kwargs'))
             return SerializedArgument(

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -53,7 +53,7 @@ Describe the changes and additions to the build and indicate the features you wo
 ##### `--beta-build-localizations=BETA_BUILD_LOCALIZATIONS`
 
 
-Localized beta test info for what's new in the uploaded build as JSON encoded list. For example `[{`locale`: `en-US`, `whats_new`: `What's new in english`}]`. See `--locale` for possible locale options. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering` BETA_BUILD_LOCALIZATIONS `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
+Localized beta test info for what's new in the uploaded build as JSON encoded list. For example `[{"locale": "en-US", "whats_new": "What's new in english"}]`. See `--locale` for possible locale options. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering` BETA_BUILD_LOCALIZATIONS `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
 ##### `--skip-package-validation`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -53,7 +53,7 @@ Describe the changes and additions to the build and indicate the features you wo
 ##### `--beta-build-localizations=BETA_BUILD_LOCALIZATIONS`
 
 
-Localized beta test info for what's new in the uploaded build as JSON encoded list. For example `[{"locale": "en-US", "whats_new": "What's new in english"}]`. See `--locale` for possible locale options. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering` BETA_BUILD_LOCALIZATIONS `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
+Localized beta test info for what's new in the uploaded build as a JSON encoded list. For example, `[{"locale": "en-US", "whats_new": "What's new in English"}]`. See `--locale` for possible locale options. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering` BETA_BUILD_LOCALIZATIONS `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
 ##### `--skip-package-validation`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -20,6 +20,7 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [--testflight]
     [--locale LOCALE_DEFAULT]
     [--whats-new WHATS_NEW]
+    [--beta-build-localizations BETA_BUILD_LOCALIZATIONS]
     [--skip-package-validation]
     [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT]
 ```
@@ -49,6 +50,10 @@ The locale code name for displaying localized "What's new" content in TestFlight
 
 
 Describe the changes and additions to the build and indicate the features you would like your users to tests. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_WHATS_NEW`. Alternatively to entering` WHATS_NEW `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
+##### `--beta-build-localizations=BETA_BUILD_LOCALIZATIONS`
+
+
+Localized beta test info for what's new in the uploaded build as JSON encoded list. For example `[{`locale`: `en-US`, `whats_new`: `What's new in english`}]`. See `--locale` for possible locale options. If not given, the value will be checked from environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering` BETA_BUILD_LOCALIZATIONS `in plaintext, it may also be specified using a `@env:` prefix followed by a environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.
 ##### `--skip-package-validation`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.4'
+__version__ = '0.8.5'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import enum
 from typing import Optional
 
@@ -32,6 +33,16 @@ class ResourceEnumMeta(enum.EnumMeta):
                 return enum_class(value)
             except TypeError:
                 raise ve
+
+    @staticmethod
+    @contextlib.contextmanager
+    def without_graceful_fallback():
+        original_value = ResourceEnumMeta.graceful_fallback
+        ResourceEnumMeta.graceful_fallback = False
+        try:
+            yield
+        finally:
+            ResourceEnumMeta.graceful_fallback = original_value
 
 
 class ResourceEnum(enum.Enum, metaclass=ResourceEnumMeta):

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -132,10 +132,12 @@ class EnvironmentArgumentValue(TypedCliArgument[T], metaclass=abc.ABCMeta):
     def get_description(cls, properties: 'ArgumentProperties', include_default=True) -> str:
         description = super().get_description(properties, include_default=False)
         usage = f'Alternatively to entering {Colors.CYAN(properties.key.upper())} in plaintext, ' \
-                f'it may also be specified using a "@env:" prefix followed by a environment variable name, ' \
-                f'or "@file:" prefix followed by a path to the file containing the value.'
-        example = 'Example: "@env:<variable>" uses the value in the environment variable named "<variable>", ' \
-                  'and "@file:<file_path>" uses the value from file at "<file_path>".'
+                f'it may also be specified using a "{Colors.WHITE("@env:")}" prefix followed ' \
+                f'by a environment variable name, or "{Colors.WHITE("@file:")}" prefix followed ' \
+                f'by a path to the file containing the value.'
+        example = f'Example: "{Colors.WHITE("@env:<variable>")}" uses the value in the environment variable ' \
+                  f'named "{Colors.WHITE("<variable>")}", and "{Colors.WHITE("@file:<file_path>")}" ' \
+                  f'uses the value from file at "{Colors.WHITE("<file_path>")}".'
 
         if include_default:
             try:

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -49,7 +49,7 @@ class TypedCliArgument(Generic[T], metaclass=abc.ABCMeta):
     def _apply_type(cls, non_typed_value: str) -> T:
         value = cls.argument_type(non_typed_value)
         if not cls._is_valid(value):
-            raise ValueError(f'Provided value "{value}" is not valid')
+            raise argparse.ArgumentTypeError(f'Provided value "{value}" is not valid')
         return value
 
     def _parse_value(self) -> T:

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -5,6 +5,7 @@ import pathlib
 from abc import ABCMeta
 from typing import List
 from typing import Optional
+from typing import Union
 
 from codemagic.apple import AppStoreConnectApiClient
 from codemagic.apple.app_store_connect import IssuerId
@@ -49,7 +50,7 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
             self,
             build_id: ResourceId,
             locale: Optional[Locale],
-            whats_new: Optional[Types.WhatsNewArgument] = None,
+            whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None,
             should_print: bool = True) -> BetaBuildLocalization:
         ...
 

--- a/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/beta_build_localizations_action_group.py
@@ -66,7 +66,7 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         """
         if locale is None:
             app = self.api_client.builds.read_app(build_id)
-            locale = self._get_application_default_locale(app.id)
+            locale = Locale(app.attributes.primaryLocale)
             msg_template = 'Using application %s primary locale %s for beta build localization'
             self.logger.info(msg_template, app.attributes.name, locale.value)
 
@@ -121,11 +121,6 @@ class BetaBuildLocalizationsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             should_print,
             whats_new=self._get_whats_new_value(whats_new),
         )
-
-    def _get_application_default_locale(self, app_id: ResourceId) -> Locale:
-        beta_app_localizations = self.api_client.apps.list_beta_app_localizations(app_id)
-        default_beta_app_localization = beta_app_localizations[0]
-        return default_beta_app_localization.attributes.locale
 
     @classmethod
     def _get_whats_new_value(cls, whats_new: Optional[Union[str, Types.WhatsNewArgument]]) -> Optional[str]:

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -38,6 +38,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 PublishArgument.SUBMIT_TO_TESTFLIGHT,
                 BuildArgument.LOCALE_DEFAULT,
                 BuildArgument.WHATS_NEW,
+                BuildArgument.BETA_BUILD_LOCALIZATIONS,
                 PublishArgument.SKIP_PACKAGE_VALIDATION,
                 PublishArgument.MAX_BUILD_PROCESSING_WAIT,
                 action_options={'requires_api_client': False})
@@ -48,11 +49,15 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 submit_to_testflight: Optional[bool] = None,
                 locale: Optional[Locale] = None,
                 whats_new: Optional[Types.WhatsNewArgument] = None,
+                beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
                 skip_package_validation: Optional[bool] = None,
                 max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None) -> None:
         """
         Publish application packages to App Store and submit them to Testflight
         """
+
+        # TODO: Make use of given beta_build_localizations.
+        _ = beta_build_localizations
 
         # Workaround to support overriding default value by environment variable.
         if max_build_processing_wait:

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -148,11 +148,11 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self.create_beta_app_review_submission(build.id)
 
     def _find_build(
-            self,
-            app_id: ResourceId,
-            application_package: Union[Ipa, MacOsPackage],
-            retries: int = 10,
-            retry_wait_seconds: int = 30,
+        self,
+        app_id: ResourceId,
+        application_package: Union[Ipa, MacOsPackage],
+        retries: int = 10,
+        retry_wait_seconds: int = 30,
     ) -> Build:
         """
         Find corresponding build for the uploaded ipa or macOS package.

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -190,10 +190,10 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             raise IOError(f'Did not find corresponding build from App Store versions for "{application_package.path}"')
 
     def _wait_until_build_is_processed(
-            self,
-            build: Build,
-            max_processing_minutes: int,
-            retry_wait_seconds: int = 30,
+        self,
+        build: Build,
+        max_processing_minutes: int,
+        retry_wait_seconds: int = 30,
     ) -> Build:
         self.logger.info(Colors.BLUE('\nWait until processing build %s is completed'), build.id)
 

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -121,7 +121,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
     def _handle_ipa_testflight_submission(
             self,
             ipa: Ipa,
-            submit_to_testflight: bool,
+            submit_to_testflight: Optional[bool],
             beta_build_infos: Sequence[BetaBuildInfo],
             max_processing_minutes: int,
     ):

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -132,17 +132,17 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         build = self._get_uploaded_build(app, ipa)
 
         if beta_build_infos:
-            self._submit_beta_build_localization_infos(ipa, build, beta_build_infos)
+            self._submit_beta_build_localization_infos(build, beta_build_infos)
         if submit_to_testflight:
-            self._submit_build_to_testflight(ipa, build, app, max_processing_minutes)
+            self._submit_build_to_testflight(build, app, max_processing_minutes)
 
-    def _submit_beta_build_localization_infos(self, ipa: Ipa, build: Build, beta_build_infos: Sequence[BetaBuildInfo]):
-        self.logger.info(Colors.BLUE('\nUpdate beta build localization info in TestFlight for %s'), ipa.path)
+    def _submit_beta_build_localization_infos(self, build: Build, beta_build_infos: Sequence[BetaBuildInfo]):
+        self.logger.info(Colors.BLUE('\nUpdate beta build localization info in TestFlight for uploaded build'))
         for info in beta_build_infos:
             self.create_beta_build_localization(build_id=build.id, locale=info.locale, whats_new=info.whats_new)
 
-    def _submit_build_to_testflight(self, ipa: Ipa, build: Build, app: App, max_processing_minutes: int):
-        self.logger.info(Colors.BLUE('\nSubmit %s to TestFlight'), ipa.path)
+    def _submit_build_to_testflight(self, build: Build, app: App, max_processing_minutes: int):
+        self.logger.info(Colors.BLUE('\nSubmit uploaded build to TestFlight beta review'))
         self._assert_app_has_testflight_information(app)
         build = self._wait_until_build_is_processed(build, max_processing_minutes)
         self.create_beta_app_review_submission(build.id)

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -120,11 +120,11 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self._upload_artifact_with_altool(altool, application_package.path)
 
     def _handle_ipa_testflight_submission(
-            self,
-            ipa: Ipa,
-            submit_to_testflight: Optional[bool],
-            beta_build_infos: Sequence[BetaBuildInfo],
-            max_processing_minutes: int,
+        self,
+        ipa: Ipa,
+        submit_to_testflight: Optional[bool],
+        beta_build_infos: Sequence[BetaBuildInfo],
+        max_processing_minutes: int,
     ):
         if not beta_build_infos and not submit_to_testflight:
             return  # Nothing to do with the ipa...

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -1,11 +1,16 @@
+import json
 import pathlib
 import re
+from argparse import ArgumentTypeError
+from collections import Counter
+from typing import List
 
 from codemagic import cli
 from codemagic.apple.app_store_connect import AppStoreConnectApiClient
 from codemagic.apple.app_store_connect import IssuerId
 from codemagic.apple.app_store_connect import KeyIdentifier
 from codemagic.apple.resources import AppStoreState
+from codemagic.apple.resources import BetaBuildLocalization
 from codemagic.apple.resources import BuildProcessingState
 from codemagic.apple.resources import BundleIdPlatform
 from codemagic.apple.resources import CertificateType
@@ -66,6 +71,45 @@ class Types:
         argument_type = int
         environment_variable_key = 'APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT'
         default_value = 20
+
+    class BetaBuildLocalizations(cli.EnvironmentArgumentValue[List[BetaBuildLocalization.Attributes]]):
+        argument_type = List[BetaBuildLocalization.Attributes]
+        environment_variable_key = 'APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS'
+        example_value = json.dumps([{'locale': 'en-US', 'whats_new': "What's new in english"}])
+
+        @classmethod
+        def _apply_type(cls, non_typed_value: str) -> List[BetaBuildLocalization.Attributes]:
+            try:
+                given_beta_build_localizations = json.loads(non_typed_value)
+                assert isinstance(given_beta_build_localizations, list)
+            except (ValueError, AssertionError):
+                raise ArgumentTypeError('Provided value is not a valid JSON encoded list')
+
+            beta_build_localization_attributes: List[BetaBuildLocalization.Attributes] = []
+            error_prefix = 'Invalid beta build localization'
+            for i, bbl in enumerate(given_beta_build_localizations):
+                try:
+                    attributes = BetaBuildLocalization.Attributes(
+                        locale=Locale(bbl['locale']),
+                        whatsNew=bbl['whats_new'],
+                    )
+                except TypeError:  # Given beta build localization is not a dictionary
+                    raise ArgumentTypeError(f'{error_prefix} on index {i}: {bbl!r}')
+                except ValueError as ve:  # Invalid locale
+                    raise ArgumentTypeError(f'{error_prefix} on index {i}, {ve}: {bbl!r}')
+                except KeyError as ke:  # Required key is missing from input
+                    raise ArgumentTypeError(f'{error_prefix} on index {i}, missing {ke.args[0]}: {bbl!r}')
+                beta_build_localization_attributes.append(attributes)
+
+            locales = Counter(a.locale for a in beta_build_localization_attributes)
+            duplicate_locales = {locale.value for locale, used_count in locales.items() if used_count > 1}
+            if duplicate_locales:
+                raise ArgumentTypeError((
+                    f'Ambiguous definitions for locale(s) {", ".join(duplicate_locales)}. '
+                    'Please define beta build localization for each locale exactly once.'
+                ))
+
+            return beta_build_localization_attributes
 
 
 _API_DOCS_REFERENCE = f'Learn more at {AppStoreConnectApiClient.API_KEYS_DOCS_URL}.'
@@ -389,6 +433,19 @@ class BuildArgument(cli.Argument):
         description=(
             'Describe the changes and additions to the build and indicate '
             'the features you would like your users to tests.'
+        ),
+        argparse_kwargs={
+            'required': False,
+        },
+    )
+    BETA_BUILD_LOCALIZATIONS = cli.ArgumentProperties(
+        key='beta_build_localizations',
+        flags=('--beta-build-localizations',),
+        type=Types.BetaBuildLocalizations,
+        description=(
+            "Localized beta test info for what's new in the uploaded build as JSON encoded list. "
+            f'For example {Colors.WHITE(f"`{Types.BetaBuildLocalizations.example_value}`")}. '
+            f'See {Colors.WHITE(f"`{LOCALE_OPTIONAL.flags[0]}`")} for possible locale options.'
         ),
         argparse_kwargs={
             'required': False,

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -449,8 +449,8 @@ class BuildArgument(cli.Argument):
         type=Types.BetaBuildLocalizations,
         description=(
             "Localized beta test info for what's new in the uploaded build as JSON encoded list. "
-            f'For example {Colors.WHITE(f"`{Types.BetaBuildLocalizations.example_value}`")}. '
-            f'See {Colors.WHITE(f"`{LOCALE_OPTIONAL.flags[0]}`")} for possible locale options.'
+            f'For example "{Colors.WHITE(Types.BetaBuildLocalizations.example_value)}". '
+            f'See "{Colors.WHITE(LOCALE_OPTIONAL.flags[0])}" for possible locale options.'
         ),
         argparse_kwargs={
             'required': False,

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -82,7 +82,7 @@ class Types:
     class BetaBuildLocalizations(cli.EnvironmentArgumentValue[List[BetaBuildInfo]]):
         argument_type = List[BetaBuildInfo]
         environment_variable_key = 'APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS'
-        example_value = json.dumps([{'locale': 'en-US', 'whats_new': "What's new in english"}])
+        example_value = json.dumps([{'locale': 'en-US', 'whats_new': "What's new in English"}])
 
         @classmethod
         def _apply_type(cls, non_typed_value: str) -> List[BetaBuildInfo]:
@@ -448,8 +448,8 @@ class BuildArgument(cli.Argument):
         flags=('--beta-build-localizations',),
         type=Types.BetaBuildLocalizations,
         description=(
-            "Localized beta test info for what's new in the uploaded build as JSON encoded list. "
-            f'For example "{Colors.WHITE(Types.BetaBuildLocalizations.example_value)}". '
+            "Localized beta test info for what's new in the uploaded build as a JSON encoded list. "
+            f'For example, "{Colors.WHITE(Types.BetaBuildLocalizations.example_value)}". '
             f'See "{Colors.WHITE(LOCALE_OPTIONAL.flags[0])}" for possible locale options.'
         ),
         argparse_kwargs={

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -83,7 +83,7 @@ class Types:
                 given_beta_build_localizations = json.loads(non_typed_value)
                 assert isinstance(given_beta_build_localizations, list)
             except (ValueError, AssertionError):
-                raise ArgumentTypeError('Provided value is not a valid JSON encoded list')
+                raise ArgumentTypeError(f'Provided value {non_typed_value!r} is not a valid JSON encoded list')
 
             beta_build_localization_attributes: List[BetaBuildLocalization.Attributes] = []
             error_prefix = 'Invalid beta build localization'
@@ -94,11 +94,11 @@ class Types:
                         whatsNew=bbl['whats_new'],
                     )
                 except TypeError:  # Given beta build localization is not a dictionary
-                    raise ArgumentTypeError(f'{error_prefix} on index {i}: {bbl!r}')
+                    raise ArgumentTypeError(f'{error_prefix} value {bbl!r} on index {i}')
                 except ValueError as ve:  # Invalid locale
-                    raise ArgumentTypeError(f'{error_prefix} on index {i}, {ve}: {bbl!r}')
+                    raise ArgumentTypeError(f'{error_prefix} on index {i}, {ve} in {bbl!r}')
                 except KeyError as ke:  # Required key is missing from input
-                    raise ArgumentTypeError(f'{error_prefix} on index {i}, missing {ke.args[0]}: {bbl!r}')
+                    raise ArgumentTypeError(f'{error_prefix} on index {i}, missing {ke.args[0]} in {bbl!r}')
                 beta_build_localization_attributes.append(attributes)
 
             locales = Counter(a.locale for a in beta_build_localization_attributes)

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -103,7 +103,7 @@ class ResourcePrinter:
             self.logger.info(Colors.GREEN(f'Filtered out {count} {name} {constraint}'))
 
     def log_delete(self, resource_type: Type[R], resource_id: ResourceId):
-        self.logger.info(f'Delete {resource_type} {resource_id}')
+        self.logger.info(Colors.BLUE(f'Delete {resource_type} {resource_id}'))
 
     def log_ignore_not_deleted(self, resource_type: Type[R], resource_id: ResourceId):
         self.logger.info(f'{resource_type} {resource_id} does not exist, did not delete.')
@@ -116,7 +116,7 @@ class ResourcePrinter:
         self.logger.info(Colors.GREEN(f'Saved {resource.__class__} {resource.get_display_info()} to {destination}'))
 
     def log_modify(self, resource_type: Type[R], resource_id: ResourceId):
-        self.logger.info(f'Modify {resource_type} {resource_id}')
+        self.logger.info(Colors.BLUE(f'Modify {resource_type} {resource_id}'))
 
     def log_modified(self, resource_type: Type[R], resource_id: ResourceId):
         self.logger.info(Colors.GREEN(f'Successfully modified {resource_type} {resource_id}'))

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -50,6 +50,7 @@ from ._app_store_connect.actions import PublishAction
 from ._app_store_connect.arguments import AppArgument
 from ._app_store_connect.arguments import AppStoreConnectArgument
 from ._app_store_connect.arguments import AppStoreVersionArgument
+from ._app_store_connect.arguments import BetaBuildInfo  # noqa: F401
 from ._app_store_connect.arguments import BuildArgument
 from ._app_store_connect.arguments import BundleIdArgument
 from ._app_store_connect.arguments import CertificateArgument

--- a/tests/apple/resources/enums/test_resource_enum.py
+++ b/tests/apple/resources/enums/test_resource_enum.py
@@ -36,3 +36,12 @@ def test_resource_enum_graceful_fallback_disabled(enum_value):
     with pytest.raises(ValueError):
         MockEnum(enum_value)
     ResourceEnumMeta.graceful_fallback = True
+
+
+@pytest.mark.parametrize('is_graceful_before', [True, False])
+def test_context_manager(is_graceful_before):
+    ResourceEnumMeta.graceful_fallback = is_graceful_before
+    with ResourceEnumMeta.without_graceful_fallback():
+        with pytest.raises(ValueError):
+            MockEnum('invalid value')
+    assert ResourceEnumMeta.graceful_fallback is is_graceful_before

--- a/tests/tools/app_store_connect/arguments/test_beta_build_localizations.py
+++ b/tests/tools/app_store_connect/arguments/test_beta_build_localizations.py
@@ -92,8 +92,8 @@ def test_from_file(valid_input, expected_valid_result):
     ('[{"locale": "en-US", "whats_new": "..."}, 1]', 'Invalid beta build localization value 1 on index 1'),
     ('[{"locale": "en-US", "whats_new": "..."}, []]', 'Invalid beta build localization value [] on index 1'),
     (
-            '[{"locale": "en-US", "whats_new": "..."}, "lorem ipsum"]',
-            "Invalid beta build localization value 'lorem ipsum' on index 1",
+        '[{"locale": "en-US", "whats_new": "..."}, "lorem ipsum"]',
+        "Invalid beta build localization value 'lorem ipsum' on index 1",
     ),
 ])
 def test_invalid_input(given_input, expected_error):

--- a/tests/tools/app_store_connect/arguments/test_beta_build_localizations.py
+++ b/tests/tools/app_store_connect/arguments/test_beta_build_localizations.py
@@ -1,0 +1,103 @@
+import json
+import os
+import tempfile
+from argparse import ArgumentTypeError
+
+import pytest
+
+from codemagic.apple.resources import Locale
+from codemagic.apple.resources.enums import ResourceEnumMeta
+from codemagic.tools.app_store_connect import BetaBuildInfo
+from codemagic.tools.app_store_connect import Types
+
+
+@pytest.fixture()
+def valid_input() -> str:
+    return json.dumps([
+        {
+            'locale': 'en-GB',
+            'whats_new': 'en-GB notes',
+        },
+        {
+            'locale': 'en-US',
+            'whats_new': 'en-US notes',
+        },
+        {
+            'locale': 'fi',
+            'whats_new': 'fi notes',
+        },
+    ])
+
+
+@pytest.fixture()
+def expected_valid_result():
+    return [
+        BetaBuildInfo(whats_new='en-GB notes', locale=Locale.EN_GB),
+        BetaBuildInfo(whats_new='en-US notes', locale=Locale.EN_US),
+        BetaBuildInfo(whats_new='fi notes', locale=Locale.FI),
+    ]
+
+
+def test_empty_input():
+    beta_build_localizations = Types.BetaBuildLocalizations('[]')
+    assert beta_build_localizations.value == []
+
+
+def test_from_str(valid_input, expected_valid_result):
+    beta_build_localizations = Types.BetaBuildLocalizations(valid_input)
+    assert beta_build_localizations.value == expected_valid_result
+
+
+def test_env_default(valid_input, expected_valid_result):
+    os.environ[Types.BetaBuildLocalizations.environment_variable_key] = valid_input
+    beta_build_localizations = Types.BetaBuildLocalizations.from_environment_variable_default()
+    assert beta_build_localizations.value == expected_valid_result
+
+
+def test_from_env(valid_input, expected_valid_result):
+    env_var = 'WHATS_NEW'
+    os.environ[env_var] = valid_input
+    beta_build_localizations = Types.BetaBuildLocalizations(f'@env:{env_var}')
+    assert beta_build_localizations.value == expected_valid_result
+
+
+def test_from_file(valid_input, expected_valid_result):
+    with tempfile.NamedTemporaryFile() as tf:
+        tf.write(valid_input.encode())
+        tf.flush()
+        beta_build_localizations = Types.BetaBuildLocalizations(f'@file:{tf.name}')
+    assert beta_build_localizations.value == expected_valid_result
+
+
+@pytest.mark.parametrize('given_input, expected_error', [
+    ('{P}', "Provided value '{P}' is not a valid JSON encoded list"),
+    ('1', "Provided value '1' is not a valid JSON encoded list"),
+    ('{}', "Provided value '{}' is not a valid JSON encoded list"),
+    ('Some string', "Provided value 'Some string' is not a valid JSON encoded list"),
+    ('', "Provided value '' is not a valid JSON encoded list"),
+    ('[{"whats_new": "..."}]', "Invalid beta build localization on index 0, missing locale in {'whats_new': '...'}"),
+    ('[{"locale": "en-US"}]', "Invalid beta build localization on index 0, missing whats_new in {'locale': 'en-US'}"),
+    (
+        '[{"locale": "il", "whats_new": "?"}]',
+        "Invalid beta build localization on index 0, 'il' is not a valid Locale in {'locale': 'il', 'whats_new': '?'}",
+    ),
+    (
+        '[{"locale": "en-US", "whats_new": "..."}, {}]',
+        'Invalid beta build localization on index 1, missing whats_new in {}',
+    ),
+    (
+        '[{"locale": "fi", "whats_new": "..."}, {"locale": "fi", "whats_new": "..."}]',
+        'Ambiguous definitions for locale(s) fi. Please define beta build localization for each locale exactly once.',
+    ),
+    ('[{"locale": "en-US", "whats_new": "..."}, 1]', 'Invalid beta build localization value 1 on index 1'),
+    ('[{"locale": "en-US", "whats_new": "..."}, []]', 'Invalid beta build localization value [] on index 1'),
+    (
+            '[{"locale": "en-US", "whats_new": "..."}, "lorem ipsum"]',
+            "Invalid beta build localization value 'lorem ipsum' on index 1",
+    ),
+])
+def test_invalid_input(given_input, expected_error):
+    with ResourceEnumMeta.without_graceful_fallback():
+        with pytest.raises(ArgumentTypeError) as exc_info:
+            Types.BetaBuildLocalizations(given_input)
+    assert str(exc_info.value) == expected_error

--- a/tests/tools/app_store_connect/test_from_cli_args.py
+++ b/tests/tools/app_store_connect/test_from_cli_args.py
@@ -59,7 +59,7 @@ def test_invalid_private_key_from_env(namespace_kwargs):
     os.environ[Types.PrivateKeyArgument.environment_variable_key] = 'this is not a private key'
     namespace_kwargs[AppStoreConnectArgument.PRIVATE_KEY.key] = None
     cli_args = argparse.Namespace(**{k: v for k, v in namespace_kwargs.items()})
-    with pytest.raises(argparse.ArgumentError) as exception_info:
+    with pytest.raises(argparse.ArgumentTypeError) as exception_info:
         AppStoreConnect.from_cli_args(cli_args)
     assert 'this is not a private key' in str(exception_info.value)
 

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -11,7 +11,6 @@ from codemagic.apple.resources import Locale
 from codemagic.models.application_package import Ipa
 from codemagic.tools.app_store_connect import AppStoreConnect
 from codemagic.tools.app_store_connect import AppStoreConnectArgument
-from codemagic.tools.app_store_connect import BuildArgument
 from codemagic.tools.app_store_connect import PublishArgument
 from codemagic.tools.app_store_connect import Types
 
@@ -74,22 +73,6 @@ def test_publish_action_with_username_and_password(_mock_altool, publishing_name
         mock_get_packages.assert_called_with(patterns)
 
 
-def test_publish_action_with_localization_and_no_testflight_submission(publishing_namespace_kwargs, cli_argument_group):
-    BuildArgument.WHATS_NEW.register(cli_argument_group)
-    cli_args = argparse.Namespace(**publishing_namespace_kwargs)
-    patterns = [pathlib.Path('path.pattern')]
-    locale = Locale('en-GB')
-
-    with pytest.raises(argparse.ArgumentError) as error_info:
-        AppStoreConnect.from_cli_args(cli_args).publish(
-            application_package_path_patterns=patterns,
-            locale=locale,
-            whats_new=Types.WhatsNewArgument("What's new"),
-        )
-
-    assert str(error_info.value) == 'argument --whats-new/-n: --testflight is required for submitting notes'
-
-
 def test_publish_action_testflight_with_localization(publishing_namespace_kwargs):
     cli_args = argparse.Namespace(**publishing_namespace_kwargs)
     with mock.patch.object(AppStoreConnect, 'find_paths') as mock_find_paths, \
@@ -106,7 +89,7 @@ def test_publish_action_testflight_with_localization(publishing_namespace_kwargs
         mock_get_packages.return_value = [mock.create_autospec(Ipa, instance=True, path=ipa_path)]
         build = mock.Mock(id='1525e3c9-3015-407a-9ba5-9addd2558224')
         mock_get_app.return_value = mock.Mock(id='1525e3c9-3015-407a-9ba5-9addd2558224')
-        mock_get_build.return_value = [build, '1.0.0']
+        mock_get_build.return_value = build
         locale = Locale('en-GB')
 
         whats_new = Types.WhatsNewArgument("What's new")

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -173,6 +173,7 @@ def test_no_skip_package_validation_argument_from_env(cli_argument_group):
     PublishArgument.SKIP_PACKAGE_VALIDATION.register(cli_argument_group)
     args = argparse.Namespace(skip_package_validation=None)
     os.environ[Types.AppStoreConnectSkipPackageValidation.environment_variable_key] = ''
-    with pytest.raises(argparse.ArgumentError) as error_info:
+    with pytest.raises(argparse.ArgumentTypeError) as error_info:
         PublishArgument.SKIP_PACKAGE_VALIDATION.from_args(args)
-    assert str(error_info.value) == 'argument --skip-package-validation: Provided value "False" is not valid'
+    print(error_info.value)
+    assert str(error_info.value) == 'Provided value "False" is not valid'

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -122,7 +122,7 @@ def test_publish_action_testflight_with_localization(publishing_namespace_kwargs
         mock_validate.assert_called()
         mock_upload.assert_called()
         mock_create_review.assert_called_with(build.id)
-        mock_create_localization.assert_called_with(build.id, locale, whats_new)
+        mock_create_localization.assert_called_with(build_id=build.id, locale=locale, whats_new=whats_new.value)
 
 
 @mock.patch('codemagic.tools._app_store_connect.actions.publish_action.Altool')

--- a/tests/tools/test_google_play.py
+++ b/tests/tools/test_google_play.py
@@ -64,7 +64,7 @@ def test_invalid_credentials_from_env(namespace_kwargs):
     os.environ[Types.CredentialsArgument.environment_variable_key] = 'invalid credentials'
     namespace_kwargs[credentials_argument.key] = None
     cli_args = argparse.Namespace(**dict(namespace_kwargs.items()))
-    with pytest.raises(argparse.ArgumentError) as exception_info:
+    with pytest.raises(argparse.ArgumentTypeError) as exception_info:
         GooglePlay.from_cli_args(cli_args)
     assert 'invalid credentials' in str(exception_info.value)
 


### PR DESCRIPTION
**Summary of the changes:**

The action `app-store-connect publish` already allowed submitting release notes, or _what's new_ notes in App Store Connect UI terms, to uploaded builds. But there was a limitation that you could only specify the notes for a single language using `--whats-new` flag. Often times this is not enough and you'd want to automate the full process of beta release cycle for whatever languages/locales you have. With the changes introduced in this pull request `app-store-connect publish` gets a new option `--beta-build-localizations` that takes JSON encoded list of locales and notes (as seen below in the example) and automates release notes creation for all given languages.

**Related changes:**

- Make `--whats-new` option independent from `--testflight` for `app-store-connect publish` as submission to external beta review is not required for specifying notes.
- Do not print out found `PreReleaseVersion` of uploaded build as it carries little extra information to the users.
- Allow plain `str` input for `whats_new` arguments to actions defined in `beta_build_localizations_action_group.py`. 
- Add more blue and green colors to logs to indicate the start of an activity and completion of it.
- Use `primaryLocale` attribute from application to detect the default locale instead of using the first `betaAppLocalization` for that app.
- Show more descriptive error messages for invalid inputs to CLI arguments that can be defined using `@env:<...>` and `@file:<...>` notations. 

**Example usage of new option:**

```shell
$ app-store-connect publish \
>     --path ~/Downloads/banaan.ipa \
>     --beta-build-localizations '[{"locale": "en-GB", "whats_new":  "en-GB notes"}, {"locale": "en-US", "whats_new":  "en-US notes"}, {"locale": "fi", "whats_new": "fi notes"}]' \
>     --testflight
Publish "/Users/priit/Downloads/banaan.ipa" to App Store Connect
App name: Banaan
Bundle identifier: io.codemagic.banaan
Certificate expires: 2022-05-14T04:35:20.000+0000
Distribution type: App Store
Min os version: 10.1
Provisioned devices: N/A
Provisions all devices: No
Supported platforms: iPhoneOS
Version code: 1.0.84
Version: 1.0

Validate "/Users/priit/Downloads/banaan.ipa" for App Store Connect
{
    "tool-version": "4.050.1210",
    "tool-path": "/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework",
    "success-message": "No errors validating archive at '/Users/priit/Downloads/banaan.ipa'.",
    "os-version": "11.2.3"
}
No errors validating archive at '/Users/priit/Downloads/banaan.ipa'.

Upload "/Users/priit/Downloads/banaan.ipa" to App Store Connect
{
    "tool-version": "4.050.1210",
    "tool-path": "/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework",
    "success-message": "No errors uploading '/Users/priit/Downloads/banaan.ipa'",
    "os-version": "11.2.3"
}
No errors uploading '/Users/priit/Downloads/banaan.ipa'

Find application entry from App Store Connect for uploaded binary
Found 1 App matching specified filters: bundleId=io.codemagic.banaan.
-- App --
Id: 1481211155
Type: apps
Bundle id: io.codemagic.banaan
Name: Banaan Codemagic
Primary locale: en-GB
Sku: banaanike
Available in new territories: False
Is or ever was made for kids: False

Find uploaded build
Did not find build matching uploaded version yet, it might be still processing. Waiting 30 seconds to try again
...
Did not find build matching uploaded version yet, it might be still processing. Waiting 30 seconds to try again

Uploaded build is
-- Build --
Id: 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b
Type: builds
Expired: False
Icon asset token: 
        Template url: https://is5-ssl.mzstatic.com/image/thumb/Purple125/v4/eb/1c/4d/eb1c4dd7-7bfb-bc46-82a6-f56da3db8961/Icon-83.5@2x.png.png/{w}x{h}bb.{f}
        Height: 167
        Width: 167
Min os version: 10.1
Processing state: PROCESSING
Version: 1.0.84
Uses non exempt encryption: False
Uploaded date: 2021-06-29 02:22:46-07:00
Expiration date: 2021-09-27 02:22:46-07:00

Update beta build localization info in TestFlight for uploaded build
Modify Beta Build Localization ce78d7f6-6deb-48a6-b14e-554b35b1af59
Successfully modified Beta Build Localization ce78d7f6-6deb-48a6-b14e-554b35b1af59
-- Beta Build Localization --
Id: ce78d7f6-6deb-48a6-b14e-554b35b1af59
Type: betaBuildLocalizations
Locale: en-GB
Whats new: en-GB notes
Creating new Beta Build Localization: build: 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b, locale: en-US, whats new: 'en-US notes'
-- Beta Build Localization (Created) --
Id: cda08179-c7f1-4d7b-84f9-bf7599228a9b
Type: betaBuildLocalizations
Locale: en-US
Whats new: en-US notes
Created Beta Build Localization cda08179-c7f1-4d7b-84f9-bf7599228a9b
Creating new Beta Build Localization: build: 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b, locale: fi, whats new: 'fi notes'
-- Beta Build Localization (Created) --
Id: 80cc936d-db89-4fc5-a175-aa48ad483940
Type: betaBuildLocalizations
Locale: fi
Whats new: fi notes
Created Beta Build Localization 80cc936d-db89-4fc5-a175-aa48ad483940

Submit uploaded build to TestFlight beta review

Wait until processing build 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b is completed
Build 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b is still being processed, wait 30 seconds and check again
...
Build 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b is still being processed, wait 30 seconds and check again
Processing build 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b is completed

Creating new Beta App Review Submission: build: 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b
-- Beta App Review Submission (Created) --
Id: 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b
Type: betaAppReviewSubmissions
Beta review state: WAITING_FOR_REVIEW
Created Beta App Review Submission 28cd6ca9-e6ba-4d3a-b054-5654bf33f88b
```

Relevant part as a screenshot to highlight colors:
![Screenshot 2021-06-29 at 12 34 15](https://user-images.githubusercontent.com/2756611/123774733-60965d00-d8d6-11eb-8f0c-814f11df5ada.png)
