### PR TITLE
Bugfix: App Store Connect test info validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.9.8
+-------------
+
+**Fixes**
+
+- Fail action `app-store-connect builds subtmit-to-testflight` properly using error handling in case the application is missing required test information in App Store Connect.
+
 Version 0.9.7
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.9.7'
+__version__ = '0.9.8'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -105,6 +105,8 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         else:
             max_processing_minutes = Types.MaxBuildProcessingWait.default_value
 
+        self.logger.info(Colors.BLUE('\nSubmit uploaded build to TestFlight beta review'))
+
         build, app = self.api_client.builds.read_with_include(build_id, App)
 
         try:
@@ -115,7 +117,6 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         if max_processing_minutes:
             build = self._wait_until_build_is_processed(build, max_processing_minutes)
 
-        self.logger.info(Colors.BLUE('\nSubmit uploaded build to TestFlight beta review'))
         self.create_beta_app_review_submission(build.id)
 
     def _wait_until_build_is_processed(

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -107,7 +107,10 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
 
         build, app = self.api_client.builds.read_with_include(build_id, App)
 
-        self._assert_app_has_testflight_information(app)
+        try:
+            self._assert_app_has_testflight_information(app)
+        except ValueError as ve:
+            raise AppStoreConnectError(str(ve)) from ve
 
         if max_processing_minutes:
             build = self._wait_until_build_is_processed(build, max_processing_minutes)

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -92,7 +92,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                     )
                 else:
                     continue  # Cannot submit macOS packages to TestFlight, skip
-            except (IOError, ValueError) as error:
+            except (AppStoreConnectError, IOError, ValueError) as error:
                 failed_packages.append(str(application_package.path))
                 self.logger.error(Colors.RED(error.args[0]))
 


### PR DESCRIPTION
Action `app-store-connect build submit-to-testflight` fails with unexpected `ValueError` in case the application for which build is being submitted to testflight does not have all required test information filled in. Handle the thrown `ValueError` and raise `AppStoreConnectError` in place of it so that the process is terminated properly.