### PR TITLE
Improvement: add auxiliary submission actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Version 0.9.6
+-------------
+
+**Improvements**
+
+- Add new action `add-beta-test-info` to submit What's new (What to test) localized information for a beta build.
+- Add new action `submit-to-testflight` to submit beta build to TestFlight.
+
+**Development**
+
+- `publish` command will now rely on `add-beta-test-info` and `submit-to-testflight` tasks.
+
 Version 0.9.5
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ Version 0.9.6
 
 - Add new action `add-beta-test-info` to submit What's new (What to test) localized information for a beta build.
 - Add new action `submit-to-testflight` to submit beta build to TestFlight.
+- Introduce strict with match with `--strict-match-identifier` keyword when listing applications filtered by Bundle ID.
+- Avoid waiting for processed build when `MAX_BUILD_PROCESSING_WAIT` or `--max-build-processing-wait` is set to 0.
 
 **Development**
 
 - `publish` command will now rely on `add-beta-test-info` and `submit-to-testflight` tasks.
+- Add `read_with_include` for Builds to return an application along with a build.
 
 Version 0.9.5
 -------------

--- a/docs/app-store-connect/apps/list.md
+++ b/docs/app-store-connect/apps/list.md
@@ -15,6 +15,7 @@ app-store-connect apps list [-h] [--log-stream STREAM] [--no-color] [--version] 
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--bundle-id-identifier BUNDLE_ID_IDENTIFIER_OPTIONAL]
+    [--strict-match-identifier]
     [--app-id APPLICATION_ID_RESOURCE_ID_OPTIONAL]
     [--app-name APPLICATION_NAME]
     [--app-sku APPLICATION_SKU]
@@ -28,6 +29,10 @@ app-store-connect apps list [-h] [--log-stream STREAM] [--no-color] [--version] 
 
 
 Identifier of the Bundle ID. For example `com.example.app`
+##### `--strict-match-identifier`
+
+
+Only match Bundle IDs that have exactly the same identifier specified by `BUNDLE_ID_IDENTIFIER`. By default identifier `com.example.app` also matches Bundle IDs with identifier such as `com.example.app.extension`
 ##### `--app-id, --application-id=APPLICATION_ID_RESOURCE_ID_OPTIONAL`
 
 

--- a/docs/app-store-connect/builds/add-beta-test-info.md
+++ b/docs/app-store-connect/builds/add-beta-test-info.md
@@ -1,12 +1,12 @@
 
-builds
-======
+add-beta-test-info
+==================
 
 
-**Manage your builds in App Store Connect**
+**Add localized What's new (what to test) information**
 ### Usage
 ```bash
-app-store-connect builds [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+app-store-connect builds add-beta-test-info [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
     [--log-api-calls]
     [--json]
     [--issuer-id ISSUER_ID]
@@ -14,8 +14,31 @@ app-store-connect builds [-h] [--log-stream STREAM] [--no-color] [--version] [-s
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    ACTION
+    [--beta-build-localizations BETA_BUILD_LOCALIZATIONS]
+    [--locale LOCALE_DEFAULT]
+    [--whats-new WHATS_NEW]
+    BUILD_ID_RESOURCE_ID
 ```
+### Required arguments for action `add-beta-test-info`
+
+##### `BUILD_ID_RESOURCE_ID`
+
+
+Alphanumeric ID value of the Build
+### Optional arguments for action `add-beta-test-info`
+
+##### `--beta-build-localizations=BETA_BUILD_LOCALIZATIONS`
+
+
+Localized beta test info for what's new in the uploaded build as a JSON encoded list. For example, `[{"locale": "en-US", "whats_new": "What's new in English"}]`. See `--locale` for possible locale options. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering `BETA_BUILD_LOCALIZATIONS` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+
+
+The locale code name for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale from test information is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes
+##### `--whats-new, -n=WHATS_NEW`
+
+
+Describe the changes and additions to the build and indicate the features you would like your users to tests. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_WHATS_NEW`. Alternatively to entering `WHATS_NEW` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`
@@ -72,11 +95,3 @@ Disable log output for commands
 
 
 Enable verbose logging for commands
-### Actions
-
-|Action|Description|
-| :--- | :--- |
-|[`add-beta-test-info`](builds/add-beta-test-info.md)|Add localized What's new (what to test) information|
-|[`get`](builds/get.md)|Get information about a specific build|
-|[`pre-release-version`](builds/pre-release-version.md)|Get the prerelease version for a specific build|
-|[`submit-to-testflight`](builds/submit-to-testflight.md)|Submit build to TestFlight|

