### PR TITLE
Bugfix: decoding undefined byte sequences in process streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.11.4
+-------------
+
+**Fixes**
+
+- Fix decoding undefined byte sequences while processing subprocess streams. [PR #161](https://github.com/codemagic-ci-cd/cli-tools/pull/160)
+
 Version 0.11.3
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.11.4
 
 **Fixes**
 
-- Fix decoding undefined byte sequences while processing subprocess streams. [PR #161](https://github.com/codemagic-ci-cd/cli-tools/pull/160)
+- Fix decoding undefined byte sequences while processing subprocess streams. [PR #162](https://github.com/codemagic-ci-cd/cli-tools/pull/162)
 
 Version 0.11.3
 -------------

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.11.3'
+__version__ = '0.11.4'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_process_stream.py
+++ b/src/codemagic/cli/cli_process_stream.py
@@ -55,7 +55,7 @@ class CliProcessStream(StringConverterMixin, metaclass=ABCMeta):
         else:
             bytes_chunk = self.read_all()
 
-        chunk = bytes_chunk.decode()
+        chunk = bytes_chunk.decode(encoding='utf-8', errors='ignore')
         if multiplex_output:
             self._output_stream.write(chunk)
         return chunk


### PR DESCRIPTION
In case there are byte sequences in the invoked subprocess output that do not have unicode representation, then unexpected `UnicodeDecodeErrors` might occur while decoding those byte chunks. An example stacktrace is as follows:
```python
Traceback (most recent call last):
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/tools/_app_store_connect/actions/publish_action.py", line 88, in publish
    self._publish_application_package(altool, application_package, validate_package)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/tools/_app_store_connect/actions/publish_action.py", line 116, in _publish_application_package
    self._validate_artifact_with_altool(altool, application_package.path)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/tools/_app_store_connect/actions/publish_action.py", line 248, in _validate_artifact_with_altool
    result = altool.validate_app(artifact_path)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/altool/altool.py", line 124, in validate_app
    return self._run_command(cmd, f'Failed to validate archive at "{artifact_path}"')
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/models/altool/altool.py", line 143, in _run_command
    stderr=subprocess.STDOUT,
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/cli/cli_app.py", line 430, in execute
    ).execute(**execute_kwargs)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/cli/cli_process.py", line 92, in execute
    self._handle_streams(self._buffer_size)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/cli/cli_process.py", line 72, in _handle_streams
    self._stdout += self._stdout_stream.process_buffer(buffer_size, self._print_streams)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.9.1-py3.7.egg/codemagic/cli/cli_process_stream.py", line 58, in process_buffer
    chunk = bytes_chunk.decode(encoding='utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 8191: unexpected end of data
```
Result of this error is that the action execution will fail with unexpected error.