### PR TITLE
Feature: Add method to obtain certificate fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.10.3
 
 **Development / Docs**
 
-- Add new properties `sha1_fingerprint` and `sha256_fingerprint` to `codemagic.models.Certificate` class that return certificate's hexadecimal SHA1 and SHA256 fingerprints respectively.
+- Add `get_fingerprint` method to `codemagic.models.Certificate` class which returns certificate's hexadecimal fingerprint for requested hashing algorithm.
 
 Version 0.10.2
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.10.3
+-------------
+
+**Development / Docs**
+
+- Add new properties `sha1_fingerprint` and `sha256_fingerprint` to `codemagic.models.Certificate` class that return certificate's hexadecimal SHA1 and SHA256 fingerprints respectively.
+
 Version 0.10.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.10.2'
+__version__ = '0.10.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -95,17 +95,18 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
     def serial(self) -> int:
         return self.x509.get_serial_number()
 
-    @property
-    def sha1_fingerprint(self) -> str:
+    def _get_fingerprint(self, algorithm: hashes.HashAlgorithm) -> str:
         x509_certificate = self.x509.to_cryptography()
-        fingerprint = x509_certificate.fingerprint(hashes.SHA1())
+        fingerprint = x509_certificate.fingerprint(algorithm)
         return fingerprint.hex().upper()
 
     @property
+    def sha1_fingerprint(self) -> str:
+        return self._get_fingerprint(hashes.SHA1())
+
+    @property
     def sha256_fingerprint(self) -> str:
-        x509_certificate = self.x509.to_cryptography()
-        fingerprint = x509_certificate.fingerprint(hashes.SHA256())
-        return fingerprint.hex().upper()
+        return self._get_fingerprint(hashes.SHA256())
 
     @property
     def extensions(self) -> List[str]:

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -95,19 +95,6 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
     def serial(self) -> int:
         return self.x509.get_serial_number()
 
-    def _get_fingerprint(self, algorithm: hashes.HashAlgorithm) -> str:
-        x509_certificate = self.x509.to_cryptography()
-        fingerprint = x509_certificate.fingerprint(algorithm)
-        return fingerprint.hex().upper()
-
-    @property
-    def sha1_fingerprint(self) -> str:
-        return self._get_fingerprint(hashes.SHA1())
-
-    @property
-    def sha256_fingerprint(self) -> str:
-        return self._get_fingerprint(hashes.SHA256())
-
     @property
     def extensions(self) -> List[str]:
         extensions_count = self.x509.get_extension_count()
@@ -158,6 +145,11 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
     def get_certificate_signing_request_content(cls, csr: x509.CertificateSigningRequest) -> str:
         public_bytes = csr.public_bytes(serialization.Encoding.PEM)
         return cls._str(public_bytes)
+
+    def get_fingerprint(self, algorithm: hashes.HashAlgorithm) -> str:
+        x509_certificate = self.x509.to_cryptography()
+        fingerprint = x509_certificate.fingerprint(algorithm)
+        return fingerprint.hex().upper()
 
     def export_p12(self,
                    private_key: PrivateKey,

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -96,6 +96,18 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
         return self.x509.get_serial_number()
 
     @property
+    def sha1_fingerprint(self) -> str:
+        x509_certificate = self.x509.to_cryptography()
+        fingerprint = x509_certificate.fingerprint(hashes.SHA1())
+        return fingerprint.hex().upper()
+
+    @property
+    def sha256_fingerprint(self) -> str:
+        x509_certificate = self.x509.to_cryptography()
+        fingerprint = x509_certificate.fingerprint(hashes.SHA256())
+        return fingerprint.hex().upper()
+
+    @property
     def extensions(self) -> List[str]:
         extensions_count = self.x509.get_extension_count()
         return [self._str(self.x509.get_extension(i).get_short_name()) for i in range(extensions_count)]

--- a/tests/models/test_certificate.py
+++ b/tests/models/test_certificate.py
@@ -130,3 +130,16 @@ def test_is_code_signing_certificate(cert_common_name, is_code_signing_certifica
     with mock.patch.object(Certificate, 'common_name', new_callable=patched_common_name):
         certificate = Certificate.from_ans1(certificate_asn1)
         assert certificate.is_code_signing_certificate() is is_code_signing_certificate
+
+
+def test_certificate_sha1_fingerprint(certificate_asn1):
+    certificate = Certificate.from_ans1(certificate_asn1)
+    expected_fingerprint = 'F9 DA F0 C5 BA 5C 82 1E 46 25 D8 C4 3E 69 66 CF 8F 63 86 37'
+    assert certificate.sha1_fingerprint == expected_fingerprint.replace(' ', '')
+
+
+def test_certificate_sha256_fingerprint(certificate_asn1):
+    certificate = Certificate.from_ans1(certificate_asn1)
+    expected_fingerprint = \
+        '42 FD E9 13 4E 92 B3 FC 2C 60 47 A9 6F B3 31 38 8F B4 60 85 BC B3 7C 67 0F 5D 78 76 1F DE E5 E3'
+    assert certificate.sha256_fingerprint == expected_fingerprint.replace(' ', '')

--- a/tests/models/test_certificate.py
+++ b/tests/models/test_certificate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 
 from codemagic.models import Certificate
@@ -135,11 +136,11 @@ def test_is_code_signing_certificate(cert_common_name, is_code_signing_certifica
 def test_certificate_sha1_fingerprint(certificate_asn1):
     certificate = Certificate.from_ans1(certificate_asn1)
     expected_fingerprint = 'F9 DA F0 C5 BA 5C 82 1E 46 25 D8 C4 3E 69 66 CF 8F 63 86 37'
-    assert certificate.sha1_fingerprint == expected_fingerprint.replace(' ', '')
+    assert certificate.get_fingerprint(hashes.SHA1()) == expected_fingerprint.replace(' ', '')
 
 
 def test_certificate_sha256_fingerprint(certificate_asn1):
     certificate = Certificate.from_ans1(certificate_asn1)
     expected_fingerprint = \
         '42 FD E9 13 4E 92 B3 FC 2C 60 47 A9 6F B3 31 38 8F B4 60 85 BC B3 7C 67 0F 5D 78 76 1F DE E5 E3'
-    assert certificate.sha256_fingerprint == expected_fingerprint.replace(' ', '')
+    assert certificate.get_fingerprint(hashes.SHA256()) == expected_fingerprint.replace(' ', '')


### PR DESCRIPTION
Add `get_fingerprint` method to `codemagic.models.Certificate` class which returns certificate's hexadecimal fingerprint for requested hashing algorithm.

For example:
```python
>>> certificate_path = ...
>>> certificate = Certificate.from_p12(open(certificate_path, 'rb').read())
>>> certificate.get_fingerprint(hashes.SHA1())
'A402B132CDF1F7A040E71DB870EA39AA952F3852'
>>> certificate.get_fingerprint(hashes.SHA256())
'7D4B15F11DC4077CDF0E7DE05574FC3FC8F53E06321C10FFDF75ED370862D0BF'
```