### PR TITLE
Bugfix: Allow configuring `distributionBundleIdentifier` export option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.24.2
+-------------
+
+**Fixes**
+- Allow defining `distributionBundleIdentifier` export option by `--custom-export-options` for `xcode-project use-profiles`. [PR #218](https://github.com/codemagic-ci-cd/cli-tools/pull/218)
+
 Version 0.24.1
 -------------
 

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -31,7 +31,7 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 ##### `--custom-export-options=CUSTOM_EXPORT_OPTIONS`
 
 
-Custom options for generated export options as JSON string. For example '{"uploadBitcode": false, "uploadSymbols": false}'.
+Custom options for generated export options as JSON string. For example `{"uploadBitcode": false, "uploadSymbols": false}`.
 ##### `--warn-only`
 
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.24.1'
+__version__ = '0.24.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -89,10 +89,21 @@ class Manifest:
         return {k: v for k, v in self.__dict__.items() if v is not None}
 
 
+ExportOptionValue = Union[
+    Dict[str, str],
+    List[ProvisioningProfileInfo],
+    Manifest,
+    bool,
+    enum.Enum,
+    str,
+]
+
+
 @dataclass
 class ExportOptions(StringConverterMixin):
     compileBitcode: Optional[bool] = None
     destination: Optional[Destination] = None
+    distributionBundleIdentifier: Optional[str] = None
     embedOnDemandResourcesAssetPacksInBundle: Optional[bool] = None
     generateAppStoreInformation: Optional[bool] = None
     iCloudContainerEnvironment: Optional[str] = None
@@ -164,10 +175,7 @@ class ExportOptions(StringConverterMixin):
         else:
             raise ValueError(f'Invalid value for provisioningProfiles: {new_profiles!r}')
 
-    def set_value(self,
-                  field_name: str,
-                  value: Union[enum.Enum, bool, str, Dict[str, str], List[ProvisioningProfileInfo], Manifest]):
-
+    def set_value(self, field_name: str, value: ExportOptionValue):
         if field_name not in self.__dict__:
             raise ValueError(f'Invalid filed {field_name}')
 

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -2,6 +2,7 @@ import pathlib
 import re
 
 from codemagic import cli
+from codemagic.cli import Colors
 from codemagic.models import ProvisioningProfile
 from codemagic.models.simulator import Runtime
 
@@ -139,8 +140,8 @@ class ExportIpaArgument(cli.Argument):
         flags=('--custom-export-options',),
         type=cli.CommonArgumentTypes.json_dict,
         description=(
-            'Custom options for generated export options as JSON string. '
-            'For example \'{"uploadBitcode": false, "uploadSymbols": false}\'.'
+            'Custom options for generated export options as JSON string. For example '
+            f'`{Colors.WHITE("""{"uploadBitcode": false, "uploadSymbols": false}""")}`.'
         ),
         argparse_kwargs={'required': False},
     )


### PR DESCRIPTION
When building Xcode projects that use App Clips it is necessary to specify `distributionBundleIdentifier` in export options property list for exporting the `xcarchive`. Right now setting this export option results in the following error:

```python
[15:13:58 29-04-2022] ERROR cli_app.py:113 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/cli/cli_app.py", line 200, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/cli/cli_app.py", line 156, in _invoke_action
    return cli_action(**action_args)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/cli/cli_app.py", line 412, in wrapper
    return func(*args, **kwargs)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/tools/xcode_project.py", line 137, in use_profiles
    export_options = code_signing_settings_manager.generate_export_options(custom_export_options)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/models/code_signing_settings_manager.py", line 196, in generate_export_options
    export_options.update(custom_options or {})
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/models/export_options.py", line 188, in update
    self.set_value(field_name, value)
  File "/Users/priit/.virtualenvs/cli-tools-shZ38mB-/lib/python3.7/site-packages/codemagic_cli_tools-0.24.1-py3.7.egg/codemagic/models/export_options.py", line 172, in set_value
    raise ValueError(f'Invalid filed {field_name}')
ValueError: Invalid filed distributionBundleIdentifier
```

Update `ExportOptions` class definition to allow specifying this value.

**Updated actions**
- `xcode-project use-profiles`

In order to include `distributionBundleIdentifier` in the generated export options use `--custom-export-options`:

```bash
xcode-project use-profiles --custom-export-options '{"distributionBundleIdentifier": "com.example.export-bundle-id"}'
```
