### PR TITLE
Bugfix: App Store review submission using `app-store-connect builds submit-to-app-store`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+Version 0.26.0
+-------------
+
+This release includes changes from [PR #227](https://github.com/codemagic-ci-cd/cli-tools/pull/227).
+
+Apple has deprecated the [Create an App Store Version Submission](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_submission) and replaced it by [Review Submissions](https://developer.apple.com/documentation/appstoreconnectapi/review_submissions) API. Changes included in this release update logic driving App Store publishing as part of actions `app-store-connect publish` and `app-store-connect builds submit-to-app-store`. 
+
+**Features**
+- Add new action `app-store-connect review-submissions create` to create new review submission request for application's latest App Store Version.
+- Add new action `app-store-connect review-submission-items create` to add contents to review submission for App Store review request.
+- Add new action `app-store-connect review-submissions confirm` to confirm pending review submission for App Review.
+- Add new action `app-store-connect review-submissions cancel` to discard review submission from App Review.
+
+**Development**
+- **Breaking**: Return type for `AppStoreConnect.submit_to_app_store` changed. Instead of `AppStoreVersionSubmission` it now returns tuple `(ReviewSubmission, ReviewSubmissionItem)`.
+- Add new resource manager properties `review_submissions` and `review_submissions_items` to `AppStoreConnectApiClient`.
+- Update `AppStoreVersion` model with optional relationships `appClipDefaultExperience` and `appStoreVersionExperiments`.
+- Define new `ReviewSubmissionState` and `ReviewSubmissionItemState` enumerations for App Store Connect API resources.
+- Add model definition for resource [`ReviewSubmission`](https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission).
+- Add model definition for resource [`ReviewSubmissionItem`](https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmissionitem).
+- Add method new methods to `AppStoreConnect`:
+  - `cancel_review_submission`,
+  - `confirm_review_submission`,
+  - `create_review_submission`,
+  - `create_review_submission_item`.
+
+
+**Tests**
+- Update mock for `AppStoreVersion` resource test.
+
+**Docs**
+- TBD
+
 Version 0.25.0
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Apple has deprecated the [Create an App Store Version Submission](https://develo
 
 **Features**
 - Add new action `app-store-connect review-submissions create` to create new review submission request for application's latest App Store Version.
+- Add new action `app-store-connect review-submissions get` to show review submission information.
 - Add new action `app-store-connect review-submission-items create` to add contents to review submission for App Store review request.
 - Add new action `app-store-connect review-submissions confirm` to confirm pending review submission for App Review.
 - Add new action `app-store-connect review-submissions cancel` to discard review submission from App Review.

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.25.0'
+__version__ = '0.26.0'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/api_client.py
+++ b/src/codemagic/apple/app_store_connect/api_client.py
@@ -27,6 +27,8 @@ from .versioning import AppStoreVersionSubmissions
 from .versioning import BetaAppReviewSubmissions
 from .versioning import BetaBuildLocalizations
 from .versioning import PreReleaseVersions
+from .versioning import ReviewSubmissionItems
+from .versioning import ReviewSubmissions
 
 
 class AppStoreConnectApiClient:
@@ -158,6 +160,14 @@ class AppStoreConnectApiClient:
     @property
     def profiles(self) -> Profiles:
         return Profiles(self)
+
+    @property
+    def review_submissions(self) -> ReviewSubmissions:
+        return ReviewSubmissions(self)
+
+    @property
+    def review_submissions_items(self) -> ReviewSubmissionItems:
+        return ReviewSubmissionItems(self)
 
     @property
     def signing_certificates(self) -> SigningCertificates:

--- a/src/codemagic/apple/app_store_connect/versioning/__init__.py
+++ b/src/codemagic/apple/app_store_connect/versioning/__init__.py
@@ -4,3 +4,5 @@ from .app_store_versions import AppStoreVersions
 from .beta_app_review_submissions import BetaAppReviewSubmissions
 from .beta_build_localizations import BetaBuildLocalizations
 from .pre_release_versions import PreReleaseVersions
+from .review_submission_items import ReviewSubmissionItems
+from .review_submissions import ReviewSubmissions

--- a/src/codemagic/apple/app_store_connect/versioning/review_submission_items.py
+++ b/src/codemagic/apple/app_store_connect/versioning/review_submission_items.py
@@ -1,4 +1,6 @@
+from typing import Dict
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from typing import Union
 
@@ -24,7 +26,10 @@ class ReviewSubmissionItems(ResourceManager[ReviewSubmissionItem]):
     def create(
         self,
         review_submission: Union[ResourceId, ReviewSubmission],
+        app_custom_product_page_version: Optional[ResourceId] = None,
+        app_event: Optional[ResourceId] = None,
         app_store_version: Optional[Union[ResourceId, AppStoreVersion]] = None,
+        app_store_version_experiment: Optional[ResourceId] = None,
     ) -> ReviewSubmissionItem:
         """
         https://developer.apple.com/documentation/appstoreconnectapi/post_v1_reviewsubmissionitems
@@ -34,10 +39,23 @@ class ReviewSubmissionItems(ResourceManager[ReviewSubmissionItem]):
                 'data': self._get_attribute_data(review_submission, ResourceType.REVIEW_SUBMISSIONS),
             },
         }
-        if app_store_version is not None:
-            relationships['appStoreVersion'] = {
-                'data': self._get_attribute_data(app_store_version, ResourceType.APP_STORE_VERSIONS),
-            }
+
+        optional_relationships: Dict[str, Tuple[Optional[Union[ResourceId, LinkedResourceData]], ResourceType]] = {
+            'appCustomProductPageVersion': (
+                app_custom_product_page_version,
+                ResourceType.APP_CUSTOM_PRODUCT_PAGE_VERSIONS,
+            ),
+            'appEvent': (app_event, ResourceType.APP_EVENTS),
+            'appStoreVersion': (app_store_version, ResourceType.APP_STORE_VERSIONS),
+            'appStoreVersionExperiment': (
+                app_store_version_experiment,
+                ResourceType.APP_STORE_VERSION_EXPERIMENTS,
+            ),
+        }
+
+        for relationship_name, (resource, resource_type) in optional_relationships.items():
+            if resource is not None:
+                relationships[relationship_name] = {'data': self._get_attribute_data(resource, resource_type)}
 
         payload = self._get_create_payload(
             ResourceType.REVIEW_SUBMISSION_ITEMS,

--- a/src/codemagic/apple/app_store_connect/versioning/review_submission_items.py
+++ b/src/codemagic/apple/app_store_connect/versioning/review_submission_items.py
@@ -1,0 +1,54 @@
+from typing import Optional
+from typing import Type
+from typing import Union
+
+from codemagic.apple.app_store_connect.resource_manager import ResourceManager
+from codemagic.apple.resources import AppStoreVersion
+from codemagic.apple.resources import LinkedResourceData
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ResourceType
+from codemagic.apple.resources import ReviewSubmission
+from codemagic.apple.resources import ReviewSubmissionItem
+
+
+class ReviewSubmissionItems(ResourceManager[ReviewSubmissionItem]):
+    """
+    Review Submission Items
+    https://developer.apple.com/documentation/appstoreconnectapi/review_submission_items
+    """
+
+    @property
+    def resource_type(self) -> Type[ReviewSubmissionItem]:
+        return ReviewSubmissionItem
+
+    def create(
+        self,
+        review_submission: Union[ResourceId, ReviewSubmission],
+        app_store_version: Optional[Union[ResourceId, AppStoreVersion]] = None,
+    ) -> ReviewSubmissionItem:
+        """
+        https://developer.apple.com/documentation/appstoreconnectapi/post_v1_reviewsubmissionitems
+        """
+        relationships = {
+            'reviewSubmission': {
+                'data': self._get_attribute_data(review_submission, ResourceType.REVIEW_SUBMISSIONS),
+            },
+        }
+        if app_store_version is not None:
+            relationships['appStoreVersion'] = {
+                'data': self._get_attribute_data(app_store_version, ResourceType.APP_STORE_VERSIONS),
+            }
+
+        payload = self._get_create_payload(
+            ResourceType.REVIEW_SUBMISSION_ITEMS,
+            relationships=relationships,
+        )
+        response = self.client.session.post(f'{self.client.API_URL}/reviewSubmissionItems', json=payload).json()
+        return ReviewSubmissionItem(response['data'], created=True)
+
+    def delete(self, review_submission_item: Union[LinkedResourceData, ResourceId]):
+        """
+        https://developer.apple.com/documentation/appstoreconnectapi/delete_v1_reviewsubmissionitems_id
+        """
+        review_submission_item_id = self._get_resource_id(review_submission_item)
+        self.client.session.delete(f'{self.client.API_URL}/reviewSubmissionItems/{review_submission_item_id}')

--- a/src/codemagic/apple/app_store_connect/versioning/review_submissions.py
+++ b/src/codemagic/apple/app_store_connect/versioning/review_submissions.py
@@ -1,0 +1,55 @@
+from typing import Type
+from typing import Union
+
+from codemagic.apple.app_store_connect.resource_manager import ResourceManager
+from codemagic.apple.resources import App
+from codemagic.apple.resources import LinkedResourceData
+from codemagic.apple.resources import Platform
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ResourceType
+from codemagic.apple.resources import ReviewSubmission
+
+
+class ReviewSubmissions(ResourceManager[ReviewSubmission]):
+    """
+    Review Submissions
+    https://developer.apple.com/documentation/appstoreconnectapi/review_submissions
+    """
+
+    @property
+    def resource_type(self) -> Type[ReviewSubmission]:
+        return ReviewSubmission
+
+    def create(
+        self,
+        platform: Platform,
+        app: Union[ResourceId, App],
+    ) -> ReviewSubmission:
+        """
+        https://developer.apple.com/documentation/appstoreconnectapi/post_v1_reviewsubmissions
+        """
+        attributes = {
+            'platform': platform.value,
+        }
+
+        relationships = {
+            'app': {
+                'data': self._get_attribute_data(app, ResourceType.APPS),
+            },
+        }
+
+        payload = self._get_create_payload(
+            ResourceType.REVIEW_SUBMISSIONS,
+            attributes=attributes,
+            relationships=relationships,
+        )
+        response = self.client.session.post(f'{self.client.API_URL}/reviewSubmissions', json=payload).json()
+        return ReviewSubmission(response['data'], created=True)
+
+    def read(self, review_submission: Union[LinkedResourceData, ResourceId]) -> ReviewSubmission:
+        """
+        https://developer.apple.com/documentation/appstoreconnectapi/get_v1_reviewsubmissions_id
+        """
+        review_submission_id = self._get_resource_id(review_submission)
+        response = self.client.session.get(f'{self.client.API_URL}/reviewSubmissions/{review_submission_id}').json()
+        return ReviewSubmission(response['data'])

--- a/src/codemagic/apple/app_store_connect/versioning/review_submissions.py
+++ b/src/codemagic/apple/app_store_connect/versioning/review_submissions.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from typing import Type
 from typing import Union
 
@@ -52,4 +53,29 @@ class ReviewSubmissions(ResourceManager[ReviewSubmission]):
         """
         review_submission_id = self._get_resource_id(review_submission)
         response = self.client.session.get(f'{self.client.API_URL}/reviewSubmissions/{review_submission_id}').json()
+        return ReviewSubmission(response['data'])
+
+    def modify(
+        self,
+        review_submission: Union[LinkedResourceData, ResourceId],
+        canceled: Optional[bool] = None,
+        submitted: Optional[bool] = None,
+    ) -> ReviewSubmission:
+        review_submission_id = self._get_resource_id(review_submission)
+
+        attributes = {}
+        if canceled is not None:
+            attributes['canceled'] = canceled
+        if submitted is not None:
+            attributes['submitted'] = submitted
+
+        payload = self._get_update_payload(
+            review_submission_id,
+            ResourceType.REVIEW_SUBMISSIONS,
+            attributes=attributes,
+        )
+        response = self.client.session.patch(
+            f'{self.client.API_URL}/reviewSubmissions/{review_submission_id}',
+            json=payload,
+        ).json()
         return ReviewSubmission(response['data'])

--- a/src/codemagic/apple/resources/__init__.py
+++ b/src/codemagic/apple/resources/__init__.py
@@ -30,10 +30,14 @@ from .enums import ProfileState
 from .enums import ProfileType
 from .enums import ReleaseType
 from .enums import ResourceType
+from .enums import ReviewSubmissionItemState
+from .enums import ReviewSubmissionState
 from .error_response import ErrorResponse
 from .pre_release_version import PreReleaseVersion
 from .profile import Profile
 from .resource import LinkedResourceData
 from .resource import Resource
 from .resource import ResourceId
+from .review_submission import ReviewSubmission
+from .review_submission_item import ReviewSubmissionItem
 from .signing_certificate import SigningCertificate

--- a/src/codemagic/apple/resources/app_store_version.py
+++ b/src/codemagic/apple/resources/app_store_version.py
@@ -54,4 +54,6 @@ class AppStoreVersion(Resource):
         routingAppCoverage: Relationship
 
         app: Optional[Relationship] = None
+        appClipDefaultExperience: Optional[Relationship] = None
+        appStoreVersionExperiments: Optional[Relationship] = None
         appVersionExperiments: Optional[Relationship] = None

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -241,6 +241,26 @@ class ResourceType(ResourceEnum):
     DEVICES = 'devices'
     PRE_RELEASE_VERSIONS = 'preReleaseVersions'
     PROFILES = 'profiles'
+    REVIEW_SUBMISSIONS = 'reviewSubmissions'
+    REVIEW_SUBMISSION_ITEMS = 'reviewSubmissionItems'
+
+
+class ReviewSubmissionState(ResourceEnum):
+    CANCELING = 'CANCELING'
+    COMPLETE = 'COMPLETE'
+    COMPLETING = 'COMPLETING'
+    IN_REVIEW = 'IN_REVIEW'
+    READY_FOR_REVIEW = 'READY_FOR_REVIEW'
+    UNRESOLVED_ISSUES = 'UNRESOLVED_ISSUES'
+    WAITING_FOR_REVIEW = 'WAITING_FOR_REVIEW'
+
+
+class ReviewSubmissionItemState(ResourceEnum):
+    ACCEPTED = 'ACCEPTED'
+    APPROVED = 'APPROVED'
+    READY_FOR_REVIEW = 'READY_FOR_REVIEW'
+    REJECTED = 'REJECTED'
+    REMOVED = 'REMOVED'
 
 
 class Locale(ResourceEnum):

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -226,7 +226,10 @@ class ReleaseType(ResourceEnum):
 
 class ResourceType(ResourceEnum):
     APPS = 'apps'
+    APP_CUSTOM_PRODUCT_PAGE_VERSIONS = 'appCustomProductPageVersions'
+    APP_EVENTS = 'appEvents'
     APP_STORE_VERSIONS = 'appStoreVersions'
+    APP_STORE_VERSION_EXPERIMENTS = 'appStoreVersionExperiments'
     APP_STORE_VERSION_LOCALIZATIONS = 'appStoreVersionLocalizations'
     APP_STORE_VERSION_SUBMISSIONS = 'appStoreVersionSubmissions'
     BETA_APP_LOCALIZATIONS = 'betaAppLocalizations'

--- a/src/codemagic/apple/resources/review_submission.py
+++ b/src/codemagic/apple/resources/review_submission.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .enums import Platform
+from .enums import ReviewSubmissionState
+from .resource import Relationship
+from .resource import Resource
+
+
+class ReviewSubmission(Resource):
+    """
+    https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission
+    """
+
+    @dataclass
+    class Attributes(Resource.Attributes):
+        platform: Platform
+        state: ReviewSubmissionState
+        submittedDate: datetime
+
+    @dataclass
+    class Relationships(Resource.Relationships):
+        items: Relationship
+        app: Optional[Relationship] = None
+        appStoreVersionForReview: Optional[Relationship] = None

--- a/src/codemagic/apple/resources/review_submission_item.py
+++ b/src/codemagic/apple/resources/review_submission_item.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .enums import ReviewSubmissionItemState
+from .resource import Relationship
+from .resource import Resource
+
+
+class ReviewSubmissionItem(Resource):
+    """
+    https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmissionitem
+    """
+
+    @dataclass
+    class Attributes(Resource.Attributes):
+        state: ReviewSubmissionItemState
+
+    @dataclass
+    class Relationships(Resource.Relationships):
+        appCustomProductPageVersion: Optional[Relationship] = None
+        appEvent: Optional[Relationship] = None
+        appStoreVersion: Optional[Relationship] = None
+        appStoreVersionExperiment: Optional[Relationship] = None

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -26,6 +26,8 @@ from codemagic.apple.resources import Locale
 from codemagic.apple.resources import Platform
 from codemagic.apple.resources import ReleaseType
 from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ReviewSubmission
+from codemagic.apple.resources import ReviewSubmissionItem
 from codemagic.mixins import PathFinderMixin
 
 from .arguments import AppStoreVersionInfo
@@ -85,6 +87,26 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
     ):
         from .action_groups import BetaGroupsActionGroup
         _ = BetaGroupsActionGroup.add_build_to_beta_groups  # Implementation
+        raise NotImplementedError()
+
+    @abstractmethod
+    def cancel_review_submission(
+        self,
+        review_submission_id: ResourceId,
+        should_print: bool = True,
+    ) -> ReviewSubmission:
+        from .action_groups import ReviewSubmissionsActionGroup
+        _ = ReviewSubmissionsActionGroup.cancel_review_submission  # Implementation
+        raise NotImplementedError()
+
+    @abstractmethod
+    def confirm_review_submission(
+        self,
+        review_submission_id: ResourceId,
+        should_print: bool = True,
+    ) -> ReviewSubmission:
+        from .action_groups import ReviewSubmissionsActionGroup
+        _ = ReviewSubmissionsActionGroup.confirm_review_submission  # Implementation
         raise NotImplementedError()
 
     @abstractmethod
@@ -149,6 +171,31 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
     ) -> BetaBuildLocalization:
         from .action_groups import BetaBuildLocalizationsActionGroup
         _ = BetaBuildLocalizationsActionGroup.create_beta_build_localization  # Implementation
+        raise NotImplementedError()
+
+    @abstractmethod
+    def create_review_submission(
+            self,
+            application_id: ResourceId,
+            platform: Platform,
+            should_print: bool = True,
+    ) -> ReviewSubmission:
+        from .action_groups import ReviewSubmissionsActionGroup
+        _ = ReviewSubmissionsActionGroup.create_review_submission  # Implementation
+        raise NotImplementedError()
+
+    @abstractmethod
+    def create_review_submission_item(
+        self,
+        review_submission_id: ResourceId,
+        app_custom_product_page_version_id: Optional[ResourceId] = None,
+        app_event_id: Optional[ResourceId] = None,
+        app_store_version_id: Optional[ResourceId] = None,
+        app_store_version_experiment_id: Optional[ResourceId] = None,
+        should_print: bool = True,
+    ) -> ReviewSubmissionItem:
+        from .action_groups import ReviewSubmissionItemsActionGroup
+        _ = ReviewSubmissionItemsActionGroup.create_review_submission_item  # Implementation
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/codemagic/tools/_app_store_connect/abstract_base_action.py
+++ b/src/codemagic/tools/_app_store_connect/abstract_base_action.py
@@ -90,16 +90,6 @@ class AbstractBaseAction(ResourceManagerMixin, PathFinderMixin, metaclass=ABCMet
         raise NotImplementedError()
 
     @abstractmethod
-    def cancel_review_submission(
-        self,
-        review_submission_id: ResourceId,
-        should_print: bool = True,
-    ) -> ReviewSubmission:
-        from .action_groups import ReviewSubmissionsActionGroup
-        _ = ReviewSubmissionsActionGroup.cancel_review_submission  # Implementation
-        raise NotImplementedError()
-
-    @abstractmethod
     def confirm_review_submission(
         self,
         review_submission_id: ResourceId,

--- a/src/codemagic/tools/_app_store_connect/action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_group.py
@@ -34,3 +34,11 @@ class AppStoreConnectActionGroup(cli.ActionGroup):
         name='beta-groups',
         description='Manage your groups of beta testers in App Store Connect',
     )
+    REVIEW_SUBMISSIONS = cli.ActionGroupProperties(
+        name='review-submissions',
+        description='Manage your App Store version review submissions',
+    )
+    REVIEW_SUBMISSION_ITEMS = cli.ActionGroupProperties(
+        name='review-submission-items',
+        description='Manage the contents of your review submission',
+    )

--- a/src/codemagic/tools/_app_store_connect/action_groups/__init__.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/__init__.py
@@ -6,3 +6,5 @@ from .beta_app_review_submissions_action_group import BetaAppReviewSubmissionsAc
 from .beta_build_localizations_action_group import BetaBuildLocalizationsActionGroup
 from .beta_groups_action_group import BetaGroupsActionGroup
 from .builds_action_group import BuildsActionGroup
+from .review_submission_items_actions_group import ReviewSubmissionItemsActionGroup
+from .review_submissions_actions_group import ReviewSubmissionsActionGroup

--- a/src/codemagic/tools/_app_store_connect/action_groups/review_submission_items_actions_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/review_submission_items_actions_group.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from abc import ABCMeta
+from typing import Optional
+
+from codemagic import cli
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ReviewSubmissionItem
+
+from ..abstract_base_action import AbstractBaseAction
+from ..action_group import AppStoreConnectActionGroup
+from ..arguments import AppStoreVersionArgument
+
+
+class ReviewSubmissionItemsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
+    ...
+
+    @cli.action(
+        'create',
+
+        AppStoreVersionArgument.APP_STORE_VERSION_ID,
+        action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSION_ITEMS,
+    )
+    def create_review_submission_item(
+        self,
+        review_submission_id: ResourceId,
+        app_custom_product_page_version_id: Optional[ResourceId] = None,
+        app_event_id: Optional[ResourceId] = None,
+        app_store_version_id: Optional[ResourceId] = None,
+        app_store_version_experiment_id: Optional[ResourceId] = None,
+        should_print: bool = True,
+    ) -> ReviewSubmissionItem:
+        """
+        Add contents to review submission for App Store review request
+        """
+        optional_kwargs = {
+            'app_custom_product_page_version': app_custom_product_page_version_id,
+            'app_event': app_event_id,
+            'app_store_version': app_store_version_id,
+            'app_store_version_experiment': app_store_version_experiment_id,
+        }
+        return self._create_resource(
+            self.api_client.review_submissions_items,
+            should_print,
+            review_submission=review_submission_id,
+            **{k: v for k, v in optional_kwargs.items() if v is not None},
+        )

--- a/src/codemagic/tools/_app_store_connect/action_groups/review_submission_items_actions_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/review_submission_items_actions_group.py
@@ -10,15 +10,17 @@ from codemagic.apple.resources import ReviewSubmissionItem
 from ..abstract_base_action import AbstractBaseAction
 from ..action_group import AppStoreConnectActionGroup
 from ..arguments import AppStoreVersionArgument
+from ..arguments import ReviewSubmissionArgument
 
 
 class ReviewSubmissionItemsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
-    ...
-
     @cli.action(
         'create',
-
         AppStoreVersionArgument.APP_STORE_VERSION_ID,
+        ReviewSubmissionArgument.APP_CUSTOM_PRODUCT_PAGE_VERSION_ID,
+        ReviewSubmissionArgument.APP_EVENT_ID,
+        ReviewSubmissionArgument.APP_STORE_VERSION_ID,
+        ReviewSubmissionArgument.APP_STORE_VERSION_EXPERIMENT_ID,
         action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSION_ITEMS,
     )
     def create_review_submission_item(

--- a/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
@@ -38,6 +38,25 @@ class ReviewSubmissionsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
         )
 
     @cli.action(
+        'get',
+        ReviewSubmissionArgument.REVIEW_SUBMISSION_ID,
+        action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSIONS,
+    )
+    def get_review_submission(
+        self,
+        review_submission_id: ResourceId,
+        should_print: bool = True,
+    ):
+        """
+        Read Review Submission information
+        """
+        return self._get_resource(
+            review_submission_id,
+            self.api_client.review_submissions,
+            should_print,
+        )
+
+    @cli.action(
         'cancel',
         ReviewSubmissionArgument.REVIEW_SUBMISSION_ID,
         action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSIONS,

--- a/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from abc import ABCMeta
+
+from codemagic import cli
+from codemagic.apple.resources import Platform
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ReviewSubmission
+
+from ..abstract_base_action import AbstractBaseAction
+from ..action_group import AppStoreConnectActionGroup
+from ..arguments import AppArgument
+from ..arguments import AppStoreVersionArgument
+from ..arguments import ReviewSubmissionArgument
+
+
+class ReviewSubmissionsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
+    @cli.action(
+        'create',
+        AppArgument.APPLICATION_ID_RESOURCE_ID,
+        AppStoreVersionArgument.PLATFORM,
+        action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSIONS,
+    )
+    def create_review_submission(
+        self,
+        application_id: ResourceId,
+        platform: Platform,
+        should_print: bool = True,
+    ) -> ReviewSubmission:
+        """
+        Create a review submission request for application's latest App Store Version
+        """
+        return self._create_resource(
+            self.api_client.review_submissions,
+            should_print,
+            app=application_id,
+            platform=platform,
+        )
+
+    @cli.action('cancel', ReviewSubmissionArgument.REVIEW_SUBMISSION_ID)
+    def cancel_review_submission(
+        self,
+        review_submission_id: ResourceId,
+        should_print: bool = True,
+    ) -> ReviewSubmission:
+        """
+        Discard review submission from App Review
+        """
+        return self._modify_resource(
+            self.api_client.review_submissions,
+            review_submission_id,
+            should_print,
+            canceled=True,
+        )
+
+    @cli.action('confirm', ReviewSubmissionArgument.REVIEW_SUBMISSION_ID)
+    def confirm_review_submission(
+        self,
+        review_submission_id: ResourceId,
+        should_print: bool = True,
+    ) -> ReviewSubmission:
+        """
+        Confirm pending review submission for App Review
+        """
+        return self._modify_resource(
+            self.api_client.review_submissions,
+            review_submission_id,
+            should_print,
+            submitted=True,
+        )

--- a/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/review_submissions_actions_group.py
@@ -37,7 +37,11 @@ class ReviewSubmissionsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             platform=platform,
         )
 
-    @cli.action('cancel', ReviewSubmissionArgument.REVIEW_SUBMISSION_ID)
+    @cli.action(
+        'cancel',
+        ReviewSubmissionArgument.REVIEW_SUBMISSION_ID,
+        action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSIONS,
+    )
     def cancel_review_submission(
         self,
         review_submission_id: ResourceId,
@@ -53,7 +57,11 @@ class ReviewSubmissionsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             canceled=True,
         )
 
-    @cli.action('confirm', ReviewSubmissionArgument.REVIEW_SUBMISSION_ID)
+    @cli.action(
+        'confirm',
+        ReviewSubmissionArgument.REVIEW_SUBMISSION_ID,
+        action_group=AppStoreConnectActionGroup.REVIEW_SUBMISSIONS,
+    )
     def confirm_review_submission(
         self,
         review_submission_id: ResourceId,

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -569,6 +569,38 @@ class AppStoreVersionArgument(cli.Argument):
     )
 
 
+class ReviewSubmissionArgument(cli.Argument):
+    APP_CUSTOM_PRODUCT_PAGE_VERSION_ID = cli.ArgumentProperties(
+        key='app_custom_product_page_version_id',
+        flags=('--app-custom-product-page-version-id',),
+        description='UUID value of custom product page',
+        type=ResourceId,
+    )
+    APP_EVENT_ID = cli.ArgumentProperties(
+        key='app_event_id',
+        flags=('--app-event-id',),
+        description='UUID value of app event',
+        type=ResourceId,
+    )
+    APP_STORE_VERSION_ID = cli.ArgumentProperties(
+        key='app_store_version_id',
+        flags=('--version-id', '--app-store-version-id'),
+        type=ResourceId,
+        description='UUID value of the App Store Version',
+    )
+    APP_STORE_VERSION_EXPERIMENT_ID = cli.ArgumentProperties(
+        key='app_store_version_experiment_id',
+        flags=('--app-store-version-experiment-id',),
+        type=ResourceId,
+        description='UUID value of the App Store Version experiment',
+    )
+    REVIEW_SUBMISSION_ID = cli.ArgumentProperties(
+        key='review_submission_id',
+        type=ResourceId,
+        description='UUID value of the review submission',
+    )
+
+
 class AppStoreVersionLocalizationArgument(cli.Argument):
     APP_STORE_VERSION_LOCALIZATION_ID = cli.ArgumentProperties(
         key='app_store_version_localization_id',

--- a/src/codemagic/tools/_app_store_connect/resource_manager_mixin.py
+++ b/src/codemagic/tools/_app_store_connect/resource_manager_mixin.py
@@ -21,7 +21,7 @@ class ResourceManagerMixin:
         try:
             resource = resource_manager.create(**create_params)
         except AppStoreConnectApiError as api_error:
-            raise AppStoreConnectError(str(api_error))
+            raise AppStoreConnectError(str(api_error)) from api_error
 
         self.printer.print_resource(resource, should_print)
         self.printer.log_created(resource)

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -50,6 +50,8 @@ from ._app_store_connect.action_groups import BetaAppReviewSubmissionsActionGrou
 from ._app_store_connect.action_groups import BetaBuildLocalizationsActionGroup
 from ._app_store_connect.action_groups import BetaGroupsActionGroup
 from ._app_store_connect.action_groups import BuildsActionGroup
+from ._app_store_connect.action_groups import ReviewSubmissionItemsActionGroup
+from ._app_store_connect.action_groups import ReviewSubmissionsActionGroup
 from ._app_store_connect.actions import PublishAction
 from ._app_store_connect.arguments import AppArgument
 from ._app_store_connect.arguments import AppStoreConnectArgument
@@ -94,6 +96,8 @@ class AppStoreConnect(
     AppsActionGroup,
     BetaAppReviewSubmissionsActionGroup,
     BetaBuildLocalizationsActionGroup,
+    ReviewSubmissionsActionGroup,
+    ReviewSubmissionItemsActionGroup,
     BetaGroupsActionGroup,
     BuildsActionGroup,
     PublishAction,

--- a/tests/apple/app_store_connect/versioning/test_review_submission_items.py
+++ b/tests/apple/app_store_connect/versioning/test_review_submission_items.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ResourceType
+from codemagic.apple.resources import ReviewSubmissionItem
+from tests.apple.app_store_connect.resource_manager_test_base import ResourceManagerTestsBase
+
+
+@pytest.mark.skipif(not os.environ.get('RUN_LIVE_API_TESTS'), reason='Live App Store Connect API access')
+class ReviewSubmissionItemsTest(ResourceManagerTestsBase):
+    def test_create(self):
+        review_submission_id = ResourceId('6e2682ef-873d-4ced-985a-787b6bd6bd7c')
+        app_store_version_id = ResourceId('409ebefb-ebd1-4f1a-903d-6ba16e013ebf')
+        review_submission_item = self.api_client.review_submissions_items.create(
+            review_submission_id,
+            app_store_version=app_store_version_id,
+        )
+        assert isinstance(review_submission_item, ReviewSubmissionItem)
+        assert review_submission_item.type is ResourceType.REVIEW_SUBMISSION_ITEMS
+
+    def test_delete(self):
+        review_submission_item_id = ResourceId('6e2682ef-873d-4ced-985a-787b6bd6bd7c')
+        self.api_client.review_submissions_items.delete(review_submission_item_id)

--- a/tests/apple/app_store_connect/versioning/test_review_submission_items.py
+++ b/tests/apple/app_store_connect/versioning/test_review_submission_items.py
@@ -21,5 +21,5 @@ class ReviewSubmissionItemsTest(ResourceManagerTestsBase):
         assert review_submission_item.type is ResourceType.REVIEW_SUBMISSION_ITEMS
 
     def test_delete(self):
-        review_submission_item_id = ResourceId('6e2682ef-873d-4ced-985a-787b6bd6bd7c')
+        review_submission_item_id = ResourceId('NmUyNjgyZWYtODczZC00Y2VkLTk4NWEtNzg3YjZiZDZiZDdjfDZ8ODMyOTAzMTI0')
         self.api_client.review_submissions_items.delete(review_submission_item_id)

--- a/tests/apple/app_store_connect/versioning/test_review_submissions.py
+++ b/tests/apple/app_store_connect/versioning/test_review_submissions.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+
+from codemagic.apple.resources import Platform
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ResourceType
+from codemagic.apple.resources import ReviewSubmission
+from tests.apple.app_store_connect.resource_manager_test_base import ResourceManagerTestsBase
+
+
+@pytest.mark.skipif(not os.environ.get('RUN_LIVE_API_TESTS'), reason='Live App Store Connect API access')
+class ReviewSubmissionsTest(ResourceManagerTestsBase):
+    def test_create(self):
+        app_id = ResourceId('1481211155')  # Banaan
+        review_submission = self.api_client.review_submissions.create(
+            Platform.IOS,
+            app_id,
+        )
+        assert isinstance(review_submission, ReviewSubmission)
+        assert review_submission.type is ResourceType.REVIEW_SUBMISSIONS
+
+    def test_read(self):
+        review_submission_id = ResourceId('6e2682ef-873d-4ced-985a-787b6bd6bd7c')
+        review_submission = self.api_client.review_submissions.read(review_submission_id)
+        print(review_submission.json())
+        assert isinstance(review_submission, ReviewSubmission)
+        assert review_submission.type is ResourceType.REVIEW_SUBMISSIONS
+        assert review_submission.id == review_submission_id

--- a/tests/apple/resources/mocks/app_store_version.json
+++ b/tests/apple/resources/mocks/app_store_version.json
@@ -26,10 +26,6 @@
         }
       },
       "build": {
-        "data": {
-          "type": "builds",
-          "id": "be235c1c-abe7-4884-a4f5-d67d97e41aa6"
-        },
         "links": {
           "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/build",
           "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/build"
@@ -63,6 +59,18 @@
         "links": {
           "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/idfaDeclaration",
           "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/idfaDeclaration"
+        }
+      },
+      "appClipDefaultExperience": {
+        "links": {
+          "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/appClipDefaultExperience",
+          "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/appClipDefaultExperience"
+        }
+      },
+      "appStoreVersionExperiments": {
+        "links": {
+          "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/appStoreVersionExperiments",
+          "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/appStoreVersionExperiments"
         }
       }
     },


### PR DESCRIPTION
Apple has deprecated the [Create an App Store Version Submission](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_submission) and replaced it by [Review Submissions](https://developer.apple.com/documentation/appstoreconnectapi/review_submissions) API. Changes included in this PR update the logic driving App Store publishing as part of actions `app-store-connect publish` and `app-store-connect builds submit-to-app-store`.

**New actions**
- `app-store-connect review-submission-items create`
- `app-store-connect review-submissions cancel`
- `app-store-connect review-submissions confirm`
- `app-store-connect review-submissions create`
- `app-store-connect review-submissions get`

**Updated actions**
- `app-store-connect publish`
- `app-store-connect builds submit-to-app-store`