### PR TITLE
Bugfix: Address issues in `android-keystore` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Version 0.22.3
+-------------
+
+This is a bugfix release from [PR #210](https://github.com/codemagic-ci-cd/cli-tools/pull/210) to fix problems with tool `android-keystore` that was first added in [version 0.21.0](https://github.com/codemagic-ci-cd/cli-tools/releases/tag/v0.21.0).
+
+**Improvements**
+- Use better error message for keystore validation in case non-keystore file is passed for validation.
+
+**Fixes**
+- Fix debug keystore creation using action `android-keystore create-debug-keysotre`. It was using invalid keyword argument to specify keystore path.
+- Make keystore path argument `--keystore` required for `android-keystore create` and `android-keystore verify` actions.
+
 Version 0.22.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.22.2'
+__version__ = '0.22.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/shell_tools/keytool.py
+++ b/src/codemagic/shell_tools/keytool.py
@@ -1,4 +1,3 @@
-import shlex
 import subprocess
 
 from codemagic.models import Keystore
@@ -62,10 +61,12 @@ class Keytool(AbstractShellTool):
         except subprocess.CalledProcessError as cpe:
             stdout = self._str(cpe.stdout)
             if f'<{keystore.key_alias}> does not exist' in stdout:
-                raise ValueError(f'Alias {shlex.quote(keystore.key_alias)} does not exist in keystore') from cpe
+                raise ValueError(f'Alias "{keystore.key_alias}" does not exist in keystore') from cpe
             elif 'keystore password was incorrect' in stdout:
                 raise ValueError('Invalid keystore password') from cpe
             elif 'file does not exist' in stdout:
                 raise ValueError('Keystore does not exist') from cpe
+            elif 'Unrecognized keystore format' in stdout:
+                raise ValueError('Unrecognized keystore format') from cpe
             else:
                 raise ValueError(stdout.strip()) from cpe

--- a/src/codemagic/tools/android_keystore/android_keystore.py
+++ b/src/codemagic/tools/android_keystore/android_keystore.py
@@ -149,7 +149,7 @@ class AndroidKeystore(cli.CliApp, PathFinderMixin):
         return self.create(
             keystore_path=pathlib.Path('~/.android/debug.keystore').expanduser(),
             key_alias='androiddebugkey',
-            store_password='android',
+            keystore_password='android',
             issuer_common_name='Android Debug',
             issuer_organization='Android',
             issuer_country='US',

--- a/src/codemagic/tools/android_keystore/arguments.py
+++ b/src/codemagic/tools/android_keystore/arguments.py
@@ -12,6 +12,7 @@ class AndroidKeystoreArgument(cli.Argument):
         flags=('-k', '--ks', '--keystore'),
         type=pathlib.Path,
         description='Path where your keystore should be created or read from',
+        argparse_kwargs={'required': True},
     )
     KEYSTORE_PASSWORD = cli.ArgumentProperties(
         key='keystore_password',


### PR DESCRIPTION
This is a bugfix PR to address issues that slipped through with `android-keystore` tool release.

The issues were:
- Action `android-keystore create-debug-keysotre` did not work since it called `create` method with invalid keyword argument.
- Argument `--keystore` was not required for actions `android-keystore create` and `android-keystore verify` which potentially caused unexpected failures when invoking those actions.
- When trying to verify non-keystore file as a keystore the shown error message contained Java classpaths and was misleading. The error is now more self-explanatory.  

**Affected actions:**
- `android-keystore create`,
- `android-keystore create-debug-keystore`,
- `android-keystore verify`.