### PR TITLE
Make certificates and private keys handling more convenient 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This release contains improvements from [PR #205](https://github.com/codemagic-c
 - PKCS#12 support in `pyOpenSSL` is deprecated and `cryptography` APIs should be used instead. Replace the deprecated `crypto.load_pkcs12` in `Certificate.from_p12` with `cryptography`'s `pkcs12.load_key_and_certificates`.
 - Add new factory method `PricateKey.from_p12` to load private key from PKCS#12 container.
 - Allow using `PrivateKey` instances for `AppStoreConnect` methods that take `certificate_key` argument. Before only instances of `Types.CertificateKeyArgument` were supported.
+- Support `DSA` and elliptic curve private keys for `PrivateKey`.
 
 Version 0.19.1
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Version 20.0.0
 -------------
 
+This release contains improvements from [PR #205](https://github.com/codemagic-ci-cd/cli-tools/pull/205).
+
 **Features**
 - Add option `--p12-path` for `app-store-connect` actions `create-certificate` and `get-certificate` to specify PKCS#12 container save path that can be used together with `--save` to specify exact file path where the container is saved. It overrides default save location, which is configured by `--certificates-dir`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Version 20.0.0
+-------------
+
+**Features**
+- Add option `--p12-path` for `app-store-connect` actions `create-certificate` and `get-certificate` to specify PKCS#12 container save path that can be used together with `--save` to specify exact file path where the container is saved. It overrides default save location, which is configured by `--certificates-dir`.
+
+**Fixes**
+- Support certificates that do not have common name defined in subject.
+
+**Development**
+- Describe new common argument type `CommonArgumentType.non_existing_path` which asserts that specified file does not exist.
+- PKCS#12 support in `pyOpenSSL` is deprecated and `cryptography` APIs should be used instead. Replace the deprecated `crypto.load_pkcs12` in `Certificate.from_p12` with `cryptography`'s `pkcs12.load_key_and_certificates`.
+- Add new factory method `PricateKey.from_p12` to load private key from PKCS#12 container.
+- Allow using `PrivateKey` instances for `AppStoreConnect` methods that take `certificate_key` argument. Before only instances of `Types.CertificateKeyArgument` were supported.
+
 Version 0.19.1
 -------------
 

--- a/docs/app-store-connect/create-certificate.md
+++ b/docs/app-store-connect/create-certificate.md
@@ -20,6 +20,7 @@ app-store-connect create-certificate [-h] [--log-stream STREAM] [--no-color] [--
     [--certificate-key PRIVATE_KEY]
     [--certificate-key-password PRIVATE_KEY_PASSWORD]
     [--p12-password P12_CONTAINER_PASSWORD]
+    [--p12-path P12_CONTAINER_SAVE_PATH]
     [--save]
 ```
 ### Optional arguments for action `create-certificate`
@@ -40,6 +41,10 @@ Password of the private key used to generate the certificate. Used together with
 
 
 If provided, the saved p12 container will be encrypted using this password. Used together with `--save` option.
+##### `--p12-path=P12_CONTAINER_SAVE_PATH`
+
+
+If provided, the exported p12 container will saved at this path. Otherwise it will be saved with a random name in the directory specified by `--certificates-dir`. Used together with `--save` option.
 ##### `--save`
 
 

--- a/docs/app-store-connect/get-certificate.md
+++ b/docs/app-store-connect/get-certificate.md
@@ -19,6 +19,7 @@ app-store-connect get-certificate [-h] [--log-stream STREAM] [--no-color] [--ver
     [--certificate-key PRIVATE_KEY]
     [--certificate-key-password PRIVATE_KEY_PASSWORD]
     [--p12-password P12_CONTAINER_PASSWORD]
+    [--p12-path P12_CONTAINER_SAVE_PATH]
     [--save]
     CERTIFICATE_RESOURCE_ID
 ```
@@ -42,6 +43,10 @@ Password of the private key used to generate the certificate. Used together with
 
 
 If provided, the saved p12 container will be encrypted using this password. Used together with `--save` option.
+##### `--p12-path=P12_CONTAINER_SAVE_PATH`
+
+
+If provided, the exported p12 container will saved at this path. Otherwise it will be saved with a random name in the directory specified by `--certificates-dir`. Used together with `--save` option.
 ##### `--save`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.19.1'
+__version__ = '0.20.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument/common_argument_types.py
+++ b/src/codemagic/cli/argument/common_argument_types.py
@@ -41,6 +41,13 @@ class CommonArgumentTypes:
         raise argparse.ArgumentTypeError(f'Path "{path}" does not exist')
 
     @staticmethod
+    def non_existing_path(path_str: str) -> pathlib.Path:
+        path = pathlib.Path(path_str).expanduser()
+        if not path.exists():
+            return path
+        raise argparse.ArgumentTypeError(f'Path "{path}" already exists')
+
+    @staticmethod
     def json_dict(json_dict: str) -> Dict:
         try:
             d = json.loads(json_dict)

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -139,7 +139,7 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
         subject_name = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, 'PEM')])
         csr_builder = x509.CertificateSigningRequestBuilder() \
             .subject_name(subject_name)
