### PR TITLE
Development: Add default values to all  arguments in `add_certificates` and `use_profiles` declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------
+**Development**
+- Use default values for all arguments in `Keychain.add_certificates` and `XcodeProject.use_profiles`
+
 Version 0.26.0
 -------------
 

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -307,7 +307,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
                 KeychainArgument.DISALLOW_ALL_APPLICATIONS)
     def add_certificates(
             self,
-            certificate_path_patterns: Sequence[pathlib.Path],
+            certificate_path_patterns: Sequence[pathlib.Path] = KeychainArgument.CERTIFICATE_PATHS.get_default(),
             certificate_password: Password = Password(''),
             allowed_applications: Sequence[pathlib.Path] = KeychainArgument.ALLOWED_APPLICATIONS.get_default(),
             allow_all_applications: Optional[bool] = KeychainArgument.ALLOW_ALL_APPLICATIONS.get_default(),

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -97,8 +97,8 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
     )
     def use_profiles(
             self,
-            xcode_project_patterns: Sequence[pathlib.Path],
-            profile_path_patterns: Sequence[pathlib.Path],
+            xcode_project_patterns: Sequence[pathlib.Path] = XcodeProjectArgument.XCODE_PROJECT_PATTERN.get_default(),
+            profile_path_patterns: Sequence[pathlib.Path] = XcodeProjectArgument.PROFILE_PATHS.get_default(),
             export_options_plist: pathlib.Path = ExportIpaArgument.EXPORT_OPTIONS_PATH.get_default(),
             custom_export_options: Optional[Dict] = None,
             warn_only: bool = False,


### PR DESCRIPTION
this makes the api behave more like the cli and makes it much easier to use.

currently in my code i have to do this, which isn't ideal and adds unnecessary bloat to my script:
```py
XcodeProject().use_profiles(
    XcodeProjectArgument.XCODE_PROJECT_PATTERN.get_default(),
    XcodeProjectArgument.PROFILE_PATHS.get_default(),
)
```