### PR TITLE
Bugfix: Export options plist generation for wildcard profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Version 0.19.1
+-------------
+
+This is a bugfix release from [PR #204](https://github.com/codemagic-ci-cd/cli-tools/pull/204) to address the regression introduced in [PR #203](https://github.com/codemagic-ci-cd/cli-tools/pull/203).
+
+**Fixes**
+- Fix export options plist generation with `xcode-project use-profiles` in case provisioning profiles with wildcard identifiers (such as `*` or `com.example.*`) were used.
+
+**Development**
+- Add new data container class `ProvisioningProfileAssignment` which can be used to track the Xcode project target onto which certain provisioning profile was assigned to.
+- Change `ExportOptions` factory method `from_used_profiles(cls, used_profiles: Sequence[ProvisioningProfile]) -> ExportOptions` to `from_profile_assignments(cls, profile_assignments: Sequence[ProvisioningProfileAssignment])`. This will persist the actual bundle identifiers of the Xcode targets when the property list constructed, instead of possibly using wildcard identifiers from provisioning profiles.
+
 Version 0.19.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.19.0'
+__version__ = '0.19.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/code_signing_settings_manager.py
+++ b/src/codemagic/models/code_signing_settings_manager.py
@@ -22,6 +22,7 @@ from codemagic.utilities import log
 
 from .certificate import Certificate
 from .export_options import ExportOptions
+from .export_options import ProvisioningProfileAssignment
 from .provisioning_profile import ProvisioningProfile
 
 
@@ -183,11 +184,14 @@ class CodeSigningSettingsManager(RunningCliAppMixin, StringConverterMixin):
         self._target_infos.sort(key=TargetInfo.sort_key)
 
     def generate_export_options(self, custom_options: Optional[Dict]) -> ExportOptions:
-        used_profiles = [
-            self.profiles[target_info.provisioning_profile_uuid]
+        profile_assignments = [
+            ProvisioningProfileAssignment(
+                target_info.bundle_id,
+                self.profiles[target_info.provisioning_profile_uuid],
+            )
             for target_info in self._target_infos
             if target_info.provisioning_profile_uuid is not None
         ]
-        export_options = ExportOptions.from_used_profiles(used_profiles)
+        export_options = ExportOptions.from_profile_assignments(profile_assignments)
         export_options.update(custom_options or {})
         return export_options


### PR DESCRIPTION
Export options propertly list generation was broken with the changes introduced in #203. Namely, the `provisioningProfiles` mapping in export options possibly contained wrong bundle identifiers as mapping keys in case wildcard provisioning profiles were used. The keys (or bundle identifiers) were directly taken from used provisioning profiles instead of using the actual bundle identifiers from the Xcode project targets to which the profiles were assigned to.

An example. When wildcard profile with identifier `*` was used for `xcode-project use-profile`, then the options for exporting the project were generated as
```
 - Method: development
 - Provisioning Profiles:
     - *: XC Wildcard ios_app_development 1645605003
 - Signing Certificate: iPhone Developer
 - Signing Style: manual
 - Team Id: X8NNQ9CYL2
```
while they should have been generated as
```  
 - Method: development
 - Provisioning Profiles:
     - io.codemagic.capybara.Messages: XC Wildcard ios_app_development 1645605003
     - io.codemagic.capybara: XC Wildcard ios_app_development 1645605003
 - Signing Certificate: iPhone Developer
 - Signing Style: manual
 - Team Id: X8NNQ9CYL2
```

The changes here resolve this regeression, and using wildcard profiles results in correct export options again.

**Updated actions:**
- `xcode-project use-profiles`.