### PR TITLE
Tests: Add default values for App Store Connect client fixture

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -45,9 +45,5 @@ jobs:
         pipenv run mypy src/codemagic
 
     - name: Test with pytest
-      env:
-        TEST_APPLE_ISSUER_ID: ${{ secrets.TEST_APPLE_ISSUER_ID }}
-        TEST_APPLE_KEY_IDENTIFIER: ${{ secrets.TEST_APPLE_KEY_IDENTIFIER }}
-        TEST_APPLE_PRIVATE_KEY_CONTENT: ${{ secrets.TEST_APPLE_PRIVATE_KEY_CONTENT }}
       run: |
         pipenv run pytest

--- a/tests/apple/app_store_connect/apps/test_apps.py
+++ b/tests/apple/app_store_connect/apps/test_apps.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from codemagic.apple import AppStoreConnectApiError
+from codemagic.apple.app_store_connect.apps import Apps
 from codemagic.apple.resources import App
 from codemagic.apple.resources import AppStoreState
 from codemagic.apple.resources import ResourceId
@@ -70,6 +71,6 @@ class AppsTest(ResourceManagerTestsBase):
     ('app_store_versions_app_store_state', 'appStoreVersions.appStoreState'),
     ('sku', 'sku'),
 ])
-def test_apps_filter(app_store_connect_api_client, python_field_name, apple_filter_name):
-    get_apple_filter_name = app_store_connect_api_client.apps.Filter._get_field_name
+def test_apps_filter(python_field_name, apple_filter_name):
+    get_apple_filter_name = Apps.Filter._get_field_name
     assert get_apple_filter_name(python_field_name) == apple_filter_name

--- a/tests/apple/app_store_connect/builds/test_builds.py
+++ b/tests/apple/app_store_connect/builds/test_builds.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from codemagic.apple.app_store_connect.builds import Builds
 from codemagic.apple.resources import AppStoreVersion
 from codemagic.apple.resources import Build
 from codemagic.apple.resources import ResourceId
@@ -41,6 +42,6 @@ class BuildsTest(ResourceManagerTestsBase):
     ('version', 'version'),
     ('pre_release_version_version', 'preReleaseVersion.version'),
 ])
-def test_builds_filter(app_store_connect_api_client, python_field_name, apple_filter_name):
-    get_apple_filter_name = app_store_connect_api_client.builds.Filter._get_field_name
+def test_builds_filter(python_field_name, apple_filter_name):
+    get_apple_filter_name = Builds.Filter._get_field_name
     assert get_apple_filter_name(python_field_name) == apple_filter_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,12 +57,12 @@ def _unencrypted_pem() -> PEM:
 
 @lru_cache()
 def _appstore_api_client() -> AppStoreConnectApiClient:
-    if 0 and 'TEST_APPLE_PRIVATE_KEY_PATH' in os.environ:
+    if 'TEST_APPLE_PRIVATE_KEY_PATH' in os.environ:
         key_path = pathlib.Path(os.environ['TEST_APPLE_PRIVATE_KEY_PATH'])
         private_key = key_path.expanduser().read_text()
         key_identifier = os.environ['TEST_APPLE_KEY_IDENTIFIER']
         issuer_id = os.environ['TEST_APPLE_ISSUER_ID']
-    elif 0 and 'TEST_APPLE_PRIVATE_KEY_CONTENT' in os.environ:
+    elif 'TEST_APPLE_PRIVATE_KEY_CONTENT' in os.environ:
         private_key = os.environ['TEST_APPLE_PRIVATE_KEY_CONTENT']
         key_identifier = os.environ['TEST_APPLE_KEY_IDENTIFIER']
         issuer_id = os.environ['TEST_APPLE_ISSUER_ID']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,31 @@ def _unencrypted_pem() -> PEM:
 
 @lru_cache()
 def _appstore_api_client() -> AppStoreConnectApiClient:
-    if 'TEST_APPLE_PRIVATE_KEY_PATH' in os.environ:
+    if 0 and 'TEST_APPLE_PRIVATE_KEY_PATH' in os.environ:
         key_path = pathlib.Path(os.environ['TEST_APPLE_PRIVATE_KEY_PATH'])
         private_key = key_path.expanduser().read_text()
-    elif 'TEST_APPLE_PRIVATE_KEY_CONTENT' in os.environ:
+        key_identifier = os.environ['TEST_APPLE_KEY_IDENTIFIER']
+        issuer_id = os.environ['TEST_APPLE_ISSUER_ID']
+    elif 0 and 'TEST_APPLE_PRIVATE_KEY_CONTENT' in os.environ:
         private_key = os.environ['TEST_APPLE_PRIVATE_KEY_CONTENT']
+        key_identifier = os.environ['TEST_APPLE_KEY_IDENTIFIER']
+        issuer_id = os.environ['TEST_APPLE_ISSUER_ID']
     else:
-        raise KeyError('TEST_APPLE_PRIVATE_KEY_PATH', 'TEST_APPLE_PRIVATE_KEY_CONTENT')
+        _logger().warning('Using mock App Store Connect private key')
+        private_key = (
+            '-----BEGIN PRIVATE KEY-----\n'
+            'MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgg57UZZvJPP2RSVnb\n'
+            'z09v3WoH9SPgoZW9Aa9zLVAIVQGgCgYIKoZIzj0DAQehRANCAAQOmjqG2uAvOmx3\n'
+            '8cXoNHDaAD9aDiNDqG2LcsOloIKgBRTLwcQPkTd/emZZndx0a0gDtviu2UDQ4l2/\n'
+            'ngq1dJ3d\n'
+            '-----END PRIVATE KEY-----\n'
+        )
+        key_identifier = '6NMHPUB3G8'
+        issuer_id = 'def71228-a8db-74ca-792d-763bded762de'  # Random non functional issuer
+
     return AppStoreConnectApiClient(
-        KeyIdentifier(os.environ['TEST_APPLE_KEY_IDENTIFIER']),
-        IssuerId(os.environ['TEST_APPLE_ISSUER_ID']),
+        KeyIdentifier(key_identifier),
+        IssuerId(issuer_id),
         private_key,
     )
 
@@ -111,11 +126,6 @@ def app_store_api_client() -> AppStoreConnectApiClient:
 def google_play_api_client() -> GooglePlayDeveloperAPIClient:
     credentials = _google_play_api_credentials()
     return GooglePlayDeveloperAPIClient(credentials)
-
-
-@pytest.fixture()
-def app_store_connect_api_client() -> AppStoreConnectApiClient:
-    return _appstore_api_client()
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
Do not require actual App Store Connect authenticaiton information for running tests as it is not used anyway.