### PR TITLE
Feature: altool verbose logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Version 0.11.3
+-------------
+
+**Features**
+
+- Add switch to use verbose logging for `altool` subcommands that are executed as part of `app-store-connect publish`. [PR #160](https://github.com/codemagic-ci-cd/cli-tools/pull/160)
+
+**Development / Docs**
+
+- Update `app-store-connect publish` action docs. [PR #160](https://github.com/codemagic-ci-cd/cli-tools/pull/160)
+
 Version 0.11.2
 -------------
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -24,6 +24,7 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [--beta-group BETA_GROUP_NAMES_OPTIONAL]
     [--skip-package-validation]
     [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT]
+    [--verbose-altool-logging]
 ```
 ### Optional arguments for action `publish`
 
@@ -67,6 +68,10 @@ Skip package validation before uploading it to App Store Connect. Use this switc
 
 
 Maximum amount of minutes to wait for the freshly uploaded build to be processed by Apple and retry submitting the build for beta review. If the processing is not finished within the specified timeframe, further submission will be terminated. Waiting will be skipped if the value is set to 0, further actions might fail if the build is not processed yet. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT`. [Default: 20]
+##### `--verbose-altool-logging`
+
+
+Show verbose log output when launching Application Loader tool. That is add `--verbose` flag to `altool` invocations when either validating the package, or while uploading the pakcage to App Store Connect. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_VERBOSE_ALTOOL_LOGGING`.
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.11.2'
+__version__ = '0.11.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -415,7 +415,8 @@ class CliApp(metaclass=abc.ABCMeta):
     def execute(self, command_args: Sequence[CommandArg],
                 obfuscate_patterns: Optional[Sequence[ObfuscationPattern]] = None,
                 show_output: bool = True,
-                suppress_output: bool = False) -> CliProcess:
+                suppress_output: bool = False,
+                **execute_kwargs) -> CliProcess:
         if suppress_output:
             print_streams = False
         else:
@@ -426,7 +427,7 @@ class CliApp(metaclass=abc.ABCMeta):
             self._obfuscate_command(command_args, obfuscate_patterns),
             dry=self.dry_run,
             print_streams=print_streams,
-        ).execute()
+        ).execute(**execute_kwargs)
 
 
 def action(action_name: str,

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -44,6 +44,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
         self._password = password  # App Specific Password
         self._validate_authentication_info()
         self.logger = log.get_logger(self.__class__)
+        self.verbose = os.environ.get('ALTOOL_VERBOSE')
 
     @classmethod
     @lru_cache(1)
@@ -103,15 +104,16 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
             except KeyError:
                 pass
 
-    @classmethod
     def _construct_action_command(
-            cls, action_name: str, artifact_path: pathlib.Path, auth_flags: Sequence[str]) -> Tuple[str, ...]:
+            self, action_name: str, artifact_path: pathlib.Path, auth_flags: Sequence[str]) -> Tuple[str, ...]:
+        verbose_flags = ['--verbose'] if self.verbose else []
         return (
             'xcrun', 'altool', action_name,
             '--file', str(artifact_path),
             '--type', PlatformType.from_path(artifact_path).value,
             *auth_flags,
             '--output-format', 'json',
+            *verbose_flags,
         )
 
     def validate_app(self, artifact_path: pathlib.Path) -> Optional[AltoolResult]:

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -34,7 +34,8 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
                  issuer_id: Optional[IssuerId] = None,
                  private_key: Optional[str] = None,
                  username: Optional[str] = None,
-                 password: Optional[str] = None):
+                 password: Optional[str] = None,
+                 verbose: bool = False):
         # JWT authentication fields
         self._key_identifier = key_identifier
         self._issuer_id = issuer_id
@@ -44,7 +45,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
         self._password = password  # App Specific Password
         self._validate_authentication_info()
         self.logger = log.get_logger(self.__class__)
-        self.verbose = os.environ.get('ALTOOL_VERBOSE')
+        self.verbose = verbose
 
     @classmethod
     @lru_cache(1)
@@ -135,11 +136,19 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
         obfuscate_patterns = [self._password] if self._password else []
         try:
             if cli_app:
-                process = cli_app.execute(command, obfuscate_patterns, show_output=False)
+                process = cli_app.execute(
+                    command,
+                    obfuscate_patterns,
+                    show_output=False,
+                    stderr=subprocess.STDOUT,
+                )
                 stdout = process.stdout
                 process.raise_for_returncode()
             else:
-                stdout = subprocess.check_output(command, stderr=subprocess.PIPE).decode()
+                stdout = subprocess.check_output(
+                    command,
+                    stderr=subprocess.STDOUT,
+                ).decode()
         except subprocess.CalledProcessError as cpe:
             stdout = cpe.stdout
             result = self._get_action_result(cpe.stdout)

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -39,6 +39,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 BuildArgument.BETA_GROUP_NAMES_OPTIONAL,
                 PublishArgument.SKIP_PACKAGE_VALIDATION,
                 PublishArgument.MAX_BUILD_PROCESSING_WAIT,
+                PublishArgument.VERBOSE_ALTOOL_LOGGING,
                 action_options={'requires_api_client': False})
     def publish(self,
                 application_package_path_patterns: Sequence[pathlib.Path],
@@ -50,6 +51,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
                 beta_group_names: Optional[List[str]] = None,
                 skip_package_validation: Optional[bool] = None,
+                verbose_altool_logging: Optional[bool] = None,
                 max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None) -> None:
         """
         Publish application packages to App Store, submit them to Testflight, and release to the groups of beta testers
@@ -74,6 +76,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 key_identifier=self._key_identifier,
                 issuer_id=self._issuer_id,
                 private_key=self._private_key,
+                verbose=bool(verbose_altool_logging),
             )
         except ValueError as ve:
             raise AppStoreConnectError(str(ve))

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -74,6 +74,10 @@ class Types:
         argument_type = bool
         environment_variable_key = 'APP_STORE_CONNECT_SKIP_PACKAGE_VALIDATION'
 
+    class AppStoreConnectVerboseAltoolLogging(cli.TypedCliArgument[bool]):
+        argument_type = bool
+        environment_variable_key = 'APP_STORE_CONNECT_VERBOSE_ALTOOL_LOGGING'
+
     class MaxBuildProcessingWait(cli.TypedCliArgument[int]):
         argument_type = int
         environment_variable_key = 'APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT'
@@ -337,6 +341,20 @@ class PublishArgument(cli.Argument):
         ),
         argparse_kwargs={
             'required': False,
+        },
+    )
+    VERBOSE_ALTOOL_LOGGING = cli.ArgumentProperties(
+        key='verbose_altool_logging',
+        flags=('--verbose-altool-logging',),
+        type=Types.AppStoreConnectVerboseAltoolLogging,
+        description=(
+            'Show verbose log output when launching Application Loader tool. '
+            'That is add `--verbose` flag to `altool` invocations when either validating '
+            'the package, or while uploading the pakcage to App Store Connect.'
+        ),
+        argparse_kwargs={
+            'required': False,
+            'action': 'store_true',
         },
     )
 


### PR DESCRIPTION
In order to get better insight about the update or validation failures during `app-store-connect publish`, add an option to launch `altool` invocation with `--verbose` flag.

Example usage:
```shell
$ app-store-connect publish \
    --path app.ipa \
    --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER \
    --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID \
    --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
    --verbose-altool-logging
```

Or using an environment variable to configure this option
```shell
$ export APP_STORE_CONNECT_VERBOSE_ALTOOL_LOGGING=true
$ app-store-connect publish \
    --path app.ipa \
    --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER \
    --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID \
    --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY
```