### PR TITLE
Do not create keychains to temporary directory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.8.6
+-------------
+
+**Improvements**
+
+- Save new keychain to `~/Library/Keychains/codemagic-cli-tools` instead of `$TMPDIR` by default with `keychain initialize` in case the `--path` option is not specified.
+
 Version 0.8.5
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
-Version 0.8.6
+Version 0.9.0
 -------------
+
+**Features**
+
+- Add action `keychain use-login` to make login keychain from `~/Library/Keychains` system default keychain again.
 
 **Improvements**
 
 - Save new keychain to `~/Library/Keychains/codemagic-cli-tools` instead of `$TMPDIR` by default with `keychain initialize` in case the `--path` option is not specified.
+
+**Development / Docs**
+
+- Add docs for action `keychain use-login`.
 
 Version 0.8.5
 -------------

--- a/docs/keychain/README.md
+++ b/docs/keychain/README.md
@@ -50,10 +50,11 @@ Enable verbose logging for commands
 |[`create`](create.md)|Create a macOS keychain, add it to the search list|
 |[`delete`](delete.md)|Delete keychains and remove them from the search list|
 |[`get-default`](get-default.md)|Show the system default keychain|
-|[`initialize`](initialize.md)|Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use|
+|[`initialize`](initialize.md)|Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use.|
 |[`list-certificates`](list-certificates.md)|List available code signing certificates in specified keychain|
 |[`lock`](lock.md)|Lock the specified keychain|
 |[`make-default`](make-default.md)|Set the keychain as the system default keychain|
 |[`set-timeout`](set-timeout.md)|Set timeout settings for the keychain.         If seconds are not provided, then no-timeout will be set|
 |[`show-info`](show-info.md)|Show all settings for the keychain|
 |[`unlock`](unlock.md)|Unlock the specified keychain|
+|[`use-login`](use-login.md)|Use login keychain as the default keychain|

--- a/docs/keychain/README.md
+++ b/docs/keychain/README.md
@@ -50,7 +50,7 @@ Enable verbose logging for commands
 |[`create`](create.md)|Create a macOS keychain, add it to the search list|
 |[`delete`](delete.md)|Delete keychains and remove them from the search list|
 |[`get-default`](get-default.md)|Show the system default keychain|
-|[`initialize`](initialize.md)|Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use.|
+|[`initialize`](initialize.md)|Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use|
 |[`list-certificates`](list-certificates.md)|List available code signing certificates in specified keychain|
 |[`lock`](lock.md)|Lock the specified keychain|
 |[`make-default`](make-default.md)|Set the keychain as the system default keychain|

--- a/docs/keychain/initialize.md
+++ b/docs/keychain/initialize.md
@@ -3,7 +3,7 @@ initialize
 ==========
 
 
-**Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use**
+**Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use.**
 ### Usage
 ```bash
 keychain initialize [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]

--- a/docs/keychain/initialize.md
+++ b/docs/keychain/initialize.md
@@ -3,7 +3,7 @@ initialize
 ==========
 
 
-**Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use.**
+**Set up the keychain to be used for code signing. Create the keychain         at specified path with specified password with given timeout.         Make it default and unlock it for upcoming use**
 ### Usage
 ```bash
 keychain initialize [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]

--- a/docs/keychain/use-login.md
+++ b/docs/keychain/use-login.md
@@ -1,0 +1,43 @@
+
+use-login
+=========
+
+
+**Use login keychain as the default keychain**
+### Usage
+```bash
+keychain use-login [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [-p PATH]
+```
+### Optional arguments for command `keychain`
+
+##### `-p, --path=PATH`
+
+
+Keychain path. If not provided, the system default keychain will be used instead
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.6'
+__version__ = '0.9.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -235,7 +235,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
         if process.returncode != 0:
             raise KeychainError(f'Unable to set {self.path} as default keychain', process)
 
-    @cli.action('use-login', action_options={'requires_default_keychain': False})
+    @cli.action('use-login')
     def use_login_keychain(self) -> Keychain:
         """
         Use login keychain as the default keychain

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -258,7 +258,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
         """
         Set up the keychain to be used for code signing. Create the keychain
         at specified path with specified password with given timeout.
-        Make it default and unlock it for upcoming use.
+        Make it default and unlock it for upcoming use
         """
 
         if not self._path:

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -267,7 +267,9 @@ class Keychain(cli.CliApp, PathFinderMixin):
         return certificates
 
     def _generate_path(self):
-        with NamedTemporaryFile(prefix='build_', suffix='.keychain') as tf:
+        keychain_dir = pathlib.Path('~/Library/Keychains/codemagic-cli-tools').expanduser()
+        keychain_dir.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(prefix='build_', suffix='.keychain', dir=keychain_dir) as tf:
             self._path = pathlib.Path(tf.name)
 
     @cli.action('add-certificates',

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import shutil
+from datetime import datetime
 from tempfile import NamedTemporaryFile
 from typing import Iterable
 from typing import List
@@ -269,7 +270,8 @@ class Keychain(cli.CliApp, PathFinderMixin):
     def _generate_path(self):
         keychain_dir = pathlib.Path('~/Library/Keychains/codemagic-cli-tools').expanduser()
         keychain_dir.mkdir(parents=True, exist_ok=True)
-        with NamedTemporaryFile(prefix='build_', suffix='.keychain', dir=keychain_dir) as tf:
+        date = datetime.now().strftime('%d-%m-%y')
+        with NamedTemporaryFile(prefix=f'{date}_', suffix='.keychain-db', dir=keychain_dir) as tf:
             self._path = pathlib.Path(tf.name)
 
     @cli.action('add-certificates',


### PR DESCRIPTION
Fixes #126.

Avoid creating temporary keychains in `$TMPDIR` that get deleted with system reboots, which in turn messes up default keychain settings by prompting errors like
> Keychain "<keychain_name>" cannot be found to store "<secret_name">.
Your keychain may have been renamed, deleted, or it's on a unmounted volume.

Instead store the keychains generated by `keychain initialize` in `~/Library/Keychains/codemagic-cli-tools/*.keychain-db` by default.
Also add a new action `keychain use-login` to easily make the default login keychain from `~/Library/Keychains` system default keychain again.

**New actions:**
- `keychain use-login`

**Example usage of new action:**

```shell
> keychain use-login  
Use login keychain /Users/priit/Library/Keychains/login.keychain-db as system default keychain
Set keychain /Users/priit/Library/Keychains/login.keychain-db to system default keychain
```

**Example usage of updated action:**

```shell
> keychain initialize
Initialize new keychain to store code signing certificates at /Users/priit/Library/Keychains/codemagic-cli-tools/01-07-21_ddumtyja.keychain-db
Create keychain /Users/priit/Library/Keychains/codemagic-cli-tools/01-07-21_ddumtyja.keychain-db
Set keychain /Users/priit/Library/Keychains/codemagic-cli-tools/01-07-21_ddumtyja.keychain-db timeout to "no timeout"
Set keychain /Users/priit/Library/Keychains/codemagic-cli-tools/01-07-21_ddumtyja.keychain-db to system default keychain
Unlock keychain /Users/priit/Library/Keychains/codemagic-cli-tools/01-07-21_ddumtyja.keychain-db
```
