### PR TITLE
Improve `AppStoreConnect.add_beta_test_info` Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.9.7
+-------------
+
+**Improvements**
+
+- Accept list of `BetaBuildInfo` objects as `beta_build_localizations` argument for `AppStoreConnect.add_beta_test_info` using Python API.
+
 Version 0.9.6
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.6'
+__version__ = '0.9.7'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -19,6 +19,7 @@ from codemagic.apple.resources import Platform
 from codemagic.apple.resources import ResourceId
 from codemagic.mixins import PathFinderMixin
 
+from .arguments import BetaBuildInfo
 from .arguments import Types
 from .resource_manager_mixin import ResourceManagerMixin
 from .resource_printer import ResourcePrinter
@@ -54,11 +55,12 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
             should_print: bool = True) -> BetaBuildLocalization:
         ...
 
-    def add_beta_test_info(self,
-                           build_id: ResourceId,
-                           beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
-                           locale: Optional[Locale] = None,
-                           whats_new: Optional[Types.WhatsNewArgument] = None):
+    def add_beta_test_info(
+            self,
+            build_id: ResourceId,
+            beta_build_localizations: Optional[Union[List[BetaBuildInfo], Types.BetaBuildLocalizations]] = None,
+            locale: Optional[Locale] = None,
+            whats_new: Optional[Types.WhatsNewArgument] = None):
         ...
 
     def submit_to_testflight(

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -61,16 +61,21 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         BuildArgument.LOCALE_DEFAULT,
         BuildArgument.WHATS_NEW,
         action_group=AppStoreConnectActionGroup.BUILDS)
-    def add_beta_test_info(self,
-                           build_id: ResourceId,
-                           beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
-                           locale: Optional[Locale] = None,
-                           whats_new: Optional[Types.WhatsNewArgument] = None):
+    def add_beta_test_info(
+        self,
+        build_id: ResourceId,
+        beta_build_localizations: Optional[Union[List[BetaBuildInfo], Types.BetaBuildLocalizations]] = None,
+        locale: Optional[Locale] = None,
+        whats_new: Optional[Types.WhatsNewArgument] = None,
+    ):
         """
         Add localized What's new (what to test) information
         """
 
-        beta_test_info_items = [*beta_build_localizations.value] if beta_build_localizations else []
+        if isinstance(beta_build_localizations, Types.BetaBuildLocalizations):
+            beta_test_info_items = beta_build_localizations.value
+        else:
+            beta_test_info_items = beta_build_localizations or []
 
         if whats_new:
             beta_test_info_items.append(BetaBuildInfo(whats_new=whats_new.value, locale=locale))

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -62,12 +62,11 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         BuildArgument.WHATS_NEW,
         action_group=AppStoreConnectActionGroup.BUILDS)
     def add_beta_test_info(
-        self,
-        build_id: ResourceId,
-        beta_build_localizations: Optional[Union[List[BetaBuildInfo], Types.BetaBuildLocalizations]] = None,
-        locale: Optional[Locale] = None,
-        whats_new: Optional[Types.WhatsNewArgument] = None,
-    ):
+            self,
+            build_id: ResourceId,
+            beta_build_localizations: Optional[Union[List[BetaBuildInfo], Types.BetaBuildLocalizations]] = None,
+            locale: Optional[Locale] = None,
+            whats_new: Optional[Types.WhatsNewArgument] = None):
         """
         Add localized What's new (what to test) information
         """


### PR DESCRIPTION
With previous implementation it was rather cumbersome to use `AppStoreConnect.beta_build_localizations` directly from Python since `beta_build_localizations` argument accepted only `Types.BetaBuildLocalizations` objects as values. To overcome this limitation also add possibility to directly pass `List[BetaBuildInfo]` as beta_build_localizations:

```python
from codemagic.tools import AppStoreConnect
from codemagic.tools.app_store_connect import BetaBuildInfo
from codemagic.apple.resources import Locale

AppStoreConnect(...).add_beta_test_info(
    build_id=...,
    beta_build_localizations=[BetaBuildInfo(whats_new='What is new ...', locale=Locale.EN_US)]
)

```