### PR TITLE
Feature: Use "Distribution" certificate for iOS App AdHoc profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+UNRELEASED
+-------------
+
+**Features**
+- Change default behaviour for resolving certificate type from provisioning profile type. Map `IOS_APP_ADHOC` provisioning profile type to `DISTRIBUTION` certificate type instead of `IOS_DISTRIBUTION` certificate type. "Apple Distribution" certificates can be used to sign any type of application (iOS, tvOS, Mac, Universal, etc.) and as a result fewer certificates are required. Applies to the following actions:
+  - `app-store-connect fetch-signing-files`,
+  - `app-store-connect list-certificates`.
+  
+  This change is backwards compatible in the sense that existing matching `IOS_DISTRIBUTION` certificates are still used for `IOS_APP_ADHOC` provisioning profiles if found. [PR #198](https://github.com/codemagic-ci-cd/cli-tools/pull/198)
+
+**Development**
+- Behaviour of `CertificateType.from_profile_type` was changed:
+  - calling it with `ProfileType.IOS_APP_STORE` returns `CertificateType.DISTRIBUTION` instead of `CertificateType.IOS_DISTRIBUTION` as before,
+  - and calling it with `ProfileType.MAC_APP_STORE` returns `CertificateType.DISTRIBUTION` instead of `CertificateType.MAC_APP_DISTRIBUTION`. [PR #198](https://github.com/codemagic-ci-cd/cli-tools/pull/198)
+
 Version 0.17.2
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ UNRELEASED
 -------------
 
 **Features**
-- Change default behaviour for resolving certificate type from provisioning profile type. Map `IOS_APP_ADHOC` provisioning profile type to `DISTRIBUTION` certificate type instead of `IOS_DISTRIBUTION` certificate type. "Apple Distribution" certificates can be used to sign any type of application (iOS, tvOS, Mac, Universal, etc.) and as a result fewer certificates are required. Applies to the following actions:
+- Change default behaviour for resolving certificate type from provisioning profile type. Map `IOS_APP_ADHOC` provisioning profile type to `DISTRIBUTION` certificate type instead of `IOS_DISTRIBUTION`. "Apple Distribution" certificates can be used to sign any type of application (iOS, tvOS, Mac, Universal, etc.) and as a result fewer certificates are required. Applies to the following actions:
   - `app-store-connect fetch-signing-files`,
   - `app-store-connect list-certificates`.
   
@@ -10,8 +10,7 @@ UNRELEASED
 
 **Development**
 - Behaviour of `CertificateType.from_profile_type` was changed:
-  - calling it with `ProfileType.IOS_APP_STORE` returns `CertificateType.DISTRIBUTION` instead of `CertificateType.IOS_DISTRIBUTION` as before,
-  - and calling it with `ProfileType.MAC_APP_STORE` returns `CertificateType.DISTRIBUTION` instead of `CertificateType.MAC_APP_DISTRIBUTION`. [PR #198](https://github.com/codemagic-ci-cd/cli-tools/pull/198)
+  - calling it with `ProfileType.IOS_APP_STORE` returns `CertificateType.DISTRIBUTION` instead of `CertificateType.IOS_DISTRIBUTION` as before. [PR #198](https://github.com/codemagic-ci-cd/cli-tools/pull/198)
 
 Version 0.17.2
 -------------

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -191,7 +191,7 @@ class CertificateType(ResourceEnum):
     @classmethod
     def from_profile_type(cls, profile_type: ProfileType) -> CertificateType:
         if profile_type is profile_type.IOS_APP_ADHOC:
-            return CertificateType.IOS_DISTRIBUTION
+            return CertificateType.DISTRIBUTION
         elif profile_type is profile_type.IOS_APP_DEVELOPMENT:
             return CertificateType.IOS_DEVELOPMENT
         elif profile_type is profile_type.IOS_APP_STORE:

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -568,6 +568,8 @@ class AppStoreConnect(
             # certificates and consequently they too can be used with those profiles.
             if profile_type is ProfileType.IOS_APP_STORE:
                 types.add(CertificateType.IOS_DISTRIBUTION)
+            elif profile_type is ProfileType.IOS_APP_ADHOC:
+                types.add(CertificateType.IOS_DISTRIBUTION)
             elif profile_type is ProfileType.MAC_APP_STORE:
                 types.add(CertificateType.MAC_APP_DISTRIBUTION)
 
@@ -792,6 +794,8 @@ class AppStoreConnect(
         # In the past iOS and Mac App Store profiles used to map to iOS and Mac App distribution
         # certificates, and we want to keep using existing certificates for as long as possible.
         if profile_type is ProfileType.IOS_APP_STORE:
+            certificate_types.append(CertificateType.IOS_DISTRIBUTION)
+        elif profile_type is ProfileType.IOS_APP_ADHOC:
             certificate_types.append(CertificateType.IOS_DISTRIBUTION)
         elif profile_type is ProfileType.MAC_APP_STORE:
             certificate_types.append(CertificateType.MAC_APP_DISTRIBUTION)


### PR DESCRIPTION
Continuation to the improvements first introduced in #185. There the default certificate type for iOS App distribution provisioning profiles was changed from iOS Distribution to Distribution so that single certificate could be used for provisioning profiles targeting different platforms.
Similar change can be also made for iOS App AdHoc profiles. Up until now iOS AdHoc profiles were mapped to iOS Distribution certificates, but those too can use the platform-independent Distribution certificates. So, with the changes here
provisioning profiles of type `IOS_APP_ADHOC` are assigned certificates with type `DISTRIBUTION` (as opposed to `IOS_DISTIBUTION` which was used before), when downloaded (or created) using action `app-store-connect fetch-signing-files`. This allows reusing one signing certificate for signing apps that target different platforms, and reduces need to create excess certificates in Apple Developer Portal.

Updated default provisioning profile type to certificate type is now as follows:
- `IOS_APP_ADHOC` provisioning profiles use `DISTRIBUTION` certificates by default (previously `IOS_DISTRIBUTION`).

The change is **backwards compatible** in the sense that existing matching `IOS_DISTRIBUTION` certificates are still used for iOS App AdHoc provisioning profiles in case they are found and no `DISTRIBUTION` certificates are present.

**Updated actions:**
- `app-store-connect fetch-signing-files`.