### PR TITLE
Bugfix: Make `ciProduct` relationship on `App` model optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.10.2
+-------------
+
+**Fixes**
+
+- Make `codemagic.apple.resources.App` relationship for `ciProduct` optional.
+
 Version 0.10.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.10.1'
+__version__ = '0.10.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/app.py
+++ b/src/codemagic/apple/resources/app.py
@@ -29,7 +29,7 @@ class App(Resource):
 
     @dataclass
     class Relationships(Resource.Relationships):
-        _OMIT_IF_NONE_KEYS = ('betaTesters', 'perfPowerMetrics')
+        _OMIT_IF_NONE_KEYS = ('betaTesters', 'ciProduct', 'perfPowerMetrics')
 
         appInfos: Relationship
         appStoreVersions: Relationship
@@ -39,7 +39,6 @@ class App(Resource):
         betaGroups: Relationship
         betaLicenseAgreement: Relationship
         builds: Relationship
-        ciProduct: Relationship
         endUserLicenseAgreement: Relationship
         gameCenterEnabledVersions: Relationship
         inAppPurchases: Relationship
@@ -48,4 +47,5 @@ class App(Resource):
         prices: Relationship
 
         betaTesters: Optional[Relationship] = None
+        ciProduct: Optional[Relationship] = None
         perfPowerMetrics: Optional[Relationship] = None


### PR DESCRIPTION
`ciProduct` relationship on `App` model is not quaranteed to be present:
 
```python
Task raised unexpected: TypeError("__init__() missing 1 required positional argument: 'ciProduct'")
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/src/app/tasks/distribution.py", line 101, in process_distribution_task
    new_status = TaskProcessor(db, raw_task).process()
  File "/usr/src/app/distribution/task_processor.py", line 110, in process
    return self.process()
  File "/usr/src/app/distribution/task_processor.py", line 97, in process
    self._process_state(current_state, self.task.current_state_attempt)
  File "/usr/src/app/distribution/task_processor.py", line 116, in _process_state
    self._process_find_build_state(attempt)
  File "/usr/src/app/distribution/task_processor.py", line 143, in _process_find_build_state
    app_id = self._get_app_store_connect_app_id()
  File "/usr/src/app/distribution/task_processor.py", line 135, in _get_app_store_connect_app_id
    apps = app_store_connect.list_apps(bundle_id_identifier=bundle_id, bundle_id_identifier_strict_match=True)
  File "/usr/local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 455, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/action_groups/apps_action_group.py", line 70, in list_apps
    return self._list_resources(
  File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/resource_manager_mixin.py", line 45, in _list_resources
    resources = resource_manager.list(resource_filter=resource_filter)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/apps/apps.py", line 63, in list
    return [App(app) for app in apps]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/app_store_connect/apps/apps.py", line 63, in <listcomp>
    return [App(app) for app in apps]
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 207, in __init__
    self.relationships = self._create_relationships(api_response)
  File "/usr/local/lib/python3.8/site-packages/codemagic/apple/resources/resource.py", line 199, in _create_relationships
    return cls.Relationships(**defined_fields)
TypeError: __init__() missing 1 required positional argument: 'ciProduct'