### PR TITLE
Improvement: App Store Connect JWT cache logging and lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+UNRELEASED
+-------------
+
+**Fixes**
+- Revoke cached App Store Connect API JSON web token when unauthorized request retry attempts are exhausted. [PR #188](https://github.com/codemagic-ci-cd/cli-tools/pull/188)
+
+**Development**
+- Log for which App Store Connect API key JWT is generated or loaded from disk cache. [PR #188](https://github.com/codemagic-ci-cd/cli-tools/pull/188)
+- Remove `reset_token` parameter from `AppStoreConnectApiClient.generate_auth_headers`. [PR #188](https://github.com/codemagic-ci-cd/cli-tools/pull/188)
+- Add optional `revoke_auth_info: Callable[[], None]` parameter to `AppStoreConnectApiSession` to reset App Store Connect API authentication information in case of unauthorized requests. [PR #188](https://github.com/codemagic-ci-cd/cli-tools/pull/188)
+
 Version 0.16.0
 -------------
 

--- a/src/codemagic/apple/app_store_connect/json_web_token_manager.py
+++ b/src/codemagic/apple/app_store_connect/json_web_token_manager.py
@@ -65,6 +65,7 @@ class JsonWebTokenManager(StringConverterMixin):
         self._revoke_disk_cache()
 
     def _revoke_disk_cache(self):
+        self._logger.info('Revoke JWT disk cache for App Store Connect key %r', self._key.identifier)
         if not self._enable_cache:
             return
 
@@ -78,7 +79,7 @@ class JsonWebTokenManager(StringConverterMixin):
             return
         self.cache_path.parent.mkdir(exist_ok=True, parents=True)
         self.cache_path.write_text(token)
-        self._logger.debug('Cached App Store Connect JWT')
+        self._logger.debug('Cached App Store Connect JWT for key %s', self._key.identifier)
 
     def _encode_token(self, jwt_payload: JwtPayload):
         return jwt.encode(
@@ -99,7 +100,7 @@ class JsonWebTokenManager(StringConverterMixin):
     def _load_jwt_from_disk(self) -> JWT:
         if not self._enable_cache:
             raise JwtCacheError('Disk cache is disabled')
-        self._logger.debug('Load JWT for App Store Connect from disk cache')
+        self._logger.debug('Load JWT for App Store Connect key %r from disk cache', self._key.identifier)
         try:
             token = self.cache_path.read_text().strip()
         except FileNotFoundError:
@@ -125,7 +126,7 @@ class JsonWebTokenManager(StringConverterMixin):
         return JWT(self._key.identifier, token, payload, expires_at)
 
     def _generate_jwt(self) -> JWT:
-        self._logger.debug('Generate new App Store Connect JWT')
+        self._logger.debug('Generate new App Store Connect JWT for key %r', self._key.identifier)
         expires_at = datetime.now() + timedelta(seconds=self._token_duration)
         payload = {
             'iss': self._key.issuer_id,

--- a/tests/apple/app_store_connect/test_api_session.py
+++ b/tests/apple/app_store_connect/test_api_session.py
@@ -64,11 +64,17 @@ def test_unauthorized_retrying_success(mock_session, mock_successful_response, m
     mock_session.side_effect = (mock_unauthorized_response, mock_unauthorized_response, mock_successful_response)
 
     mock_auth_headers_factory = mock.Mock(return_value={})
-    session = AppStoreConnectApiSession(mock_auth_headers_factory, unauthorized_request_retries=3)
+    mock_revoke_auth_info = mock.Mock()
+    session = AppStoreConnectApiSession(
+        mock_auth_headers_factory,
+        unauthorized_request_retries=3,
+        revoke_auth_info=mock_revoke_auth_info,
+    )
     final_response = session.get('https://example.com')
 
     # Check that only first call does not require JWT refresh
-    assert mock_auth_headers_factory.mock_calls == [((False,),), ((True,),), ((True,),)]
+    assert mock_auth_headers_factory.mock_calls == [(), (), ()]
+    assert mock_revoke_auth_info.mock_calls == [(), ()]
     mock_unauthorized_response.assert_not_called()
     mock_successful_response.assert_has_calls([('json', (), {})])
 
@@ -82,7 +88,12 @@ def test_unauthorized_retrying_failure(mock_session, mock_unauthorized_response)
 
     mock_session.side_effect = [mock_unauthorized_response for _ in range(retries_count + 1)]
     mock_auth_headers_factory = mock.Mock(return_value={})
-    session = AppStoreConnectApiSession(mock_auth_headers_factory, unauthorized_request_retries=retries_count)
+    mock_revoke_auth_info = mock.Mock()
+    session = AppStoreConnectApiSession(
+        mock_auth_headers_factory,
+        unauthorized_request_retries=retries_count,
+        revoke_auth_info=mock_revoke_auth_info,
+    )
     with pytest.raises(AppStoreConnectApiError) as error_info:
         session.get('https://example.com')
 
@@ -90,7 +101,8 @@ def test_unauthorized_retrying_failure(mock_session, mock_unauthorized_response)
     assert mock_session.call_count == retries_count
 
     # Check that only first call does not require JWT refresh
-    assert mock_auth_headers_factory.mock_calls == [((False,),), ((True,),), ((True,),)]
+    assert mock_auth_headers_factory.mock_calls == [(), (), ()]
+    assert mock_revoke_auth_info.mock_calls == [(), (), ()]
 
     # Finally when retries are exhausted the unauthorized error is still thrown
     assert error_info.value.response is mock_unauthorized_response
@@ -101,16 +113,22 @@ def test_http_error_not_found(mock_session, mock_successful_response, mock_not_f
     mock_session.side_effect = (mock_not_found_response, mock_successful_response)
 
     mock_auth_headers_factory = mock.Mock(return_value={})
-    session = AppStoreConnectApiSession(mock_auth_headers_factory, unauthorized_request_retries=3)
+    mock_revoke_auth_info = mock.Mock()
+    session = AppStoreConnectApiSession(
+        mock_auth_headers_factory,
+        unauthorized_request_retries=3,
+        revoke_auth_info=mock_revoke_auth_info,
+    )
     with pytest.raises(AppStoreConnectApiError) as error_info:
         session.get('https://example.com')
 
     # Fail hard on first attempt on non-authorization error
     assert mock_session.call_count == 1
 
-    mock_auth_headers_factory.assert_called_once_with(False)
+    mock_auth_headers_factory.assert_called_once()
     assert mock_auth_headers_factory.method_calls == []
 
+    mock_revoke_auth_info.assert_not_called()
     mock_successful_response.assert_not_called()
     assert mock_successful_response.method_calls == []
 


### PR DESCRIPTION
Improvements to App Store Connect JSON web token management.

- Include App Store Connect API key identifier in verbose log to indicate for which keys JSON web token is either generated or loaded from cache.
- Revoke invalid JSON web token when unauthorized request retries are exhausted so that the same token will not be used for subsequent command invocations from disk cache.