### PR TITLE
Bugfix: Fix listing all builds for an app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Version 0.9.5
+-------------
+
+**Fixes**
+
+- Fix finding uploaded build as part of `app-store-connect publish`.
+- Fix `app-store-connect apps builds` action by replacing broken [List All Builds of an App
+](https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app) API endpoint by [List Builds
+](https://developer.apple.com/documentation/appstoreconnectapi/list_builds) endpoint.
+**Development / Docs**
+
+- Add warning to method `list_builds` in `Apps` resource manager about malfunctioning pagination.
+- Add missing relationship `ciProduct` to `App` model.
+- Accept strings for builds filter version restriction.
+
 Version 0.9.4
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/api_client.py
+++ b/src/codemagic/apple/app_store_connect/api_client.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from typing import Dict
 from typing import List
 from typing import Optional
-from urllib import parse
 
 import jwt
 
@@ -101,19 +100,21 @@ class AppStoreConnectApiClient(StringConverterMixin):
     def _paginate(self, url, params, page_size) -> PaginateResult:
         params = {k: v for k, v in (params or {}).items() if v is not None}
         if page_size is None:
-            response = self.session.get(url, params=params).json()
+            response = self.session.get(url, params=params)
         else:
-            response = self.session.get(url, params={'limit': page_size, **params}).json()
-        result = PaginateResult(response.get('data', []), response.get('included', []))
-        while 'next' in response['links']:
+            response = self.session.get(url, params={'limit': page_size, **params})
+        response_payload = response.json()
+        result = PaginateResult(response_payload.get('data', []), response_payload.get('included', []))
+        while 'next' in response_payload['links']:
             # Query params from previous pagination call can be included in the next URL
             # and duplicate parameters are not allowed, so we need to filter those out.
-            parsed_url = parse.urlparse(response['links']['next'])
-            included_params = parse.parse_qs(parsed_url.query)
-            step_params = {k: v for k, v in params.items() if k not in included_params}
-            response = self.session.get(response['links']['next'], params=step_params).json()
-            result.data.extend(response['data'])
-            result.included.extend(response.get('included', []))
+            # parsed_url = parse.urlparse(response_payload['links']['next'])
+            # included_params = parse.parse_qs(parsed_url.query)
+            # step_params = {k: v for k, v in params.items() if k not in included_params}
+            response = self.session.get(response_payload['links']['next'])
+            response_payload = response.json()
+            result.data.extend(response_payload['data'])
+            result.included.extend(response_payload.get('included', []))
         return result
 
     def paginate(self, url, params=None, page_size: Optional[int] = 100) -> List[Dict]:

--- a/src/codemagic/apple/app_store_connect/apps/apps.py
+++ b/src/codemagic/apple/app_store_connect/apps/apps.py
@@ -11,6 +11,7 @@ from codemagic.apple.resources import AppStoreState
 from codemagic.apple.resources import AppStoreVersion
 from codemagic.apple.resources import BetaAppLocalization
 from codemagic.apple.resources import BetaAppReviewDetail
+from codemagic.apple.resources import Build
 from codemagic.apple.resources import LinkedResourceData
 from codemagic.apple.resources import Platform
 from codemagic.apple.resources import PreReleaseVersion
@@ -68,6 +69,19 @@ class Apps(ResourceManager[App]):
         app_id = self._get_resource_id(app)
         response = self.client.session.get(f'{self.client.API_URL}/apps/{app_id}').json()
         return App(response['data'])
+
+    def list_builds(self, app: Union[LinkedResourceData, ResourceId]) -> List[Build]:
+        """
+        https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app
+
+        Warning! As of 11.08.21 pagination does not work as expected for this API endpoint. See
+        https://github.com/codemagic-ci-cd/cli-tools/pull/140 for more information.
+        """
+        if isinstance(app, App):
+            url = app.relationships.builds.links.related
+        else:
+            url = f'{self.client.API_URL}/apps/{app}/builds'
+        return [Build(build) for build in self.client.paginate(url, page_size=None)]
 
     def list_pre_release_versions(self, app: Union[LinkedResourceData, ResourceId]) -> List[PreReleaseVersion]:
         """

--- a/src/codemagic/apple/app_store_connect/apps/apps.py
+++ b/src/codemagic/apple/app_store_connect/apps/apps.py
@@ -11,7 +11,6 @@ from codemagic.apple.resources import AppStoreState
 from codemagic.apple.resources import AppStoreVersion
 from codemagic.apple.resources import BetaAppLocalization
 from codemagic.apple.resources import BetaAppReviewDetail
-from codemagic.apple.resources import Build
 from codemagic.apple.resources import LinkedResourceData
 from codemagic.apple.resources import Platform
 from codemagic.apple.resources import PreReleaseVersion
@@ -69,16 +68,6 @@ class Apps(ResourceManager[App]):
         app_id = self._get_resource_id(app)
         response = self.client.session.get(f'{self.client.API_URL}/apps/{app_id}').json()
         return App(response['data'])
-
-    def list_builds(self, app: Union[LinkedResourceData, ResourceId]) -> List[Build]:
-        """
-        https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app
-        """
-        if isinstance(app, App):
-            url = app.relationships.builds.links.related
-        else:
-            url = f'{self.client.API_URL}/apps/{app}/builds'
-        return [Build(build) for build in self.client.paginate(url, page_size=None)]
 
     def list_pre_release_versions(self, app: Union[LinkedResourceData, ResourceId]) -> List[PreReleaseVersion]:
         """

--- a/src/codemagic/apple/app_store_connect/builds/builds.py
+++ b/src/codemagic/apple/app_store_connect/builds/builds.py
@@ -61,7 +61,7 @@ class Builds(ResourceManager[Build]):
         """
 
         params = {'sort': ordering.as_param(reverse), **resource_filter.as_query_params()}
-        builds = self.client.paginate(f'{self.client.API_URL}/builds', params=params)
+        builds = self.client.paginate(f'{self.client.API_URL}/builds', params=params, page_size=10)
         return [Build(build) for build in builds]
 
     def read_app(self, build: Union[Build, ResourceId]) -> App:

--- a/src/codemagic/apple/app_store_connect/builds/builds.py
+++ b/src/codemagic/apple/app_store_connect/builds/builds.py
@@ -61,7 +61,7 @@ class Builds(ResourceManager[Build]):
         """
 
         params = {'sort': ordering.as_param(reverse), **resource_filter.as_query_params()}
-        builds = self.client.paginate(f'{self.client.API_URL}/builds', params=params, page_size=10)
+        builds = self.client.paginate(f'{self.client.API_URL}/builds', params=params)
         return [Build(build) for build in builds]
 
     def read_app(self, build: Union[Build, ResourceId]) -> App:

--- a/src/codemagic/apple/app_store_connect/builds/builds.py
+++ b/src/codemagic/apple/app_store_connect/builds/builds.py
@@ -30,7 +30,7 @@ class Builds(ResourceManager[Build]):
         expired: Optional[bool] = None
         id: Optional[ResourceId] = None
         processing_state: Optional[BuildProcessingState] = None
-        version: Optional[int] = None
+        version: Optional[Union[str, int]] = None
         pre_release_version_version: Optional[str] = None
 
         @classmethod

--- a/src/codemagic/apple/resources/app.py
+++ b/src/codemagic/apple/resources/app.py
@@ -39,6 +39,7 @@ class App(Resource):
         betaGroups: Relationship
         betaLicenseAgreement: Relationship
         builds: Relationship
+        ciProduct: Relationship
         endUserLicenseAgreement: Relationship
         gameCenterEnabledVersions: Relationship
         inAppPurchases: Relationship

--- a/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
@@ -69,7 +69,9 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         Get a list of builds associated with a specific app
         """
 
-        builds_filter = self.api_client.builds.Filter(app=application_id)
+        builds_filter = self.api_client.builds.Filter(
+            app=application_id,
+        )
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @cli.action('pre-release-versions',

--- a/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
@@ -69,14 +69,10 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         Get a list of builds associated with a specific app
         """
 
-        return self._list_related_resources(
-            application_id,
-            App,
-            Build,
-            self.api_client.apps.list_builds,
-            None,
-            should_print,
+        builds_filter = self.api_client.builds.Filter(
+            app=application_id,
         )
+        return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @cli.action('pre-release-versions',
                 AppArgument.APPLICATION_ID_RESOURCE_ID,

--- a/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
@@ -69,9 +69,7 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         Get a list of builds associated with a specific app
         """
 
-        builds_filter = self.api_client.builds.Filter(
-            app=application_id,
-        )
+        builds_filter = self.api_client.builds.Filter(app=application_id)
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @cli.action('pre-release-versions',

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -166,8 +166,9 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         after the upload and as a result the API calls may not return it. Implement a
         simple retrying logic to overcome this issue.
         """
+        builds_filter = self.api_client.builds.Filter(app=app_id)
         try:
-            found_builds = self.api_client.apps.list_builds(app_id)
+            found_builds = self.api_client.builds.list(builds_filter)
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
 

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -166,17 +166,18 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         after the upload and as a result the API calls may not return it. Implement a
         simple retrying logic to overcome this issue.
         """
-        builds_filter = self.api_client.builds.Filter(app=app_id)
+        builds_filter = self.api_client.builds.Filter(
+            app=app_id,
+            version=application_package.version_code,
+            pre_release_version_version=application_package.version,
+        )
         try:
             found_builds = self.api_client.builds.list(builds_filter)
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
 
-        for build in found_builds:
-            if build.attributes.version == application_package.version_code:
-                pre_release_version = self.api_client.builds.read_pre_release_version(build.id)
-                if pre_release_version and pre_release_version.attributes.version == application_package.version:
-                    return build
+        if found_builds:
+            return found_builds[0]
 
         # Matching build was not found.
         if retries > 0:


### PR DESCRIPTION
Pagination of App Store Connect API endpoint [List All Builds of an App
](https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app) does not work and instead or returning all unique builds across all pages, there are duplicates in pages and not all builds are returned.

Result with current implementation using list app builds:
```bash
$ app-store-connect apps builds 1496105355 | grep Id | sort | uniq -c | sort -n | tail -3
Get Builds for App 1496105355
Found 150 Builds for App
   3 Id: d0a20499-3234-459b-9d76-387054f5f85c
   3 Id: ee655964-6174-4cf2-9c0f-895fde55a797
   3 Id: f7f67034-3585-483b-b591-17409e3b40b1
```

With the fix:
```shell
$ app-store-connect apps builds 1496105355 | grep Id | sort | uniq -c | sort -n | tail -3
Found 105 Builds matching specified filters: app=1496105355.
   1 Id: f7f67034-3585-483b-b591-17409e3b40b1
   1 Id: f9f6f39e-c810-49ac-93cb-a6d729509aca
   1 Id: fa657fd2-994d-4a44-b857-52cc4a7b8724
```

As can be seen from above, the fixed version does not include builds with duplicate identifiers.
