### PR TITLE
Bugfix: `google-play get-latest-build-number` crashes on incomplete response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.23.1
 -------------
 
 **Fixes**
-- Action `google-play get-latest-build-number` crashed when response from Google's APIs did specify `includeRestOfWorld` field for [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#countrytargeting). [PR #214](https://github.com/codemagic-ci-cd/cli-tools/pull/214)
+- Action `google-play get-latest-build-number` crashed when [`Track`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks) response from Google Play Developer API did not specify `includeRestOfWorld` field for [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#countrytargeting). [PR #214](https://github.com/codemagic-ci-cd/cli-tools/pull/214)
 
 Version 0.23.0
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.23.1
+-------------
+
+**Fixes**
+- Action `google-play get-latest-build-number` crashed when response from Google's APIs did specify `includeRestOfWorld` field for [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#countrytargeting). [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+
 Version 0.23.0
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.23.1
 -------------
 
 **Fixes**
-- Action `google-play get-latest-build-number` crashed when response from Google's APIs did specify `includeRestOfWorld` field for [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#countrytargeting). [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+- Action `google-play get-latest-build-number` crashed when response from Google's APIs did specify `includeRestOfWorld` field for [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#countrytargeting). [PR #214](https://github.com/codemagic-ci-cd/cli-tools/pull/214)
 
 Version 0.23.0
 -------------

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.23.0'
+__version__ = '0.23.1'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -28,7 +28,7 @@ class CountryTargeting(Resource):
     """
 
     countries: List[str]
-    includeRestOfWorld: bool
+    includeRestOfWorld: Optional[bool] = None
 
 
 @dataclass

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -33,6 +33,10 @@ class CountryTargeting(Resource):
 
 @dataclass
 class Release(Resource):
+    """
+    https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#release
+    """
+
     _OMIT_IF_NONE_KEYS = (
         'name',
         'userFraction',

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -62,7 +62,7 @@ class Release(Resource):
 @dataclass
 class Track(Resource):
     """
-    https://developers.google.com/android-publisher/api-ref/rest/v3/edits
+    https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#Track
     """
     _OMIT_IF_NONE_KEYS = ('releases',)
 

--- a/tests/google_play/resources/test_resource_print.py
+++ b/tests/google_play/resources/test_resource_print.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
-from textwrap import dedent
-
 from codemagic.google_play.resources import Track
 
 
 def test_track_string(api_track):
     track = Track(**api_track)
-    expected_output = dedent("""
-        Track: internal
-        Releases: [
-            Status: draft
-            Name: 29 (1.0.29)
-            Version codes: [
-                29
-            ]
-
-            Status: completed
-            Name: trying2
-            Version codes: [
-                26
-            ]
-            Release notes: [
-                Language: en-US
-                Text: trying2
-            ]
-        ]""")
-    assert str(track).replace('\t', '    ') == expected_output
+    expected_output = (
+        '\n'
+        'Track: internal\n'
+        'Releases: [\n'
+        '    Status: draft\n'
+        '    Name: 29 (1.0.29)\n'
+        '    Version codes: [\n'
+        '        29\n'
+        '    ]\n'
+        '\n'
+        '    Status: completed\n'
+        '    Name: trying2\n'
+        '    Version codes: [\n'
+        '        26\n'
+        '    ]\n'
+        '    Release notes: [\n'
+        '        Language: en-US\n'
+        '        Text: trying2\n'
+        '    ]\n'
+        ']'
+    ).replace(4*' ', '\t')
+    assert str(track) == expected_output


### PR DESCRIPTION
This fixes #208.

Action `google-play get-latest-build-number` uses Google Play Developer API method [`edits.tracks.get`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks/get) to obtain the latest build build number in certain release track.
While API documentation indicates that the response for [`Track`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks) resource should contain a list of [`Release`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#Release) objects that all have reference to [`CountryTargeting`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#CountryTargeting) which has a field called `includeRestOfWorld`, in reality the `includeRestOfWorld` field might not be defined. This will result in the following error on client side:

```python
Traceback (most recent call last):
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 200, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 156, in _invoke_action
    return cli_action(**action_args)
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 412, in wrapper
    return func(*args, **kwargs)
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/tools/google_play.py", line 143, in get_latest_build_number
    track = self.api_client.get_track_information(edit.id, track_name)
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/google_play/api_client.py", line 92, in get_track_information
    resource = Track(**track_response)
  File "<string>", line 5, in __init__
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/google_play/resources/track.py", line 74, in __post_init__
    self.releases = [Release(**release) for release in self.releases]
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/google_play/resources/track.py", line 74, in <listcomp>
    self.releases = [Release(**release) for release in self.releases]
  File "<string>", line 10, in __init__
  File "/home/docker/.local/lib/python3.8/site-packages/codemagic/google_play/resources/track.py", line 59, in __post_init__
    self.countryTargeting = CountryTargeting(**self.countryTargeting)
TypeError: __init__() missing 1 required positional argument: 'includeRestOfWorld'```
```

In order to tackle the cases when `includeRestOfWorld` is not defined, make it optional field for `CountryTargeting` resource and set default value for it to `None`.

**Affected actions:**
- `google-play get-latest-build-number`.