-        csr = csr_builder.sign(private_key.rsa_key, hashes.SHA256(), default_backend())
+        csr = csr_builder.sign(private_key.cryptography_private_key, hashes.SHA256(), default_backend())
         return csr
 
     @classmethod
@@ -169,7 +169,6 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
 
     def is_signed_with(self, private_key: PrivateKey) -> bool:
         certificate_public_key = self.x509.to_cryptography().public_key()
-        rsa_key_public_key = private_key.public_key
         certificate_public_numbers = certificate_public_key.public_numbers()
-        rsa_key_public_numbers = rsa_key_public_key.public_numbers()
-        return certificate_public_numbers == rsa_key_public_numbers
+        private_key_public_numbers = private_key.public_key.public_numbers()
+        return certificate_public_numbers == private_key_public_numbers

--- a/src/codemagic/models/private_key.py
+++ b/src/codemagic/models/private_key.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 from typing import AnyStr
 from typing import Optional
+from typing import Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.dsa import DSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import KeySerializationEncryption
 from cryptography.hazmat.primitives.serialization import pkcs12
@@ -15,11 +20,23 @@ from OpenSSL import crypto
 from codemagic.mixins import StringConverterMixin
 from codemagic.utilities import log
 
+CryptographyPrivateKey = Union[
+    DSAPrivateKey,
+    EllipticCurvePrivateKey,
+    RSAPrivateKey,
+]
+
+CryptographyPublicKey = Union[
+    DSAPublicKey,
+    EllipticCurvePublicKey,
+    RSAPublicKey,
+]
+
 
 class PrivateKey(StringConverterMixin):
 
-    def __init__(self, rsa_key: RSAPrivateKeyWithSerialization):
-        self.rsa_key = rsa_key
+    def __init__(self, cryptography_private_key: CryptographyPrivateKey):
+        self.cryptography_private_key = cryptography_private_key
 
     @classmethod
     def _get_pkey(cls, buffer: AnyStr, passphrase: bytes):
@@ -44,9 +61,14 @@ class PrivateKey(StringConverterMixin):
 
     @classmethod
     def from_openssh_key(cls, buffer: AnyStr, password: Optional[AnyStr] = None) -> PrivateKey:
-        rsa_key: RSAPrivateKey = serialization.load_ssh_private_key(  # type: ignore
-            cls._bytes(buffer), cls._bytes(password) if password else b'', default_backend())
-        return PrivateKey(rsa_key)
+        cryptography_private_key = serialization.load_ssh_private_key(
+            cls._bytes(buffer),
+            cls._bytes(password) if password else b'',
+            default_backend(),
+        )
+        if isinstance(cryptography_private_key, Ed25519PrivateKey):
+            raise ValueError('Ed25519 private keys are not supported')
+        return PrivateKey(cryptography_private_key)
 
     @classmethod
     def from_pem(cls, pem_key: AnyStr, password: Optional[AnyStr] = None) -> PrivateKey:
@@ -56,8 +78,12 @@ class PrivateKey(StringConverterMixin):
     @classmethod
     def from_p12(cls, p12: bytes, password: Optional[AnyStr] = None) -> PrivateKey:
         password_encoded = None if password is None else cls._bytes(password)
-        rsa_key, _, _ = pkcs12.load_key_and_certificates(p12, password_encoded)
-        return PrivateKey(rsa_key)
+        cryptography_private_key, _, _ = pkcs12.load_key_and_certificates(p12, password_encoded)
+        if cryptography_private_key is None:
+            raise ValueError('Private key is missing from PKCS#12')
+        elif isinstance(cryptography_private_key, Ed25519PrivateKey):
+            raise ValueError('Ed25519 private keys are not supported')
+        return PrivateKey(cryptography_private_key)
 
     def as_pem(self, password: Optional[AnyStr] = None) -> str:
         key_format = serialization.PrivateFormat.TraditionalOpenSSL
