### PR TITLE
Improvement: `xcresult` test result parsing speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-Version 0.24.2
+Version 0.24.3
+-------------
+
+**Improvements**
+- Speed up `xcresult` parsing for `xcode-project` actions `run-tests`, `junit-test-results` and `test-summary`. [PR #223](https://github.com/codemagic-ci-cd/cli-tools/pull/223)
+
+- Version 0.24.2
 -------------
 
 **Fixes**

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.24.2'
+__version__ = '0.24.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/cli_process.py
+++ b/src/codemagic/cli/cli_process.py
@@ -85,6 +85,7 @@ class CliProcess:
             stdout: Union[int, IO] = subprocess.PIPE,
             stderr: Union[int, IO] = subprocess.PIPE,
             env: Optional[Dict[str, str]] = None,
+            poll_interval: float = 0.01,
     ) -> CliProcess:
         self._log_exec_started()
         start = time.time()
@@ -99,7 +100,7 @@ class CliProcess:
                 self._configure_process_streams()
                 while self._process.poll() is None:
                     self._handle_streams(self._buffer_size)
-                    time.sleep(0.1)
+                    time.sleep(poll_interval)
                 self._handle_streams()
         finally:
             self.duration = time.time() - start

--- a/src/codemagic/models/xctests/xcresulttool.py
+++ b/src/codemagic/models/xctests/xcresulttool.py
@@ -48,13 +48,13 @@ class XcResultTool(RunningCliAppMixin):
         return output_path
 
     @classmethod
-    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> str:
+    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> bytes:
         cli_app = cls.get_current_cli_app()
         try:
             if cli_app:
-                return cls._run_command_with_cli_app(cli_app, command_args).decode()
+                return cls._run_command_with_cli_app(cli_app, command_args)
             else:
-                return subprocess.check_output(command_args).decode()
+                return subprocess.check_output(command_args)
         except subprocess.CalledProcessError:
             raise IOError(error_message)
 

--- a/src/codemagic/models/xctests/xcresulttool.py
+++ b/src/codemagic/models/xctests/xcresulttool.py
@@ -4,7 +4,9 @@ import json
 import pathlib
 import subprocess
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import AnyStr
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -12,6 +14,9 @@ from typing import Sequence
 
 from codemagic.cli import CommandArg
 from codemagic.mixins import RunningCliAppMixin
+
+if TYPE_CHECKING:
+    from codemagic.cli import CliApp
 
 
 class XcResultTool(RunningCliAppMixin):
@@ -44,14 +49,28 @@ class XcResultTool(RunningCliAppMixin):
         return output_path
 
     @classmethod
-    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> str:
+    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> AnyStr:
         cli_app = cls.get_current_cli_app()
         try:
             if cli_app:
-                process = cli_app.execute(command_args, suppress_output=True)
-                process.raise_for_returncode()
-                return process.stdout
+                return cls._run_command_with_cli_app(cli_app, command_args)
             else:
                 return subprocess.check_output(command_args).decode()
         except subprocess.CalledProcessError:
             raise IOError(error_message)
+
+    @classmethod
+    def _run_command_with_cli_app(cls, cli_app: CliApp, command_args: Sequence[CommandArg]) -> bytes:
+        """
+        Replace default stdout stream with direct file handle to bypass stream
+        processing in Python which can be very slow. For example
+        `xcrun xcresulttool get --format json --path results.xcresult --id 'object-id'`
+        can output 500K+ lines at 30+ MB. Processing it in small chunks in Python is very time
+        consuming whereas using file handles is almost instantaneous.
+        """
+        with NamedTemporaryFile(mode='w+b') as stdout_fd:
+            process = cli_app.execute(command_args, suppress_output=True, stdout=stdout_fd)
+            process.raise_for_returncode()
+            stdout_fd.flush()
+            stdout_fd.seek(0)
+            return stdout_fd.read()

--- a/src/codemagic/models/xctests/xcresulttool.py
+++ b/src/codemagic/models/xctests/xcresulttool.py
@@ -6,7 +6,6 @@ import subprocess
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import AnyStr
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -49,11 +48,11 @@ class XcResultTool(RunningCliAppMixin):
         return output_path
 
     @classmethod
-    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> AnyStr:
+    def _run_command(cls, command_args: Sequence[CommandArg], error_message: str) -> str:
         cli_app = cls.get_current_cli_app()
         try:
             if cli_app:
-                return cls._run_command_with_cli_app(cli_app, command_args)
+                return cls._run_command_with_cli_app(cli_app, command_args).decode()
             else:
                 return subprocess.check_output(command_args).decode()
         except subprocess.CalledProcessError:


### PR DESCRIPTION
In case Xcode project has a lot of tests, then parsing test result information from generated `xcresult` bundle can become relatively slow. This is because underlying conversion command

```shell
xcrun xcresulttool get --format json --path '/path/to/TestSuite.xcresult' --id '...'
```

to transform binary test results included in the bundle to `JSON` format can generate a lot of output (30+ MB at 500K+ lines).

Evidently processing this kind of text output in Python via small (8KB) chunks is not the most efficient way to deal with it. As the output is only needed as a whole once the command is completed, then it makes sense to pipe it directly to a file, and finally read the generated JSON from this file once processing is completed.

**Updated actions**

- `xcode-project run-tests`
- `xcode-project junit-test-results`
- `xcode-project test-summary`