### PR TITLE
Bugfix: App Store Connect API error responses with links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.9.8
+-------------
+
+**Fixes**
+
+- Support `links` field in App Store Connect API [error responses](https://developer.apple.com/documentation/appstoreconnectapi/errorresponse/errors). 
+
 Version 0.9.7
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.7'
+__version__ = '0.9.8'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/error_response.py
+++ b/src/codemagic/apple/resources/error_response.py
@@ -33,7 +33,7 @@ class ErrorMeta(DictSerializable):
 
 @dataclass
 class Error(DictSerializable):
-    _OMIT_IF_NONE_KEYS = ('meta',)
+    _OMIT_IF_NONE_KEYS = ('meta', 'source', 'links')
 
     code: str
     status: str
@@ -42,6 +42,7 @@ class Error(DictSerializable):
     id: Optional[str] = None
     source: Optional[Dict[str, str]] = None
     meta: Optional[ErrorMeta] = None
+    links: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         if isinstance(self.meta, dict):

--- a/tests/apple/resources/conftest.py
+++ b/tests/apple/resources/conftest.py
@@ -48,6 +48,12 @@ def api_error_response() -> Dict:
 
 
 @pytest.fixture
+def api_error_response_with_links() -> Dict:
+    mock_path = pathlib.Path(__file__).parent / 'mocks' / 'error_response_with_links.json'
+    return json.loads(mock_path.read_text())
+
+
+@pytest.fixture
 def api_pre_release_version() -> Dict:
     mock_path = pathlib.Path(__file__).parent / 'mocks' / 'pre_release_version.json'
     return json.loads(mock_path.read_text())

--- a/tests/apple/resources/mocks/error_response_with_links.json
+++ b/tests/apple/resources/mocks/error_response_with_links.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "id": "XHI3JTPAXPXMTCWTY6RJMMMZUI",
+            "status": "403",
+            "code": "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED",
+            "title": "A required agreement is missing or has expired.",
+            "detail": "This request requires an in-effect agreement that has not been signed or has expired.",
+            "links": {
+                "see": "/agreements"
+            }
+        }
+    ]
+}

--- a/tests/apple/resources/test_error_response.py
+++ b/tests/apple/resources/test_error_response.py
@@ -6,3 +6,8 @@ from codemagic.apple.resources import ErrorResponse
 def test_error_response_initialization(api_error_response):
     error_response = ErrorResponse(api_error_response)
     assert error_response.dict() == api_error_response
+
+
+def test_error_response_with_links(api_error_response_with_links):
+    error_response = ErrorResponse(api_error_response_with_links)
+    assert error_response.dict() == api_error_response_with_links


### PR DESCRIPTION
App Store Connect API errors now can contain an [undocumented](https://developer.apple.com/documentation/appstoreconnectapi/errorresponse/errors) `links` field in `ErrorResponse.Error` object, which caused exception on error handling:

```python
[2021-08-18 22:01:57,599: INFO/ForkPoolWorker-2] >>> GET https://api.appstoreconnect.apple.com/v1/bundleIds {'limit': 100, 'sort': 'name'}
[2021-08-18 22:01:57,938: INFO/ForkPoolWorker-2] <<< 403 {'errors': [{'id': 'XHI3JTPAXPXMTCWTY6RJMMMZUI', 'status': '403', 'code': 'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED', 'title': 'A required agreement is missing or has expired.', 'detail': 'This request requires an in-effect agreement that has not been signed or has expired.', 'links': {'see': '/agreements'}}]}
[2021-08-18 22:01:57,965: ERROR/ForkPoolWorker-2] Task list_bundle_ids[e67e0d02-8072-4fc2-a832-29fae42aeb26] raised unexpected: TypeError("__init__() got an unexpected keyword argument 'links'")
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/src/app/tasks/list_bundle_ids.py", line 39, in list_bundle_ids
    bundle_ids = api_client.bundle_ids.list()
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/provisioning/bundle_ids.py", line 103, in list
    bundle_ids = (BundleId(bundle_id) for bundle_id in self.client.paginate(url, params=params))
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/api_client.py", line 120, in paginate
    return self._paginate(url, params, page_size).data
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/api_client.py", line 106, in _paginate
    response = self.session.get(url, params={'limit': page_size, **params}).json()
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 555, in get
    return self.request('GET', url, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/api_session.py", line 42, in request
    raise AppStoreConnectApiError(response)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/api_error.py", line 11, in __init__
    self.error_response = ErrorResponse(response.json())
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/error_response.py", line 63, in __init__
    self.errors = [Error(**error) for error in api_response['errors']]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/error_response.py", line 63, in <listcomp>
    self.errors = [Error(**error) for error in api_response['errors']]
TypeError: __init__() got an unexpected keyword argument 'links'
```