@@ -65,7 +91,7 @@ class PrivateKey(StringConverterMixin):
         if password is not None:
             key_format = serialization.PrivateFormat.PKCS8
             algorithm = serialization.BestAvailableEncryption(self._bytes(password))
-        pem = self.rsa_key.private_bytes(
+        pem = self.cryptography_private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=key_format,
             encryption_algorithm=algorithm,
@@ -73,8 +99,8 @@ class PrivateKey(StringConverterMixin):
         return self._str(pem)
 
     @property
-    def public_key(self) -> RSAPublicKey:
-        return self.rsa_key.public_key()
+    def public_key(self) -> CryptographyPublicKey:
+        return self.cryptography_private_key.public_key()
 
     def get_public_key(self) -> bytes:
         return self.public_key.public_bytes(

--- a/src/codemagic/models/private_key.py
+++ b/src/codemagic/models/private_key.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import KeySerializationEncryption
+from cryptography.hazmat.primitives.serialization import pkcs12
 from OpenSSL import crypto
 
 from codemagic.mixins import StringConverterMixin
@@ -51,6 +52,12 @@ class PrivateKey(StringConverterMixin):
     def from_pem(cls, pem_key: AnyStr, password: Optional[AnyStr] = None) -> PrivateKey:
         pkey = cls._get_pkey(pem_key, cls._bytes(password) if password else b'')
         return PrivateKey(pkey.to_cryptography_key())
+
+    @classmethod
+    def from_p12(cls, p12: bytes, password: Optional[AnyStr] = None) -> PrivateKey:
+        password_encoded = None if password is None else cls._bytes(password)
+        rsa_key, _, _ = pkcs12.load_key_and_certificates(p12, password_encoded)
+        return PrivateKey(rsa_key)
 
     def as_pem(self, password: Optional[AnyStr] = None) -> str:
         key_format = serialization.PrivateFormat.TraditionalOpenSSL

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -1214,6 +1214,18 @@ class CertificateArgument(cli.Argument):
         ),
         argparse_kwargs={'required': False, 'default': ''},
     )
+    P12_CONTAINER_SAVE_PATH = cli.ArgumentProperties(
+        key='p12_container_save_path',
+        flags=('--p12-path',),
+        type=cli.CommonArgumentTypes.non_existing_path,
+        description=(
+            'If provided, the exported p12 container will saved at this path. '
+            'Otherwise it will be saved with a random name in the directory specified '
+            f'by {Colors.BRIGHT_BLUE("--certificates-dir")}. '
+            f'Used together with {Colors.BRIGHT_BLUE("--save")} option.'
+        ),
+        argparse_kwargs={'required': False},
+    )
 
 
 class ProfileArgument(cli.Argument):

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -72,8 +72,10 @@ from ._app_store_connect.resource_printer import ResourcePrinter
 
 
 def _get_certificate_key(
-        certificate_key: Optional[Types.CertificateKeyArgument] = None,
+        certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]] = None,
         certificate_key_password: Optional[Types.CertificateKeyPasswordArgument] = None) -> Optional[PrivateKey]:
+    if isinstance(certificate_key, PrivateKey):
+        return certificate_key
     password = certificate_key_password.value if certificate_key_password else None
     if certificate_key is not None:
         try:
@@ -418,7 +420,7 @@ class AppStoreConnect(
                 CommonArgument.SAVE)
     def create_certificate(self,
                            certificate_type: CertificateType = CertificateType.IOS_DEVELOPMENT,
-                           certificate_key: Optional[Types.CertificateKeyArgument] = None,
+                           certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]] = None,
                            certificate_key_password: Optional[Types.CertificateKeyPasswordArgument] = None,
                            p12_container_password: str = '',
                            save: bool = False,
@@ -449,7 +451,7 @@ class AppStoreConnect(
                 CommonArgument.SAVE)
     def get_certificate(self,
                         certificate_resource_id: ResourceId,
-                        certificate_key: Optional[Types.CertificateKeyArgument] = None,
+                        certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]] = None,
                         certificate_key_password: Optional[Types.CertificateKeyPasswordArgument] = None,
                         p12_container_password: str = '',
                         save: bool = False,
