### PR TITLE
Bugfix: Ignore uncompatible devices when creating provisioning profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+UNRELEASED
+-------------
+
+**Fixes**
+- When creating new provisioning profiles as part of action `app-store-connect fetch-signing-files` include only eligible devices when creating the profiles. Before the action could fail for example in case when iOS development or Ad Hoc provisioning profile was created, but an Apple TV device was included as a create parameter. [PR #200](https://github.com/codemagic-ci-cd/cli-tools/pull/200)
+
 Version 0.17.2
 -------------
 

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -223,6 +223,19 @@ class DeviceClass(ResourceEnum):
     IPOD = 'IPOD'
     MAC = 'MAC'
 
+    def is_compatible(self, profile_type: ProfileType) -> bool:
+        if profile_type.is_tvos_profile:
+            return self is DeviceClass.APPLE_TV
+        elif profile_type.is_macos_profile:
+            return self is DeviceClass.MAC
+        else:
+            return self in (
+                DeviceClass.APPLE_WATCH,
+                DeviceClass.IPAD,
+                DeviceClass.IPOD,
+                DeviceClass.IPHONE,
+            )
+
 
 class DeviceStatus(ResourceEnum):
     DISABLED = 'DISABLED'
@@ -268,6 +281,10 @@ class ProfileType(ResourceEnum):
     @property
     def is_macos_profile(self) -> bool:
         return self.value.startswith('MAC_')
+
+    @property
+    def is_tvos_profile(self) -> bool:
+        return self.value.startswith('TVOS_')
 
     def devices_not_allowed(self) -> bool:
         return not self.devices_allowed()

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -828,7 +828,7 @@ class AppStoreConnect(
             yield self.create_profile(
                 bundle_id.id,
                 [certificate.id for certificate in certificates],
-                [device.id for device in devices],
+                [device.id for device in devices if device.attributes.deviceClass.is_compatible(profile_type)],
                 profile_type=profile_type,
                 should_print=False,
             )


### PR DESCRIPTION
There is a bug in `app-store-connect fetch-signing-files` action related to provisioning profile creation. When requested AdHoc or development provisioning profile, that is profiles that can contain allowed devices identifiers, does not exist then the tool automatically tries to include all eligible devices registered in Apple Developer Portal in the new profile during creation.

However, up until now Apple TV devices were also included when iOS provisioning profiles were created, which is not allowed, despite the fact that devices Apple TV devices share the same [platform attribute](https://developer.apple.com/documentation/appstoreconnectapi/device/attributes) with iPhones, iPads, iPods and Apple Watches.

This makes the [Create a Profile](https://developer.apple.com/documentation/appstoreconnectapi/create_a_profile) request 
```
POST https://api.appstoreconnect.apple.com/v1/profiles
```
fail with `409` error response:
```json
{
    "errors": [
        {
            "id": "177ddcb8-8dc7-44f8-8889-d0117978fbbd",
            "status": "409",
            "code": "ENTITY_ERROR",
            "title": "There is a problem with the request entity",
            "detail": "Invalid deviceClass for profile type."
        }
    ]
}
```

Now distinct separation is made using the `deviceClass` attribute on the device resource to filter out which devices can be included in the provisioning profile.

**Updated actions:**
- `app-store-connect fetch-signing-files`.