--- a/docs/app-store-connect/builds/submit-to-testflight.md
+++ b/docs/app-store-connect/builds/submit-to-testflight.md
@@ -1,12 +1,12 @@
 
-builds
-======
+submit-to-testflight
+====================
 
 
-**Manage your builds in App Store Connect**
+**Submit build to TestFlight**
 ### Usage
 ```bash
-app-store-connect builds [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+app-store-connect builds submit-to-testflight [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
     [--log-api-calls]
     [--json]
     [--issuer-id ISSUER_ID]
@@ -14,8 +14,14 @@ app-store-connect builds [-h] [--log-stream STREAM] [--no-color] [--version] [-s
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    ACTION
+    BUILD_ID_RESOURCE_ID
 ```
+### Required arguments for action `submit-to-testflight`
+
+##### `BUILD_ID_RESOURCE_ID`
+
+
+Alphanumeric ID value of the Build
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`
@@ -72,11 +78,3 @@ Disable log output for commands
 
 
 Enable verbose logging for commands
-### Actions
-
-|Action|Description|
-| :--- | :--- |
-|[`add-beta-test-info`](builds/add-beta-test-info.md)|Add localized What's new (what to test) information|
-|[`get`](builds/get.md)|Get information about a specific build|
-|[`pre-release-version`](builds/pre-release-version.md)|Get the prerelease version for a specific build|
-|[`submit-to-testflight`](builds/submit-to-testflight.md)|Submit build to TestFlight|

--- a/docs/app-store-connect/builds/submit-to-testflight.md
+++ b/docs/app-store-connect/builds/submit-to-testflight.md
@@ -14,6 +14,7 @@ app-store-connect builds submit-to-testflight [-h] [--log-stream STREAM] [--no-c
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
+    [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT]
     BUILD_ID_RESOURCE_ID
 ```
 ### Required arguments for action `submit-to-testflight`
