### PR TITLE
Improvement: Finding build timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.9.3
+-------------
+
+**Improvements**
+
+- Double the number of attempts to find an uploaded build on App Store Connect side
+
 Version 0.9.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -182,8 +182,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             # There are retries left, wait a bit and try again.
             self.logger.info(
                 (
-                    'Build has finished uploading but is processing on App Store Connect side. Could not find '
-                    'build matching uploaded version yet. Waiting %d seconds to try again, %d attempts remaining.'
+                    'Build has finished uploading but is processing on App Store Connect side. Could not find the '
+                    'build matching the uploaded version yet. Waiting %d seconds to try again, %d attempts remaining.'
                 ),
                 retry_wait_seconds,
                 retries,
@@ -216,8 +216,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         start_waiting = time.time()
         while time.time() - start_waiting < max_processing_minutes * 60:
             if build.attributes.processingState is BuildProcessingState.PROCESSING:
-                msg_template = 'Build %s is still being processed on Apple Store Connect side, ' \
-                               'waiting %d seconds and checking again'
+                msg_template = 'Build %s is still being processed on App Store Connect side, waiting %d seconds ' \
+                               'and checking again'
                 self.logger.info(msg_template, build.id, retry_wait_seconds)
                 time.sleep(retry_wait_seconds)
                 try:

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -205,12 +205,20 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         max_processing_minutes: int,
         retry_wait_seconds: int = 30,
     ) -> Build:
-        self.logger.info(Colors.BLUE('\nWait until processing build %s is completed'), build.id)
+        self.logger.info(
+            Colors.BLUE(
+                '\nProcessing of builds by Apple can take a while, the timeout for waiting the completion of '
+                'processing of build %s is set to %d minutes.'
+            ),
+            build.id,
+            max_processing_minutes,
+        )
 
         start_waiting = time.time()
         while time.time() - start_waiting < max_processing_minutes * 60:
             if build.attributes.processingState is BuildProcessingState.PROCESSING:
-                msg_template = 'Build %s is still being processed, wait %d seconds and check again'
+                msg_template = 'Build %s is still being processed on Apple Store Connect side, ' \
+                               'waiting %d seconds and checking again'
                 self.logger.info(msg_template, build.id, retry_wait_seconds)
                 time.sleep(retry_wait_seconds)
                 try:

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -207,9 +207,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
     ) -> Build:
         self.logger.info(
             Colors.BLUE(
-                '\nProcessing of builds by Apple can take a while, the timeout for waiting the processing to finish '
-                'for build %s is set to %d minutes.'
-            ),
+                '\nProcessing of builds by Apple can take a while, the timeout for waiting the processing '
+                'to finish for build %s is set to %d minutes.'),
             build.id,
             max_processing_minutes,
         )

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -157,7 +157,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self,
         app_id: ResourceId,
         application_package: Union[Ipa, MacOsPackage],
-        retries: int = 10,
+        retries: int = 20,
         retry_wait_seconds: int = 30,
     ) -> Build:
         """
@@ -192,7 +192,10 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 app_id, application_package, retries=retries - 1, retry_wait_seconds=retry_wait_seconds)
         else:
             # There are no more retries left, give up.
-            raise IOError(f'Did not find corresponding build from App Store versions for "{application_package.path}"')
+            raise IOError(
+                f'Could not yet find corresponding build from App Store versions for "{application_package.path}" '
+                'artifact. The build is uploaded successfully, but it is not yet available for further actions, '
+                'since App Store Connect is still processing the uploaded build.')
 
     def _wait_until_build_is_processed(
         self,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -182,10 +182,11 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             # There are retries left, wait a bit and try again.
             self.logger.info(
                 (
-                    'Did not find build matching uploaded version yet, it might be still processing. '
-                    'Waiting %d seconds to try again'
+                    'Build has finished uploading but is processing on App Store Connect side. Could not find '
+                    'build matching uploaded version yet. Waiting %d seconds to try again, %d attempts remaining.'
                 ),
                 retry_wait_seconds,
+                retries,
             )
             time.sleep(retry_wait_seconds)
             return self._find_build(

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -195,9 +195,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             raise IOError(
                 'The build was successfully uploaded to App Store Connect but the corresponding artifact '
                 f'"{application_package.path}" has not finished processing and is unavailable for further actions '
-                'like uploading release notes or submitting to beta review. You can upload release notes or '
-                'submit the build to beta review manually once the uploaded build has finished processing.'
-            )
+                'like uploading What to test notes or submitting to beta review. You can upload release notes or '
+                'submit the build to beta review manually once the uploaded build has finished processing.')
 
     def _wait_until_build_is_processed(
         self,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -196,8 +196,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             raise IOError(
                 'The build was successfully uploaded to App Store Connect but processing the corresponding artifact '
                 f'"{application_package.path}" by Apple took longer than expected. Further actions like updating the '
-                'What to test information or submitting the build to beta review could not be performed but can be '
-                'completed manually in TestFlight once the build has finished processing.')
+                'What to test information or submitting the build to beta review could not be performed at the moment '
+                'but can be completed manually in TestFlight once the build has finished processing.')
 
     def _wait_until_build_is_processed(
         self,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -193,9 +193,11 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         else:
             # There are no more retries left, give up.
             raise IOError(
-                f'Could not yet find corresponding build from App Store versions for "{application_package.path}" '
-                'artifact. The build is uploaded successfully, but it is not yet available for further actions, '
-                'since App Store Connect is still processing the uploaded build.')
+                'The build was successfully uploaded to App Store Connect but the corresponding artifact '
+                f'"{application_package.path}" has not finished processing and is unavailable for further actions '
+                'like uploading release notes or submitting to beta review. You can upload release notes or '
+                'submit the build to beta review manually once the uploaded build has finished processing.'
+            )
 
     def _wait_until_build_is_processed(
         self,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -194,10 +194,10 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         else:
             # There are no more retries left, give up.
             raise IOError(
-                'The build was successfully uploaded to App Store Connect but the corresponding artifact '
-                f'"{application_package.path}" has not finished processing and is unavailable for further actions '
-                'like uploading What to test notes or submitting to beta review. You can upload release notes or '
-                'submit the build to beta review manually once the uploaded build has finished processing.')
+                'The build was successfully uploaded to App Store Connect but processing the corresponding artifact '
+                f'"{application_package.path}" by Apple took longer than expected. Further actions like updating the '
+                'What to test information or submitting the build to beta review could not be performed but can be '
+                'completed manually in TestFlight once the build has finished processing.')
 
     def _wait_until_build_is_processed(
         self,

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -207,8 +207,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
     ) -> Build:
         self.logger.info(
             Colors.BLUE(
-                '\nProcessing of builds by Apple can take a while, the timeout for waiting the completion of '
-                'processing of build %s is set to %d minutes.'
+                '\nProcessing of builds by Apple can take a while, the timeout for waiting the processing to finish '
+                'for build %s is set to %d minutes.'
             ),
             build.id,
             max_processing_minutes,


### PR DESCRIPTION
Multiple users reported frequent timeouts when attempting to submit release notes and submitting build to TestFlight. In this PR, I double the number of attempts to find an uploaded build on App Store Connect side.