### PR TITLE
Support command execution on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.11.2
+-------------
+
+**Development / Docs**
+
+- Do not import `fcntl` module globally in order to support Windows platform.
+
 Version 0.11.1
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 Version 0.11.2
 -------------
 
+**Features**
+
+- Support running subprocesses on Windows. [PR #156](https://github.com/codemagic-ci-cd/cli-tools/pull/156)
+- Capture logs from subprocesses on Windows. [PR #156](https://github.com/codemagic-ci-cd/cli-tools/pull/156)
+
 **Development / Docs**
 
-- Do not import `fcntl` module globally in order to support Windows platform.
+- Do not import `fcntl` module globally in order to support Windows platform. [PR #156](https://github.com/codemagic-ci-cd/cli-tools/pull/156)
+- Create `CliProcessStream` abstraction layer to handle streams on both POSIX and Windows. [PR #156](https://github.com/codemagic-ci-cd/cli-tools/pull/156)
 
 Version 0.11.1
 -------------

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.11.1'
+__version__ = '0.11.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import os
 import shlex
 import subprocess
@@ -65,6 +64,11 @@ class CliProcess:
         self.logger.debug(f'Completed "{self.safe_form}" with returncode {self.returncode} in {duration}')
 
     def _ensure_process_streams_are_non_blocking(self):
+        try:
+            import fcntl
+        except ImportError:
+            return
+
         for stream in (self._process.stdout, self._process.stderr):
             if stream is None:
                 continue

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shlex
 import subprocess
 import sys
@@ -14,6 +13,7 @@ from typing import Union
 
 from codemagic.utilities import log
 
+from .cli_process_stream import CliProcessStream
 from .cli_types import CommandArg
 from .cli_types import ObfuscatedCommand
 
@@ -37,6 +37,8 @@ class CliProcess:
             self.safe_form = ObfuscatedCommand(full_command)
         self._stdout = ''
         self._stderr = ''
+        self._stdout_stream: Optional[CliProcessStream] = None
+        self._stderr_stream: Optional[CliProcessStream] = None
 
     @property
     def stdout(self) -> str:
@@ -63,37 +65,19 @@ class CliProcess:
         file_logger.debug('STDERR: %s', self.stderr)
         self.logger.debug(f'Completed "{self.safe_form}" with returncode {self.returncode} in {duration}')
 
-    def _ensure_process_streams_are_non_blocking(self):
-        try:
-            import fcntl
-        except ImportError:
-            return
-
-        for stream in (self._process.stdout, self._process.stderr):
-            if stream is None:
-                continue
-            stream_descriptor = stream.fileno()
-            current_stream_flags = fcntl.fcntl(stream_descriptor, fcntl.F_GETFL)
-            fcntl.fcntl(stream_descriptor, fcntl.F_SETFL, current_stream_flags | os.O_NONBLOCK)
-
-    def _handle_stream(self, input_stream: IO, output_stream: IO, buffer_size: Optional[int] = None) -> str:
-        if buffer_size:
-            bytes_chunk = input_stream.read(buffer_size)
-        else:
-            bytes_chunk = input_stream.read()
-
-        chunk = '' if bytes_chunk is None else bytes_chunk.decode()
-        if self._print_streams:
-            output_stream.write(chunk)
-        return chunk
-
     def _handle_streams(self, buffer_size: Optional[int] = None):
         if self._process is None:
             return
+        if self._stdout_stream:
+            self._stdout += self._stdout_stream.process_buffer(buffer_size, self._print_streams)
+        if self._stderr_stream:
+            self._stderr += self._stderr_stream.process_buffer(buffer_size, self._print_streams)
+
+    def _configure_process_streams(self):
         if self._process.stdout:
-            self._stdout += self._handle_stream(self._process.stdout, sys.stdout, buffer_size)
+            self._stdout_stream = CliProcessStream.create(self._process.stdout, sys.stdout, blocking=False)
         if self._process.stderr:
-            self._stderr += self._handle_stream(self._process.stderr, sys.stderr, buffer_size)
+            self._stderr_stream = CliProcessStream.create(self._process.stderr, sys.stderr, blocking=False)
 
     def execute(self,
                 stdout: Union[int, IO] = subprocess.PIPE,
@@ -103,7 +87,7 @@ class CliProcess:
         try:
             if not self._dry_run:
                 self._process = subprocess.Popen(self._command_args, stdout=stdout, stderr=stderr)
-                self._ensure_process_streams_are_non_blocking()
+                self._configure_process_streams()
                 while self._process.poll() is None:
                     self._handle_streams(self._buffer_size)
                     time.sleep(0.1)

--- a/src/codemagic/cli/cli_process_stream.py
+++ b/src/codemagic/cli/cli_process_stream.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+from abc import ABCMeta
+from abc import abstractmethod
+from typing import IO
+from typing import Optional
+
+from codemagic.mixins import StringConverterMixin
+
+if os.name == 'nt':
+    import msvcrt
+
+    import _winapi as winapi
+
+
+class CliProcessStream(StringConverterMixin, metaclass=ABCMeta):
+
+    def __init__(self, input_stream_descriptor: IO, output_stream: IO):
+        self._descriptor = input_stream_descriptor
+        self._fileno = input_stream_descriptor.fileno()
+        self._output_stream = output_stream
+
+    @classmethod
+    def create(cls, stream_descriptor: IO, output_stream: IO, blocking: bool = False) -> CliProcessStream:
+        if os.name == 'nt':  # Running on Windows
+            stream = _WindowsCliProcessStream(stream_descriptor, output_stream)
+        else:
+            stream = _PosixCliProcessStream(stream_descriptor, output_stream)
+        if not blocking:
+            stream.unblock()
+        return stream
+
+    @abstractmethod
+    def unblock(self):
+        """
+        Unblock stream by making the file descriptor async
+        """
+
+    @abstractmethod
+    def read(self, buffer_size=1024) -> bytes:
+        """
+        Read up to specified number of bytes from the stream
+        """
+
+    @abstractmethod
+    def read_all(self) -> bytes:
+        """
+        Read all remaining bytes from the stream
+        """
+
+    def process_buffer(self, buffer_size: Optional[int] = None, multiplex_output: bool = True) -> str:
+        if buffer_size:
+            bytes_chunk = self.read(buffer_size)
+        else:
+            bytes_chunk = self.read_all()
+
+        chunk = bytes_chunk.decode()
+        if multiplex_output:
+            self._output_stream.write(chunk)
+        return chunk
+
+
+class _PosixCliProcessStream(CliProcessStream):
+    def unblock(self):
+        os.set_blocking(self._fileno, False)
+
+    def read(self, buffer_size=1024) -> bytes:
+        try:
+            chunk = self._descriptor.read(buffer_size)
+        except IOError:
+            # In case we get "Resource temporarily unavailable" from the OS
+            chunk = b''
+        return self._bytes(chunk or b'')
+
+    def read_all(self) -> bytes:
+        return self.read(-1)
+
+
+class _WindowsCliProcessStream(CliProcessStream):
+    PIPE_NOWAIT = 0x00000001
+
+    def __init__(self, stream_descriptor: IO, output_stream: IO):
+        super().__init__(stream_descriptor, output_stream)
+        self._pipe_handle = msvcrt.get_osfhandle(self._fileno)
+
+    def unblock(self):
+        # https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-setnamedpipehandlestate
+        winapi.SetNamedPipeHandleState(self._pipe_handle, self.PIPE_NOWAIT, None, None)
+
+    def read(self, buffer_size=1024) -> bytes:
+        # https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
+        try:
+            chunk, _result = winapi.ReadFile(self._pipe_handle, buffer_size, 0)
+        except BrokenPipeError:
+            chunk = b''
+        return self._bytes(chunk or b'')
+
+    def read_all(self) -> bytes:
+        # https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe
+        # Check how much is there still remaining in the pipe to be read and use that as the final buffer size
+        _data, buffer_size, _res = winapi.PeekNamedPipe(self._pipe_handle, 1)
+        return self.read(buffer_size)

--- a/src/codemagic/cli/cli_process_stream.py
+++ b/src/codemagic/cli/cli_process_stream.py
@@ -99,5 +99,9 @@ class _WindowsCliProcessStream(CliProcessStream):
     def read_all(self) -> bytes:
         # https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe
         # Check how much is there still remaining in the pipe to be read and use that as the final buffer size
-        _data, buffer_size, *_rest = winapi.PeekNamedPipe(self._pipe_handle, 1)
+        try:
+            _data, buffer_size, *_rest = winapi.PeekNamedPipe(self._pipe_handle, 1)
+        except BrokenPipeError:
+            # The pipe has already been ended
+            return b''
         return self.read(buffer_size)

--- a/tests/cli/test_cli_process.py
+++ b/tests/cli/test_cli_process.py
@@ -2,25 +2,23 @@ import os
 import subprocess
 from tempfile import NamedTemporaryFile
 
+import pytest
+
 from codemagic import cli
 
 
 def assert_non_blocking(stream):
-    try:
-        import fcntl
-    except ImportError:
-        assert False, 'Failed to import module "fcntl"'
-    stream_flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
-    assert stream_flags & os.O_NONBLOCK == os.O_NONBLOCK
+    assert os.get_blocking(stream.fileno()) is False
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Cannot run on Windows')
 def test_non_blocking_streams():
     cli_process = cli.CliProcess([])
     cli_process._process = subprocess.Popen(
         ['sleep', '3'],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    cli_process._ensure_process_streams_are_non_blocking()
+    cli_process._configure_process_streams()
 
     assert_non_blocking(cli_process._process.stdout)
     assert_non_blocking(cli_process._process.stderr)
@@ -28,6 +26,7 @@ def test_non_blocking_streams():
     cli_process._process.kill()
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Cannot run on Windows')
 def test_non_blocking_streams_file_fd():
     with NamedTemporaryFile(mode='wb') as tf:
         cli_process = cli.CliProcess([])
@@ -35,7 +34,7 @@ def test_non_blocking_streams_file_fd():
             ['sleep', '3'],
             stdout=tf,
             stderr=tf)
-        cli_process._ensure_process_streams_are_non_blocking()
+        cli_process._configure_process_streams()
 
         assert cli_process._process.stdout is None
         assert cli_process._process.stderr is None

--- a/tests/cli/test_cli_process.py
+++ b/tests/cli/test_cli_process.py
@@ -26,7 +26,6 @@ def test_non_blocking_streams():
     cli_process._process.kill()
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='Cannot run on Windows')
 def test_non_blocking_streams_file_fd():
     with NamedTemporaryFile(mode='wb') as tf:
         cli_process = cli.CliProcess([])
@@ -38,5 +37,7 @@ def test_non_blocking_streams_file_fd():
 
         assert cli_process._process.stdout is None
         assert cli_process._process.stderr is None
+        assert cli_process._stdout_stream is None
+        assert cli_process._stderr_stream is None
 
         cli_process._process.kill()

--- a/tests/cli/test_cli_process.py
+++ b/tests/cli/test_cli_process.py
@@ -1,4 +1,3 @@
-import fcntl
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
@@ -7,6 +6,10 @@ from codemagic import cli
 
 
 def assert_non_blocking(stream):
+    try:
+        import fcntl
+    except ImportError:
+        assert False, 'Failed to import module "fcntl"'
     stream_flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
     assert stream_flags & os.O_NONBLOCK == os.O_NONBLOCK
 


### PR DESCRIPTION
In most cases the tools provided by this module are actually just more user-friendy wrappers for some other executables in the system. As such, much of the heavylifting is done by the [`CliProcess`](https://github.com/codemagic-ci-cd/cli-tools/blob/326787ce788282ad88a0aa62d0ca4a6c98e98c2f/src/codemagic/cli/cli_process.py) class, which unfortunately currently does not work on Windows: 

```python
In [1]: from codemagic.cli import CliProcess
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-dbc669446119> in <module>
----> 1 from codemagic.cli import CliProcess

c:\users\administrator\.pyenv\pyenv-win\versions\3.9.6\lib\site-packages\codemagic\cli\__init__.py in <module>
      6 from .argument import EnvironmentArgumentValue
      7 from .argument import TypedCliArgument
----> 8 from .cli_app import CliApp
      9 from .cli_app import CliAppException
     10 from .cli_app import action

c:\users\administrator\.pyenv\pyenv-win\versions\3.9.6\lib\site-packages\codemagic\cli\cli_app.py in <module>
     34 from .argument import ArgumentFormatter
     35 from .cli_help_formatter import CliHelpFormatter
---> 36 from .cli_process import CliProcess
     37 from .cli_types import CommandArg
     38 from .cli_types import ObfuscatedCommand

c:\users\administrator\.pyenv\pyenv-win\versions\3.9.6\lib\site-packages\codemagic\cli\cli_process.py in <module>
      3 from __future__ import annotations
      4
----> 5 import fcntl
      6 import os
      7 import shlex

ModuleNotFoundError: No module named 'fcntl'
```

The exception above is caused because reading executed command `stderr` and `stdout` was implemented for Unix file descriptors only, which rely on [`fcntl`](https://manpages.debian.org/bullseye/manpages-dev/fcntl.2.en.html). However on Windows the command streams have [Win32 named pipes](https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes) in the background.

To overcome this, an abstraction layer was added in the form of `CliProcessStream`, which takes care of platform specific code for unblocking the streams and reading from them.