@@ -22,6 +23,12 @@ app-store-connect builds submit-to-testflight [-h] [--log-stream STREAM] [--no-c
 
 
 Alphanumeric ID value of the Build
+### Optional arguments for action `submit-to-testflight`
+
+##### `--max-build-processing-wait=MAX_BUILD_PROCESSING_WAIT`
+
+
+Maximum amount of minutes to wait for the freshly uploaded build to be processed by Apple and retry submitting the build for beta review. If the processing is not finished within the specified timeframe, further submission will be terminated. Waiting will be skipped if the value is set to 0, further actions might fail if the build is not processed yet. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT`. [Default: 20]
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -61,7 +61,7 @@ Skip package validation before uploading it to App Store Connect. Use this switc
 ##### `--max-build-processing-wait=MAX_BUILD_PROCESSING_WAIT`
 
 
-Maximum amount of minutes to wait for the freshly uploaded build to be processed by Apple and retry submitting the build for beta review. If the processing is not finished within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT`. [Default: 20]
+Maximum amount of minutes to wait for the freshly uploaded build to be processed by Apple and retry submitting the build for beta review. If the processing is not finished within the specified timeframe, further submission will be terminated. Waiting will be skipped if the value is set to 0, further actions might fail if the build is not processed yet. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT`. [Default: 20]
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.5'
+__version__ = '0.9.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -54,6 +54,17 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
             should_print: bool = True) -> BetaBuildLocalization:
         ...
 
+    def add_beta_test_info(self,
+                           build_id: ResourceId,
+                           beta_build_localizations: Types.BetaBuildLocalizations,
+                           locale: Optional[Locale],
+                           whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None):
+        ...
+
+    def submit_to_testflight(
+            self, build_id: ResourceId, max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None):
+        ...
+
     def list_apps(self,
                   bundle_id_identifier: Optional[str] = None,
                   application_id: Optional[ResourceId] = None,

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -56,9 +56,9 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
 
     def add_beta_test_info(self,
                            build_id: ResourceId,
-                           beta_build_localizations: Optional[Types.BetaBuildLocalizations],
-                           locale: Optional[Locale],
-                           whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None):
+                           beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
+                           locale: Optional[Locale] = None,
+                           whats_new: Optional[Types.WhatsNewArgument] = None):
         ...
 
     def submit_to_testflight(

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -62,7 +62,7 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
         ...
 
     def submit_to_testflight(
-            self, build_id: ResourceId, max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None):
+            self, build_id: ResourceId, max_build_processing_wait: Optional[Union[int, Types.MaxBuildProcessingWait]] = None):
         ...
 
     def list_apps(self,

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -67,6 +67,7 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
 
     def list_apps(self,
                   bundle_id_identifier: Optional[str] = None,
+                  bundle_id_identifier_strict_match: bool = False,
                   application_id: Optional[ResourceId] = None,
                   application_name: Optional[str] = None,
                   application_sku: Optional[str] = None,

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -56,7 +56,7 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
 
     def add_beta_test_info(self,
                            build_id: ResourceId,
-                           beta_build_localizations: Types.BetaBuildLocalizations,
+                           beta_build_localizations: Optional[Types.BetaBuildLocalizations],
                            locale: Optional[Locale],
                            whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None):
         ...

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -62,7 +62,9 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
         ...
 
     def submit_to_testflight(
-            self, build_id: ResourceId, max_build_processing_wait: Optional[Union[int, Types.MaxBuildProcessingWait]] = None):
+            self,
+            build_id: ResourceId,
+            max_build_processing_wait: Optional[Union[int, Types.MaxBuildProcessingWait]] = None):
         ...
 
     def list_apps(self,

--- a/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
@@ -41,6 +41,7 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
                 action_group=AppStoreConnectActionGroup.APPS)
     def list_apps(self,
                   bundle_id_identifier: Optional[str] = None,
+                  bundle_id_identifier_strict_match: bool = False,
                   application_id: Optional[ResourceId] = None,
                   application_name: Optional[str] = None,
                   application_sku: Optional[str] = None,
@@ -52,6 +53,9 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         Find and list apps added in App Store Connect
         """
 
+        def predicate(app):
+            return app.attributes.bundleId == bundle_id_identifier
+
         apps_filter = self.api_client.apps.Filter(
             bundle_id=bundle_id_identifier,
             id=application_id,
@@ -61,7 +65,13 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             app_store_versions_platform=platform,
             app_store_versions_app_store_state=app_store_state,
         )
-        return self._list_resources(apps_filter, self.api_client.apps, should_print)
+
+        return self._list_resources(
+            apps_filter,
+            self.api_client.apps,
+            should_print,
+            filter_predicate=predicate if bundle_id_identifier and bundle_id_identifier_strict_match else None,
+        )
 
     @cli.action('builds', AppArgument.APPLICATION_ID_RESOURCE_ID, action_group=AppStoreConnectActionGroup.APPS)
     def list_app_builds(self, application_id: ResourceId, should_print: bool = True) -> List[Build]:

--- a/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py
@@ -32,6 +32,7 @@ class AppsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
     @cli.action('list',
                 BundleIdArgument.BUNDLE_ID_IDENTIFIER_OPTIONAL,
+                BundleIdArgument.IDENTIFIER_STRICT_MATCH,
                 AppArgument.APPLICATION_ID_RESOURCE_ID_OPTIONAL,
                 AppArgument.APPLICATION_NAME,
                 AppArgument.APPLICATION_SKU,

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -4,6 +4,7 @@ import time
 from abc import ABCMeta
 from typing import List
 from typing import Optional
+from typing import Union
 
 from codemagic import cli
 from codemagic.apple import AppStoreConnectApiError
@@ -83,14 +84,17 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         BuildArgument.BUILD_ID_RESOURCE_ID,
         action_group=AppStoreConnectActionGroup.BUILDS)
     def submit_to_testflight(
-            self, build_id: ResourceId, max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None):
+            self,
+            build_id: ResourceId,
+            max_build_processing_wait: Optional[Union[int, Types.MaxBuildProcessingWait]] = None):
         """
         Submit build to TestFlight
         """
 
         # Workaround to support overriding default value by environment variable.
-        if max_build_processing_wait:
-            max_processing_minutes = max_build_processing_wait.value
+        if max_build_processing_wait is not None:
+            max_processing_minutes = max_build_processing_wait.value if \
+                isinstance(max_build_processing_wait, Types.MaxBuildProcessingWait) else max_build_processing_wait
         else:
             max_processing_minutes = Types.MaxBuildProcessingWait.default_value
 
@@ -98,7 +102,7 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
         self._assert_app_has_testflight_information(app)
 
-        if max_build_processing_wait:
+        if max_processing_minutes:
             build = self._wait_until_build_is_processed(build, max_processing_minutes)
 
         self.logger.info(Colors.BLUE('\nSubmit uploaded build to TestFlight beta review'))

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from codemagic.apple.resources import PreReleaseVersion
-
-from ..action_group import AppStoreConnectActionGroup
-from ..arguments import BetaBuildInfo
-
 import time
 from abc import ABCMeta
 from typing import List
@@ -18,10 +13,13 @@ from codemagic.apple.resources import BetaAppLocalization
 from codemagic.apple.resources import Build
 from codemagic.apple.resources import BuildProcessingState
 from codemagic.apple.resources import Locale
+from codemagic.apple.resources import PreReleaseVersion
 from codemagic.apple.resources import ResourceId
 from codemagic.cli import Colors
 
 from ..abstract_base_action import AbstractBaseAction
+from ..action_group import AppStoreConnectActionGroup
+from ..arguments import BetaBuildInfo
 from ..arguments import BuildArgument
 from ..arguments import PublishArgument
 from ..arguments import Types

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -4,7 +4,6 @@ import time
 from abc import ABCMeta
 from typing import List
 from typing import Optional
-from typing import Union
 
 from codemagic import cli
 from codemagic.apple import AppStoreConnectApiError
@@ -65,7 +64,7 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
                            build_id: ResourceId,
                            beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
                            locale: Optional[Locale] = None,
-                           whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None):
+                           whats_new: Optional[Types.WhatsNewArgument] = None):
         """
         Add localized What's new (what to test) information
         """
@@ -73,7 +72,7 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         beta_test_info_items = [*beta_build_localizations.value] if beta_build_localizations else []
 
         if whats_new:
-            beta_test_info_items.append(BetaBuildInfo(whats_new=whats_new, locale=locale))
+            beta_test_info_items.append(BetaBuildInfo(whats_new=whats_new.value, locale=locale))
 
         for item in beta_test_info_items:
             self.create_beta_build_localization(build_id=build_id, locale=item.locale, whats_new=item.whats_new)

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -82,6 +82,7 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
     @cli.action(
         'submit-to-testflight',
         BuildArgument.BUILD_ID_RESOURCE_ID,
+        PublishArgument.MAX_BUILD_PROCESSING_WAIT,
         action_group=AppStoreConnectActionGroup.BUILDS)
     def submit_to_testflight(
             self,
@@ -93,8 +94,10 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
         # Workaround to support overriding default value by environment variable.
         if max_build_processing_wait is not None:
-            max_processing_minutes = max_build_processing_wait.value if \
-                isinstance(max_build_processing_wait, Types.MaxBuildProcessingWait) else max_build_processing_wait
+            if isinstance(max_build_processing_wait, Types.MaxBuildProcessingWait):
+                max_processing_minutes = max_build_processing_wait.value
+            else:
+                max_processing_minutes = max_build_processing_wait
         else:
             max_processing_minutes = Types.MaxBuildProcessingWait.default_value
 

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
+from codemagic.apple.resources import PreReleaseVersion
+
+from ..action_group import AppStoreConnectActionGroup
+from ..arguments import BetaBuildInfo
+
+import time
 from abc import ABCMeta
+from typing import List
+from typing import Optional
+from typing import Union
 
 from codemagic import cli
+from codemagic.apple import AppStoreConnectApiError
+from codemagic.apple.resources import App
+from codemagic.apple.resources import BetaAppLocalization
 from codemagic.apple.resources import Build
-from codemagic.apple.resources import PreReleaseVersion
+from codemagic.apple.resources import BuildProcessingState
+from codemagic.apple.resources import Locale
 from codemagic.apple.resources import ResourceId
+from codemagic.cli import Colors
 
 from ..abstract_base_action import AbstractBaseAction
-from ..action_group import AppStoreConnectActionGroup
 from ..arguments import BuildArgument
+from ..arguments import PublishArgument
+from ..arguments import Types
+from ..errors import AppStoreConnectError
 
 
 class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
@@ -39,3 +55,137 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             self.api_client.builds.read_pre_release_version,
             should_print,
         )
+
+    @cli.action(
+        'add-beta-test-info',
+        BuildArgument.BUILD_ID_RESOURCE_ID,
+        BuildArgument.BETA_BUILD_LOCALIZATIONS,
+        BuildArgument.LOCALE_DEFAULT,
+        BuildArgument.WHATS_NEW,
+        action_group=AppStoreConnectActionGroup.BUILDS)
+    def add_beta_test_info(self,
+                           build_id: ResourceId,
+                           beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
+                           locale: Optional[Locale] = None,
+                           whats_new: Optional[Union[str, Types.WhatsNewArgument]] = None):
+        """
+        Add localized What's new (what to test) information
+        """
+
+        beta_test_info_items = [*beta_build_localizations.value] if beta_build_localizations else []
+
+        if whats_new:
+            beta_test_info_items.append(BetaBuildInfo(whats_new=whats_new, locale=locale))
+
+        for item in beta_test_info_items:
+            self.create_beta_build_localization(build_id=build_id, locale=item.locale, whats_new=item.whats_new)
+
+    @cli.action(
+        'submit-to-testflight',
+        BuildArgument.BUILD_ID_RESOURCE_ID,
+        action_group=AppStoreConnectActionGroup.BUILDS)
+    def submit_to_testflight(
+            self, build_id: ResourceId, max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None):
+        """
+        Submit build to TestFlight
+        """
+
+        # Workaround to support overriding default value by environment variable.
+        if max_build_processing_wait:
+            max_processing_minutes = max_build_processing_wait.value
+        else:
+            max_processing_minutes = Types.MaxBuildProcessingWait.default_value
+
+        app = self.api_client.builds.read_app(build_id)
+        build = self.api_client.builds.read(build_id)
+
+        self._assert_app_has_testflight_information(app)
+        build = self._wait_until_build_is_processed(build, max_processing_minutes)
+
+        self.create_beta_app_review_submission(build.id)
+
+    def _wait_until_build_is_processed(
+        self,
+        build: Build,
+        max_processing_minutes: int,
+        retry_wait_seconds: int = 30,
+    ) -> Build:
+        self.logger.info(
+            Colors.BLUE(
+                '\nProcessing of builds by Apple can take a while, the timeout for waiting the processing '
+                'to finish for build %s is set to %d minutes.'),
+            build.id,
+            max_processing_minutes,
+        )
+
+        start_waiting = time.time()
+        while time.time() - start_waiting < max_processing_minutes * 60:
+            if build.attributes.processingState is BuildProcessingState.PROCESSING:
+                msg_template = 'Build %s is still being processed on App Store Connect side, waiting %d seconds ' \
+                               'and checking again'
+                self.logger.info(msg_template, build.id, retry_wait_seconds)
+                time.sleep(retry_wait_seconds)
+                try:
+                    build = self.api_client.builds.read(build)
+                except AppStoreConnectApiError as api_error:
+                    raise AppStoreConnectError(str(api_error))
+            elif build.attributes.processingState in (BuildProcessingState.FAILED, BuildProcessingState.INVALID):
+                raise IOError(f'Uploaded build {build.id} is {build.attributes.processingState.value.lower()}')
+            else:
+                self.logger.info(Colors.BLUE('Processing build %s is completed\n'), build.id)
+                return build
+
+        raise IOError((
+            f'Waiting for build {build.id} processing timed out in {max_processing_minutes} minutes. '
+            f'You can configure maximum timeout using {PublishArgument.MAX_BUILD_PROCESSING_WAIT.flag} '
+            f'command line option, or {Types.MaxBuildProcessingWait.environment_variable_key} environment variable.'
+        ))
+
+    def _assert_app_has_testflight_information(self, app: App):
+        missing_beta_app_information = self._get_missing_beta_app_information(app)
+        missing_beta_app_review_information = self._get_missing_beta_app_review_information(app)
+
+        if not missing_beta_app_information and not missing_beta_app_review_information:
+            return  # All information required for TestFlight submission seems to be present
+
+        error_lines = []
+        if missing_beta_app_information:
+            missing_values = ', '.join(missing_beta_app_information)
+            error_lines.append(f'App is missing required Beta App Information: {missing_values}.')
+        if missing_beta_app_review_information:
+            missing_values = ', '.join(missing_beta_app_review_information)
+            error_lines.append(f'App is missing required Beta App Review Information: {missing_values}.')
+
+        name = app.attributes.name
+        raise ValueError('\n'.join([
+            f'Complete test information is required to submit application {name} build for external testing.',
+            *error_lines,
+            f'Fill in test information at https://appstoreconnect.apple.com/apps/{app.id}/testflight/test-info.',
+        ]))
+
+    def _get_missing_beta_app_information(self, app: App) -> List[str]:
+        app_beta_localization = self._get_app_default_beta_localization(app)
+
+        feedback_email = app_beta_localization.attributes.feedbackEmail if app_beta_localization else None
+        required_test_information = {
+            'Feedback Email': feedback_email,
+        }
+        return [field_name for field_name, value in required_test_information.items() if not value]
+
+    def _get_missing_beta_app_review_information(self, app: App) -> List[str]:
+        beta_app_review_detail = self.api_client.apps.read_beta_app_review_detail(app)
+        required_test_information = {
+            'First Name': beta_app_review_detail.attributes.contactFirstName,
+            'Last Name': beta_app_review_detail.attributes.contactLastName,
+            'Phone Number': beta_app_review_detail.attributes.contactPhone,
+            'Email': beta_app_review_detail.attributes.contactEmail,
+        }
+        return [field_name for field_name, value in required_test_information.items() if not value]
+
+    def _get_app_default_beta_localization(self, app: App) -> Optional[BetaAppLocalization]:
+        beta_app_localizations = self.api_client.apps.list_beta_app_localizations(app)
+        for beta_app_localization in beta_app_localizations:
+            if beta_app_localization.attributes.locale.value == app.attributes.primaryLocale:
+                return beta_app_localization
+        # If nothing matches, then just take the first
+        return beta_app_localizations[0] if beta_app_localizations else None

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -121,17 +121,15 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         whats_new: Optional[Types.WhatsNewArgument],
         max_build_processing_wait: Optional[Types.MaxBuildProcessingWait],
     ):
-        if not beta_build_localizations and not submit_to_testflight:
+        if not beta_build_localizations and not whats_new and not submit_to_testflight:
             return  # Nothing to do with the ipa...
 
         app = self._get_uploaded_build_application(ipa)
         build = self._get_uploaded_build(app, ipa)
 
         if beta_build_localizations or whats_new:
-            self.logger.info(Colors.BLUE('\nUpdate beta build localization info in TestFlight for uploaded build'))
             self.add_beta_test_info(build.id, beta_build_localizations, locale, whats_new)
         if submit_to_testflight:
-            self.logger.info(Colors.BLUE('\nSubmit uploaded build to TestFlight beta review'))
             self.submit_to_testflight(build.id, max_build_processing_wait)
 
     def _find_build(

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -184,7 +184,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         bundle_id = application_package.bundle_identifier
         self.logger.info(Colors.BLUE('\nFind application entry from App Store Connect for uploaded binary'))
         try:
-            app = self.list_apps(bundle_id_identifier=bundle_id, should_print=False)[0]
+            app = self.list_apps(
+                bundle_id_identifier=bundle_id, bundle_id_identifier_strict_match=True, should_print=False)[0]
         except IndexError:
             raise IOError(f'Did not find app with bundle identifier "{bundle_id}" from App Store Connect')
         else:

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -127,7 +127,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         app = self._get_uploaded_build_application(ipa)
         build = self._get_uploaded_build(app, ipa)
 
-        if beta_build_localizations:
+        if beta_build_localizations or whats_new:
             self.logger.info(Colors.BLUE('\nUpdate beta build localization info in TestFlight for uploaded build'))
             self.add_beta_test_info(build.id, beta_build_localizations, locale, whats_new)
         if submit_to_testflight:

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -331,7 +331,9 @@ class PublishArgument(cli.Argument):
         description=(
             'Maximum amount of minutes to wait for the freshly uploaded build to be processed by '
             'Apple and retry submitting the build for beta review. If the processing is not finished '
-            'within the specified timeframe, further submission will be terminated'
+            'within the specified timeframe, further submission will be terminated. '
+            'Waiting will be skipped if the value is set to 0, further actions might fail '
+            'if the build is not processed yet.'
         ),
         argparse_kwargs={
             'required': False,

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -103,8 +103,8 @@ def test_publish_action_testflight_with_localization(publishing_namespace_kwargs
             mock.patch.object(AppStoreConnect, '_assert_app_has_testflight_information'), \
             mock.patch.object(AppStoreConnect, '_get_uploaded_build_application') as mock_get_app, \
             mock.patch.object(AppStoreConnect, '_get_uploaded_build') as mock_get_build, \
-            mock.patch.object(AppStoreConnect, 'create_beta_app_review_submission') as mock_create_review, \
-            mock.patch.object(AppStoreConnect, 'create_beta_build_localization') as mock_create_localization:
+            mock.patch.object(AppStoreConnect, 'submit_to_testflight') as mock_submit_to_testflight, \
+            mock.patch.object(AppStoreConnect, 'add_beta_test_info') as mock_add_beta_test_info:
         ipa_path = pathlib.Path('app.ipa')
         mock_find_paths.return_value = [ipa_path]
         mock_get_packages.return_value = [mock.create_autospec(Ipa, instance=True, path=ipa_path)]
@@ -125,8 +125,8 @@ def test_publish_action_testflight_with_localization(publishing_namespace_kwargs
         mock_get_packages.assert_called_with(patterns)
         mock_validate.assert_called()
         mock_upload.assert_called()
-        mock_create_review.assert_called_with(build.id)
-        mock_create_localization.assert_called_with(build_id=build.id, locale=locale, whats_new=whats_new.value)
+        mock_submit_to_testflight.assert_called_with(build.id, None)
+        mock_add_beta_test_info.assert_called_with(build.id, None, locale, whats_new)
 
 
 @mock.patch('codemagic.tools._app_store_connect.actions.publish_action.Altool')


### PR DESCRIPTION
Create new actions based on two steps from `publish` action:

* `app-store-connect builds add-beta-test-info` -- submission of localized What's new notes
* `app-store-connect builds submit-to-testflight` -- build submission to TestFlight

Both actions may now be used independently

# QA

✅ `add-beta-test-info`

```
Successfully modified Beta Build Localization 9f74c7d7-006d-4f5b-b8e6-866a0645cf4f
-- Beta Build Localization --
Id: 9f74c7d7-006d-4f5b-b8e6-866a0645cf4f
Type: betaBuildLocalizations
Locale: en-US
Whats new: What is new in English
```

✅ `submit-to-testflight`

```
Processing of builds by Apple can take a while, the timeout for waiting the processing to finish for build d5ea4bb8-9a4f-4d48-8fb3-4ee0db18a5c1 is set to 20 minutes.
Processing build d5ea4bb8-9a4f-4d48-8fb3-4ee0db18a5c1 is completed

Creating new Beta App Review Submission: build: d5ea4bb8-9a4f-4d48-8fb3-4ee0db18a5c1
-- Beta App Review Submission (Created) --
Id: d5ea4bb8-9a4f-4d48-8fb3-4ee0db18a5c1
Type: betaAppReviewSubmissions
Beta review state: WAITING_FOR_REVIEW
Created Beta App Review Submission d5ea4bb8-9a4f-4d48-8fb3-4ee0db18a5c1
```

✅ `publish`
```
% app-store-connect publish --testflight --whats-new "Really new stuff" --locale='en-GB' --beta-build-localizations='[{"locale": "en-US", "whats_new": "What is new in English"}]' --path ~/Downloads/capybara.ipa


Publish "/Users/artemii/Downloads/capybara.ipa" to App Store Connect
Validate "/Users/artemii/Downloads/capybara.ipa" for App Store Connect
Upload "/Users/artemii/Downloads/capybara.ipa" to App Store Connect

Find application entry from App Store Connect for uploaded binary
Found 1 App matching specified filters: bundleId=io.codemagic.capybara.

Find uploaded build
Build has finished uploading but is processing on App Store Connect side. Could not find the build matching the uploaded version yet. Waiting 30 seconds to try again, 20 attempts remaining.

Uploaded build is
-- Build --
Id: 48cb54c5-669c-4c80-b6b3-77d034fd32cf

Update beta build localization info in TestFlight for uploaded build
Modify Beta Build Localization 69f1092c-3c4b-47cd-acbe-adfe80612e94
Successfully modified Beta Build Localization 69f1092c-3c4b-47cd-acbe-adfe80612e94

Processing of builds by Apple can take a while, the timeout for waiting the processing to finish for build 48cb54c5-669c-4c80-b6b3-77d034fd32cf is set to 20 minutes.
Build 48cb54c5-669c-4c80-b6b3-77d034fd32cf is still being processed on App Store Connect side, waiting 30 seconds and checking again
Processing build 48cb54c5-669c-4c80-b6b3-77d034fd32cf is completed

Submit uploaded build to TestFlight beta review
Creating new Beta App Review Submission: build: 48cb54c5-669c-4c80-b6b3-77d034fd32cf
Created Beta App Review Submission 48cb54c5-669c-4c80-b6b3-77d034fd32cf
```