### PR TITLE
Feature: Add new action `app-store-connect register-device`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Version 0.11.0
+-------------
+
+**Features**
+
+- New `app-store-connect register-device` action to add new device to Apple Developer team. Registering a device allows creating a provisioning profile for app testing and ad hoc distribution.
+
+**Development / Docs**
+
+- Rename `DeviceArgument.DEVICE_NAME` CLI argument to `DeviceArgument.DEVICE_NAME_OPTIONAL`.
+- Update docs for action `app-store-connect beta-groups add-build`.
+- Update docs for action `app-store-connect beta-groups remove-build`.
+- Update docs for action `app-store-connect list-devices`.
+- Add docs for action `app-store-connect register-device`.
+
 Version 0.10.3
 -------------
 

--- a/docs/app-store-connect/README.md
+++ b/docs/app-store-connect/README.md
@@ -95,6 +95,7 @@ Enable verbose logging for commands
 |[`list-devices`](list-devices.md)|List Devices from Apple Developer portal matching given constraints|
 |[`list-profiles`](list-profiles.md)|List Profiles from Apple Developer portal matching given constraints|
 |[`publish`](publish.md)|Publish application packages to App Store, submit them to Testflight, and release to the groups of beta testers|
+|[`register-device`](register-device.md)|Register a new device for app development|
 
 ### Action groups
 

--- a/docs/app-store-connect/beta-groups/add-build.md
+++ b/docs/app-store-connect/beta-groups/add-build.md
@@ -14,12 +14,12 @@ app-store-connect beta-groups add-build [-h] [--log-stream STREAM] [--no-color] 
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    --build-id BUILD_ID_RESOURCE_ID_REQUIRED
+    BUILD_ID_RESOURCE_ID
     --beta-group BETA_GROUP_NAMES_REQUIRED
 ```
 ### Required arguments for action `add-build`
 
-##### `--build-id=BUILD_ID_RESOURCE_ID_REQUIRED`
+##### `BUILD_ID_RESOURCE_ID`
 
 
 Alphanumeric ID value of the Build

--- a/docs/app-store-connect/list-devices.md
+++ b/docs/app-store-connect/list-devices.md
@@ -15,7 +15,7 @@ app-store-connect list-devices [-h] [--log-stream STREAM] [--no-color] [--versio
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--platform PLATFORM_OPTIONAL]
-    [--name DEVICE_NAME]
+    [--name DEVICE_NAME_OPTIONAL]
     [--status DEVICE_STATUS]
 ```
 ### Optional arguments for action `list-devices`
@@ -24,7 +24,7 @@ app-store-connect list-devices [-h] [--log-stream STREAM] [--no-color] [--versio
 
 
 Bundle ID platform
-##### `--name=DEVICE_NAME`
+##### `--name=DEVICE_NAME_OPTIONAL`
 
 
 Name of the Device

--- a/docs/app-store-connect/register-device.md
+++ b/docs/app-store-connect/register-device.md
@@ -1,12 +1,12 @@
 
-remove-build
-============
+register-device
+===============
 
 
-**Remove build from Beta groups**
+**Register a new device for app development**
 ### Usage
 ```bash
-app-store-connect beta-groups remove-build [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
     [--log-api-calls]
     [--json]
     [--issuer-id ISSUER_ID]
@@ -14,19 +14,26 @@ app-store-connect beta-groups remove-build [-h] [--log-stream STREAM] [--no-colo
     [--private-key PRIVATE_KEY]
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
-    BUILD_ID_RESOURCE_ID
-    --beta-group BETA_GROUP_NAMES_REQUIRED
+    [--platform PLATFORM]
+    --name DEVICE_NAME
+    --udid DEVICE_UDID
 ```
-### Required arguments for action `remove-build`
+### Required arguments for action `register-device`
 
-##### `BUILD_ID_RESOURCE_ID`
-
-
-Alphanumeric ID value of the Build
-##### `--beta-group=BETA_GROUP_NAMES_REQUIRED`
+##### `--name=DEVICE_NAME`
 
 
-Name of your Beta group. Multiple arguments
+Name of the Device
+##### `--udid=DEVICE_UDID`
+
+
+Device ID (UDID)
+### Optional arguments for action `register-device`
+
+##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
+
+
+Bundle ID platform. Default:&nbsp;`IOS`
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.10.3'
+__version__ = '0.11.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -564,7 +564,16 @@ class DeviceArgument(cli.Argument):
         key='device_name',
         flags=('--name',),
         description='Name of the Device',
+        argparse_kwargs={'required': True},
+    )
+    DEVICE_NAME_OPTIONAL = DEVICE_NAME.duplicate(
         argparse_kwargs={'required': False},
+    )
+    DEVICE_UDID = cli.ArgumentProperties(
+        key='device_udid',
+        flags=('--udid',),
+        description='Device ID (UDID)',
+        argparse_kwargs={'required': True},
     )
     DEVICE_STATUS = cli.ArgumentProperties(
         key='device_status',

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -284,7 +284,7 @@ class AppStoreConnect(cli.CliApp,
 
     @cli.action('list-devices',
                 BundleIdArgument.PLATFORM_OPTIONAL,
-                DeviceArgument.DEVICE_NAME,
+                DeviceArgument.DEVICE_NAME_OPTIONAL,
                 DeviceArgument.DEVICE_STATUS)
     def list_devices(self,
                      platform: Optional[BundleIdPlatform] = None,
@@ -298,6 +298,28 @@ class AppStoreConnect(cli.CliApp,
         device_filter = self.api_client.devices.Filter(
             name=device_name, platform=platform, status=device_status)
         return self._list_resources(device_filter, self.api_client.devices, should_print)
+
+    @cli.action('register-device',
+                BundleIdArgument.PLATFORM,
+                DeviceArgument.DEVICE_NAME,
+                DeviceArgument.DEVICE_UDID)
+    def register_device(
+        self,
+        platform: BundleIdPlatform,
+        device_name: str,
+        device_udid: str,
+        should_print: bool = True,
+    ) -> Device:
+        """
+        Register a new device for app development
+        """
+        return self._create_resource(
+            self.api_client.devices,
+            should_print,
+            udid=device_udid,
+            name=device_name,
+            platform=platform,
+        )
 
     @cli.action('create-bundle-id',
                 BundleIdArgument.BUNDLE_ID_IDENTIFIER,


### PR DESCRIPTION
There already was client method available for registering iOS and macOS devices to Apple Development team using [Register a New Device](https://developer.apple.com/documentation/appstoreconnectapi/register_a_new_device) API, but there was no CLI access to it. This PR addes capabilities to register new devices using CLI:

```shell
$ app-store-connect register-device \
        --udid 00008101-000960143488001E \
        --name "White iPhone 12 mini"
Creating new Device: udid: 00008101-000960143488001E, name: 'White iPhone 12 mini', platform: IOS
-- Device (Created) --
Id: P2U5FJ7DX4
Type: devices
Class: IPHONE
Model: iPhone 12 mini
Name: White iPhone 12 mini
Platform: IOS
Status: ENABLED
Udid: 00008101-000960143488001E
Created Device P2U5FJ7DX4

```
