### PR TITLE
Bugfix: Gracefully handle invalid arguments from environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 0.12.1
 
 **Fixes**
 
-- Show appropriate error messages when invalid values are passed to CLI actions using environment variables.
+- Show appropriate error messages when invalid values are passed to CLI actions using environment variables. [PR #168](https://github.com/codemagic-ci-cd/cli-tools/pull/168)
 
 Version 0.12.0
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.12.1
+-------------
+
+**Fixes**
+
+- Show appropriate error messages when invalid values are passed to CLI actions using environment variables.
+
 Version 0.12.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.12.0'
+__version__ = '0.12.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -129,6 +129,8 @@ class EnvironmentArgumentValue(TypedCliArgument[T], metaclass=abc.ABCMeta):
             return self._apply_type(os.environ[key])
         except KeyError:
             raise argparse.ArgumentTypeError(f'Environment variable "{key}" is not defined')
+        except argparse.ArgumentTypeError as ate:
+            raise argparse.ArgumentTypeError(f'Provided value in environment variable "{key}" is not valid') from ate
 
     def _get_from_file(self) -> T:
         path = Path(self._raw_value[6:])
@@ -139,8 +141,8 @@ class EnvironmentArgumentValue(TypedCliArgument[T], metaclass=abc.ABCMeta):
         content = path.read_text()
         try:
             return self._apply_type(content)
-        except argparse.ArgumentTypeError:
-            raise argparse.ArgumentTypeError(f'Provided value in file "{path}" is not valid')
+        except argparse.ArgumentTypeError as ate:
+            raise argparse.ArgumentTypeError(f'Provided value in file "{path}" is not valid') from ate
 
     def _parse_value(self) -> T:
         if self._is_from_environment():

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -177,10 +177,9 @@ def test_no_skip_package_validation_argument_from_env(cli_argument_group):
     PublishArgument.SKIP_PACKAGE_VALIDATION.register(cli_argument_group)
     args = argparse.Namespace(skip_package_validation=None)
     os.environ[Types.AppStoreConnectSkipPackageValidation.environment_variable_key] = ''
-    with pytest.raises(argparse.ArgumentTypeError) as error_info:
+    with pytest.raises(argparse.ArgumentError) as error_info:
         PublishArgument.SKIP_PACKAGE_VALIDATION.from_args(args)
-    print(error_info.value)
-    assert str(error_info.value) == 'Provided value "False" is not valid'
+    assert str(error_info.value) == 'argument --skip-package-validation: Provided value "False" is not valid'
 
 
 def test_add_build_to_beta_groups(publishing_namespace_kwargs):

--- a/tests/tools/test_google_play.py
+++ b/tests/tools/test_google_play.py
@@ -64,18 +64,18 @@ def test_invalid_credentials_from_env(namespace_kwargs):
     os.environ[Types.CredentialsArgument.environment_variable_key] = 'invalid credentials'
     namespace_kwargs[credentials_argument.key] = None
     cli_args = argparse.Namespace(**dict(namespace_kwargs.items()))
-    with pytest.raises(argparse.ArgumentTypeError) as exception_info:
+    with pytest.raises(argparse.ArgumentError) as exception_info:
         GooglePlay.from_cli_args(cli_args)
-    assert 'invalid credentials' in str(exception_info.value)
+    assert str(exception_info.value) == 'argument --credentials: Provided value "invalid credentials" is not valid'
 
 
 def test_credentials_invalid_path(namespace_kwargs):
     os.environ[Types.CredentialsArgument.environment_variable_key] = '@file:this-is-not-a-file'
     namespace_kwargs[credentials_argument.key] = None
     cli_args = argparse.Namespace(**dict(namespace_kwargs.items()))
-    with pytest.raises(argparse.ArgumentTypeError) as exception_info:
+    with pytest.raises(argparse.ArgumentError) as exception_info:
         GooglePlay.from_cli_args(cli_args)
-    assert 'this-is-not-a-file' in str(exception_info.value)
+    assert str(exception_info.value) == 'argument --credentials: File "this-is-not-a-file" does not exist'
 
 
 @mock.patch('codemagic.tools.google_play.GooglePlayDeveloperAPIClient')


### PR DESCRIPTION
In case invalid argument value (either by validation standards or type mismatch) is provided for CLI action via environment variables, then the invoked action fails unexpectedly with status code 9 and no appopriate error message.
For example if App Store Connect API key is defined via environment variables, then `app-store-connect` commands fail unexpectedly like
```shell
$ APP_STORE_CONNECT_PRIVATE_KEY="invalid private key" app-store-connect apps list
Executing AppStoreConnect action apps failed unexpectedly. Detailed logs are available at "/var/folders/vs/tcrc5cns67zgynxt6fssjdg80000gn/T/codemagic-24-11-21.log". To see more details about the error, add `--verbose` command line option.
```

From the logs we can see that handling invalid argument failed:
```log
[12:40:16 24-11-2021] DEBUG cli_app.py:232 > ------------------------------------------------------------------------------
[12:40:16 24-11-2021] DEBUG cli_app.py:233 > Execute /Users/priit/.pyenv/versions/3.8.10/bin/app-store-connect apps list
[12:40:16 24-11-2021] DEBUG cli_app.py:234 > From /Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic
[12:40:16 24-11-2021] DEBUG cli_app.py:235 > Using Python 3.8.10 on Darwin 20.3.0
[12:40:16 24-11-2021] DEBUG cli_app.py:236 > ------------------------------------------------------------------------------
[12:40:16 24-11-2021] WARNING cli_app.py:111 > Executing AppStoreConnect action apps failed unexpectedly. Detailed logs are available at "/var/folders/vs/tcrc5cns67zgynxt6fssjdg80000gn/T/codemagic-24-11-21.log". To see more details about the error, add `--verbose` command line option.
[12:40:16 24-11-2021] ERROR cli_app.py:113 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 201, in invoke_cli
    CliApp._running_app = cls._create_instance(parser, args)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 130, in _create_instance
    instance = cls.from_cli_args(cli_args)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 118, in from_cli_args
    private_key_argument = AppStoreConnectArgument.PRIVATE_KEY.from_args(cli_args)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/argument.py", line 65, in from_args
    return self.value.type.from_environment_variable_default()
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/typed_cli_argument.py", line 58, in from_environment_variable_default
    return cls(os.environ[cls.environment_variable_key], from_environment=True)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/typed_cli_argument.py", line 33, in __init__
    self.value: T = self._parse_value()
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/typed_cli_argument.py", line 145, in _parse_value
    return super()._parse_value()
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/typed_cli_argument.py", line 73, in _parse_value
    return self._apply_type(value)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic/cli/argument/typed_cli_argument.py", line 68, in _apply_type
    raise argparse.ArgumentTypeError(f'Provided value "{value}" is not valid')
argparse.ArgumentTypeError: Provided value "invalid private key" is not valid
[12:40:16 24-11-2021] DEBUG cli_app.py:244 > ----------------------------------------------------------
[12:40:16 24-11-2021] DEBUG cli_app.py:245 > Completed AppStoreConnect apps in 00:00 with status code 9
[12:40:16 24-11-2021] DEBUG cli_app.py:246 > ----------------------------------------------------------
```

Changes introduced in this PR fix handling those validation errors. Examples again with `app-store-connect` and API key argument:

```shell
$ app-store-connect apps list --private-key 'invalid key'
app-store-connect apps list: error: argument --private-key: Provided value "invalid key" is not valid

$ app-store-connect apps list --private-key @file:/tmp/file-does-not-exist.p8
app-store-connect apps list: error: argument --private-key: File "/tmp/file-does-not-exist.p8" does not exist

$ app-store-connect apps list --private-key @file:/tmp/invalid-private-key.p8
app-store-connect apps list: error: argument --private-key: Provided value in file "/tmp/invalid-private-key.p8" is not valid

$ app-store-connect apps list --private-key @env:UNDEFINED_VARIABLE
app-store-connect apps list: error: argument --private-key: Environment variable "UNDEFINED_VARIABLE" is not defined

$ INVALID_PRIVATE_KEY='invalid private key' app-store-connect apps list --private-key @env:INVALID_PRIVATE_KEY
app-store-connect apps list: error: argument --private-key: Provided value in environment variable "INVALID_PRIVATE_KEY" is not valid

$ APP_STORE_CONNECT_PRIVATE_KEY="invalid key" app-store-connect apps list
app-store-connect: error: argument --private-key: Provided value "invalid key" is not valid

$ APP_STORE_CONNECT_PRIVATE_KEY="@file:/tmp/file-does-not-exist.p8" app-store-connect apps list
app-store-connect: error: argument --private-key: File "/tmp/file-does-not-exist.p8" does not exist

$ APP_STORE_CONNECT_PRIVATE_KEY="@file:/tmp/invalid-private-key.p8" app-store-connect apps list
app-store-connect: error: argument --private-key: Provided value in file "/tmp/invalid-private-key.p8" is not valid

$ APP_STORE_CONNECT_PRIVATE_KEY="@env:UNDEFINED_VARIABLE" app-store-connect apps list
app-store-connect: error: argument --private-key: Environment variable "UNDEFINED_VARIABLE" is not defined

$ APP_STORE_CONNECT_PRIVATE_KEY="@env:UNDEFINED_VARIABLE" app-store-connect apps list
app-store-connect: error: argument --private-key: Environment variable "UNDEFINED_VARIABLE" is not defined
```

Closes #167.