### PR TITLE
Bugfix: Allow OpenSSH keys for certificate private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.17.2
+-------------
+
+This is a bugfix release to fix the regression introduced in v0.17.2.
+
+**Fixes**
+- Consider OpenSSH private keys for `app-store-connect` argument `--certificate-key` valid again. Due to changes in [PR #196](https://github.com/codemagic-ci-cd/cli-tools/pull/196) only PEM encoded keys were accepted as certificate keys, but OpenSSH keys are not fully compatible with the PEM standard, and should be allowed too. [PR #197](https://github.com/codemagic-ci-cd/cli-tools/pull/197)
+
 Version 0.17.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -86,8 +86,12 @@ class Types:
                 raise argparse.ArgumentTypeError('Provided value is not a valid PEM encoded private key')
             return pem_private_key
 
-    class CertificateKeyArgument(PrivateKeyArgument):
+    class CertificateKeyArgument(cli.EnvironmentArgumentValue[str]):
         environment_variable_key = 'CERTIFICATE_PRIVATE_KEY'
+
+        @classmethod
+        def _is_valid(cls, value: str) -> bool:
+            return value.startswith('-----BEGIN ')
 
     class CertificateKeyPasswordArgument(cli.EnvironmentArgumentValue):
         environment_variable_key = 'CERTIFICATE_PRIVATE_KEY_PASSWORD'


### PR DESCRIPTION
Due to changes in [PR #196](https://github.com/codemagic-ci-cd/cli-tools/pull/196) only PEM encoded keys were accepted as certificate keys, but OpenSSH keys are not fully compatible with the PEM standard, and should be allowed too.
Consider OpenSSH private keys for `app-store-connect` argument `--certificate-key` valid again. 
