### PR TITLE
Improvement: Add graceful handling for undefined App Store Connect model attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-Version 0.9.4
+Version 0.9.5
+-------------
+
+**Fixes**
+
+- Ignore undefined model attributes in App Store Connect API responses instead of failing with `TypeError`.
+
+- Version 0.9.4
 -------------
 
 **Fixes**

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/tests/apple/resources/conftest.py
+++ b/tests/apple/resources/conftest.py
@@ -57,3 +57,9 @@ def api_pre_release_version() -> Dict:
 def api_profile() -> Dict:
     mock_path = pathlib.Path(__file__).parent / 'mocks' / 'profile.json'
     return json.loads(mock_path.read_text())
+
+
+@pytest.fixture
+def api_mock_resource() -> Dict:
+    mock_path = pathlib.Path(__file__).parent / 'mocks' / 'mock_resource.json'
+    return json.loads(mock_path.read_text())

--- a/tests/apple/resources/mocks/mock_resource.json
+++ b/tests/apple/resources/mocks/mock_resource.json
@@ -1,0 +1,21 @@
+{
+    "type": "mockResource",
+    "id": "253YPL8VY6",
+    "attributes": {
+        "name": "John Smith"
+    },
+    "relationships": {
+        "parent": {
+            "data": {
+                "type": "mockResource",
+                "id": "F88J43FA9J"
+            },
+            "links": {
+                "self": "https://example.com/mock_resource/F88J43FA9J"
+            }
+        }
+    },
+    "links": {
+        "self": "https://example.com/mock_resource/253YPL8VY6"
+    }
+}

--- a/tests/apple/resources/test_undefined_resource_fields.py
+++ b/tests/apple/resources/test_undefined_resource_fields.py
@@ -1,0 +1,42 @@
+import copy
+from dataclasses import dataclass
+
+from codemagic.apple.resources import Resource
+from codemagic.apple.resources.resource import Relationship
+
+
+class MockResource(Resource):
+    @dataclass
+    class Attributes(Resource.Attributes):
+        name: str
+
+    @dataclass
+    class Relationships(Resource.Relationships):
+        parent: Relationship
+
+
+def test_mock_resource(api_mock_resource):
+    resource = MockResource(api_mock_resource)
+    assert resource.dict() == api_mock_resource
+
+
+def test_undefined_attribute(api_mock_resource):
+    api_mock_resource_with_excess_attribute = copy.deepcopy(api_mock_resource)
+    api_mock_resource_with_excess_attribute['attributes']['age'] = 27
+    resource = MockResource(api_mock_resource_with_excess_attribute)
+    assert resource.dict() == api_mock_resource
+
+
+def test_undefined_relationship(api_mock_resource):
+    api_mock_resource_with_excess_relationship = copy.deepcopy(api_mock_resource)
+    api_mock_resource_with_excess_relationship['relationships']['job'] = {
+        'data': {
+            'type': 'mockResource',
+            'id': 'F88J43FA9J',
+        },
+        'links': {
+            'self': 'https://example.com/mock_resource/F88J43FA9J',
+        },
+    }
+    resource = MockResource(api_mock_resource_with_excess_relationship)
+    assert resource.dict() == api_mock_resource


### PR DESCRIPTION
Yet again App Store Connect API has changed without any documentation about it. This time [`BetaAppReviewSubmission.Attributes`](https://developer.apple.com/documentation/appstoreconnectapi/betaappreviewsubmission/attributes) comes with `submittedDate` in the response body, which as of 12.08.21, is not reflected by Apple's API docs.

Changes such as these break our strict mapping of API responses to Python objects and as a result full command invokation can fail unexpectedly. To be more flexible about such changes in API responses we now dynamically initialize only known model attributes and log the presence of unknown fields to a file.

The changes introduced here are are extension to what was already implemented in PR #100 for model relationships.

Example log entries from the test runs:
```log
[10:56:04 12-08-2021] WARNING resource.py:74 > Unknown field 'age' for resource MockResource.Attributes
[10:56:04 12-08-2021] WARNING resource.py:74 > Unknown field 'job' for resource MockResource.Relationships
```