### PR TITLE
Bugfix: Ipas compressed with LZFSE algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.10.1
+-------------
+
+**Fixes**
+
+- Fix `codemagic.models.application_package.Ipa` initialization for packages that are compressed using [`LZFSE`](https://github.com/lzfse/lzfse) compression algorithm. Fix requires `unzip` to be available in system `$PATH`. 
+
 Version 0.10.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.10.0'
+__version__ = '0.10.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
Initializing `Ipa` models from packages that are compressed using `LZFSE` algoritm results in the following error:

```python
Traceback (most recent call last):
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 23, in _validate_package
    return bool(self.info_plist)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 71, in info_plist
    return self._get_info_plist()
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 65, in _get_info_plist
    info_plist_contents = self._get_app_file_contents('Info.plist')
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 45, in _get_app_file_contents
    return self._extract_file(filename_filter)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 33, in _extract_file
    with zf.open(found_file_name, 'r') as fd:
  File "/Users/priit/.pyenv/versions/3.7.10/lib/python3.7/zipfile.py", line 1524, in open
    raise BadZipFile("Bad magic number for file header")
zipfile.BadZipFile: Bad magic number for file header
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-12-c15461fcb5ef>", line 1, in <module>
    ipa = Ipa('/Users/priit/ALC-Mobile.ipa')
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/abstract_package.py", line 19, in __init__
    self._validate_package()
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/application_package/ipa.py", line 25, in _validate_package
    raise IOError(f'Not a valid iOS application package at {self.path}') from bad_zip_file
OSError: Not a valid iOS application package at /Users/priit/App.ipa
```

This is due to limited support in Python's stdlib for said compression algorithm. `unzip` throws warnings while extracting files from such containers, but does the job.