### PR TITLE
Bugfix: Add manageAppVersionAndBuildNumber to export options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.18.1
+-------------
+
+**Fixes**
+- Allow using `manageAppVersionAndBuildNumber` as an export option when building with `xcode-project build-ipa`.
+
 Version 0.18.0
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.18.1
 -------------
 
 **Fixes**
-- Allow using `manageAppVersionAndBuildNumber` as an export option when building with `xcode-project build-ipa`.
+- Allow using `manageAppVersionAndBuildNumber` as an export option when building with `xcode-project build-ipa`. [PR #201](https://github.com/codemagic-ci-cd/cli-tools/pull/201)
 
 Version 0.18.0
 -------------

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.18.0'
+__version__ = '0.18.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -93,6 +93,7 @@ class ExportOptions(StringConverterMixin):
     iCloudContainerEnvironment: Optional[str] = None
     installerSigningCertificate: Optional[str] = None
     manifest: Optional[Manifest] = None
+    manageAppVersionAndBuildNumber: Optional[bool] = None
     method: Optional[ArchiveMethod] = None
     onDemandResourcesAssetPacksBaseURL: Optional[str] = None
     provisioningProfiles: Optional[List[ProvisioningProfileInfo]] = None

--- a/tests/models/test_export_options.py
+++ b/tests/models/test_export_options.py
@@ -38,6 +38,30 @@ def test_export_options_initialize(export_options_dict):
     assert export_options.dict() == export_options_dict
 
 
+    @pytest.mark.parametrize('field_name, value', [
+    ('manageAppVersionAndBuildNumber', True),
+    ('manageAppVersionAndBuildNumber', False),
+    ('signingCertificate', 'Certificate name'),
+    ('iCloudContainerEnvironment', 'environment'),
+])
+def test_export_options_initialize_extra_values(field_name, value, export_options_dict):
+    given_export_options = {**export_options_dict, field_name: value}
+    export_options = ExportOptions(**given_export_options)
+    assert export_options.dict() == given_export_options
+
+
+@pytest.mark.parametrize('field_name, value', [
+    ('manageAppVersionAndBuildNumber', True),
+    ('manageAppVersionAndBuildNumber', False),
+    ('signingCertificate', 'Certificate name'),
+    ('iCloudContainerEnvironment', 'environment'),
+])
+def test_export_options_set_valid_values(field_name, value, export_options_dict):
+    export_options = ExportOptions(**export_options_dict)
+    export_options.set_value(field_name=field_name, value=value)
+    assert export_options.dict() == {**export_options_dict, field_name: value}
+
+
 @pytest.mark.parametrize('field_name, value', [
     ('manifest', ''),
     ('manifest', 1),

--- a/tests/models/test_export_options.py
+++ b/tests/models/test_export_options.py
@@ -38,7 +38,7 @@ def test_export_options_initialize(export_options_dict):
     assert export_options.dict() == export_options_dict
 
 
-    @pytest.mark.parametrize('field_name, value', [
+@pytest.mark.parametrize('field_name, value', [
     ('manageAppVersionAndBuildNumber', True),
     ('manageAppVersionAndBuildNumber', False),
     ('signingCertificate', 'Certificate name'),


### PR DESCRIPTION
Starting from Xcode 13 export options support new key named `manageAppVersionAndBuildNumber`. Read more about it from this [Apple Developer Forum thread](https://developer.apple.com/forums/thread/690647).

This key is not supported by `ExportOptions` class and as such executing `xcode-project build-ipa` will fail in case provided export options property list contains said key `manageAppVersionAndBuildNumber`. Full stacktrace for the error is as follows:
```python
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 200, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 156, in _invoke_action
    return cli_action(**action_args)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 412, in wrapper
    return func(*args, **kwargs)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/tools/xcode_project.py", line 198, in build_ipa
    export_options = self._get_export_options_from_path(export_options_plist)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/tools/xcode_project.py", line 550, in _get_export_options_from_path
    return ExportOptions.from_path(export_options_plist)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/models/export_options.py", line 195, in from_path
    return ExportOptions(**data)
TypeError: __init__() got an unexpected keyword argument 'manageAppVersionAndBuildNumber'
```

This parameter was introduced in Xcode 13 with a default value of `true`. Currently, it is not possible to set the value to `false`.

**Updated actions:**
- `xcode-project build-ipa`
- `xcode-project use-profiles`