### PR TITLE
Typing: Add `py.typed` marker file to indicate inline types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.22.0
 -------------
 
 **Development**
-- [PEP 561](https://www.python.org/dev/peps/pep-0561/) compliance. Include `py.typed` marker file to indicate that this package has inline type hints.
+- [PEP 561](https://www.python.org/dev/peps/pep-0561/) compliance. Include `py.typed` marker file to indicate that this package has inline type hints. [PR #207](https://github.com/codemagic-ci-cd/cli-tools/pull/207)
 
 Version 0.21.0
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.22.0
+-------------
+
+**Development**
+- [PEP 561](https://www.python.org/dev/peps/pep-0561/) compliance. Include `py.typed` marker file to indicate that this package has inline type hints.
+
 Version 0.21.0
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.21.0'
+__version__ = '0.22.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/py.typed
+++ b/src/codemagic/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. This package uses inline types.


### PR DESCRIPTION
Include `py.typed` marker file to indicate that the package contains inlined type information. See more information from [PEP 561 -- Distributing and Packaging Type Information](https://www.python.org/dev/peps/pep-0561/).