@@ -495,7 +497,7 @@ class AppStoreConnect(
             certificate_types: Optional[Union[CertificateType, Sequence[CertificateType]]] = None,
             profile_type: Optional[ProfileType] = None,
             display_name: Optional[str] = None,
-            certificate_key: Optional[Types.CertificateKeyArgument] = None,
+            certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]] = None,
             certificate_key_password: Optional[Types.CertificateKeyPasswordArgument] = None,
             p12_container_password: str = '',
             save: bool = False,
@@ -719,7 +721,7 @@ class AppStoreConnect(
                 CommonArgument.CREATE_RESOURCE)
     def fetch_signing_files(self,
                             bundle_id_identifier: str,
-                            certificate_key: Optional[Types.CertificateKeyArgument] = None,
+                            certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]] = None,
                             certificate_key_password: Optional[Types.CertificateKeyPasswordArgument] = None,
                             p12_container_password: str = '',
                             platform: BundleIdPlatform = BundleIdPlatform.IOS,

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -792,7 +792,7 @@ class AppStoreConnect(
 
     def _get_or_create_certificates(self,
                                     profile_type: ProfileType,
-                                    certificate_key: Optional[Types.CertificateKeyArgument],
+                                    certificate_key: Optional[Union[PrivateKey, Types.CertificateKeyArgument]],
                                     certificate_key_password: Optional[Types.CertificateKeyPasswordArgument],
                                     create_resource: bool) -> List[SigningCertificate]:
         certificate_types = [CertificateType.from_profile_type(profile_type)]

--- a/tests/models/test_private_key.py
+++ b/tests/models/test_private_key.py
@@ -45,3 +45,16 @@ def test_load_private_key_from_buffer(mock_file_name, expected_fingerprint):
     key_bytes = base64.b64decode(public_key_content)
     fingerprint = hashlib.md5(key_bytes).hexdigest()
     assert fingerprint == expected_fingerprint
+
+
+@pytest.mark.parametrize('mock_p12_name, password, expected_fingerprint', [
+    ('certificate.p12', '123456', '16764b6fe08edf6ebba22e68f6f95b40'),
+    ('certificate-no-password.p12', None, '16764b6fe08edf6ebba22e68f6f95b40'),
+])
+def test_load_private_key_from_p12(mock_p12_name, password, expected_fingerprint):
+    p12_path = pathlib.Path(__file__).parent / 'mocks' / mock_p12_name
+    pk = PrivateKey.from_p12(p12_path.read_bytes(), password)
+    public_key_content = pk.get_public_key().split()[1]
+    key_bytes = base64.b64decode(public_key_content)
+    fingerprint = hashlib.md5(key_bytes).hexdigest()
+    assert fingerprint == expected_fingerprint

--- a/tests/models/test_private_key.py
+++ b/tests/models/test_private_key.py
@@ -31,7 +31,7 @@ def test_pem_to_rsa_with_encrypted_key_wrong_password(encrypted_pem):
 def test_pem_to_rsa_with_unencrypted_key_wrong_password(unencrypted_pem):
     pk = PrivateKey.from_pem(unencrypted_pem.content, b'wrong password')
     # Unencrypted keys can be opened with any password
-    assert pk.rsa_key.key_size == unencrypted_pem.key_size
+    assert pk.cryptography_private_key.key_size == unencrypted_pem.key_size
 
 
 @pytest.mark.parametrize('mock_file_name, expected_fingerprint', [


### PR DESCRIPTION
The aim of this pull request is to make the Python API more user friendly for private key and certificate management. Additionally make `AppStoreConnect` class methods that implement `app-store-connect` actions which manage certificate easier to use by allowing directly plugging in `PrivateKey` instances in stead of having to use `Types.CertificateKeyArgument` type wrapper.

**Notable changes:**
- Add new factory method for `PrivateKey` to load the key from PKCS#12 containers.
- Add option to specify save path for certificates downloaded using `app-store-connect` tool.
- Support `DSA` and elliptic curve private keys in addition to `RSA` keys for `PrivateKey`.

**Updated actions:**
- `app-store-connect create-certificate`,
- `app-store-connect get-certificate`,
- `app-store-connect list-certificates`,
- `app-store-connect fetch-signing-files`.