### PR TITLE
Bugfix: Update Xcode project bundle identifier resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 -------------
 
+**Fixes**
+- Action `xcode-project use-profiles` failed to assign code signing information to build configurations that inherited build settings from `xcconfig` files. Reported in [issue #220](https://github.com/codemagic-ci-cd/cli-tools/issues/220). [PR #232](https://github.com/codemagic-ci-cd/cli-tools/pull/232)
+
 **Development**
 - Use default values for all arguments in `Keychain.add_certificates` and `XcodeProject.use_profiles`. [PR #226](https://github.com/codemagic-ci-cd/cli-tools/pull/226)
 

--- a/bin/code_signing_manager.rb
+++ b/bin/code_signing_manager.rb
@@ -7,7 +7,6 @@ require "set"
 require "tmpdir"
 require "xcodeproj"
 
-
 USAGE = "Usage: #{File.basename(__FILE__)} [options] -x XCODEPROJ_PATH -r RESULT_PATH -p [{...}, ...]
 
 Example provisioning profile in JSON format:
@@ -25,7 +24,6 @@ Example: #{File.basename(__FILE__)} -x Project.xcodeproj -u used-profiles.json -
 
 Arguments:
 "
-
 
 class Log
 
@@ -47,175 +45,13 @@ class Log
 
 end
 
-
-class VariableResolver
-
-  def initialize(build_target, build_configuration)
-    @build_target = build_target
-    @build_configuration = build_configuration
-  end
-
-  def resolve(source_str, target_str)
-    return unless target_str
-    target_str = inherit_variable(source_str, target_str)
-
-    Variable.new(target_str).keys_and_modifiers.each do |variable, key, modifiers|
-      value = resolve_from_target_or_config(key)
-      value = expand_environment_variables(value, target_str)
-      value = Variable.new(value).apply modifiers
-      target_str = target_str.sub(variable, value)
-    end
-
-    Log.info "> Resolved variable '#{source_str}' to '#{target_str}'"
-    # In case target str is still a variable look it up from xcconfig if possible
-    Variable.new(target_str).keys_and_modifiers.each do |_variable, key, modifiers|
-      real_path = @build_configuration&.base_configuration_reference&.real_path || 'unknown path'
-      value = resolve_variable_from_xcconfig_attributes(key)
-      unless value.nil?
-        Log.info "Got '#{value}' for '#{target_str}' from xcconfig #{real_path}"
-        target_str = Variable.new(value).apply modifiers
-      end
-    end
-    target_str
-  end
-
-  private
-
-  def inherit_variable(variable_name, target_str)
-    if target_str.downcase != '$inherited'
-      return target_str
-    end
-
-    @build_target.project.build_configurations.each do |project_build_configuration|
-      if project_build_configuration.name == @build_configuration.name
-        return project_build_configuration.build_settings[variable_name]
-      end
-    end
-    nil
-  end
-
-  def resolve_variable_from_xcconfig(variable_name, build_configuration = nil)
-    build_configuration = build_configuration || @build_configuration
-    base_configuration_reference = build_configuration.base_configuration_reference
-    if !base_configuration_reference.nil? && base_configuration_reference.real_path.exist?
-      xcconfig = Xcodeproj::Config.new(base_configuration_reference.real_path)
-      xcconfig.to_hash[variable_name]
-    end
-  end
-
-  def resolve_variable_from_target_configs(variable_name)
-    value = nil
-    Log.info "Trying to find a target with the same name as PBXProj build configuration"
-    @build_target.project.build_configurations.each do |project_build_configuration|
-      if project_build_configuration.name == @build_configuration.name
-        Log.info "Found build config on PBXProj for target #{@build_target.name}: #{project_build_configuration.name}"
-        value = project_build_configuration.build_settings[variable_name] \
-                || resolve_variable_from_xcconfig(variable_name, project_build_configuration)
-        if value
-          break
-        end
-      end
-    end
-    value || ''
-  end
-
-  def resolve_variable_from_xcconfig_attributes(variable_name)
-    base_configuration_reference = @build_configuration.base_configuration_reference
-    if base_configuration_reference.nil? || !base_configuration_reference.real_path.exist?
-      return nil
-    end
-
-    Log.info "Checking value for '#{variable_name}' from #{base_configuration_reference.real_path}"
-    xcconfig = Xcodeproj::Config.new(base_configuration_reference.real_path)
-    xcconfig.attributes[variable_name]
-  end
-
-  def resolve_from_target_or_config(variable_name)
-    def discard(resolved_value, original_name)
-      # Return resolved variable if it does not contain recursive reference to
-      # original key. Otherwise discard this value as it is recursive definition.
-      if !resolved_value.nil? && !(resolved_value.include? original_name)
-        resolved_value
-      end
-    end
-
-    default_options = {:TARGET_NAME => @build_target.name, :CONFIGURATION => @build_configuration.name}
-    value = discard(default_options[variable_name.to_sym], variable_name) \
-        || discard(@build_configuration.build_settings[variable_name], variable_name) \
-        || discard(resolve_variable_from_xcconfig(variable_name), variable_name) \
-        || discard(resolve_variable_from_target_configs(variable_name), variable_name)
-    value
-  end
-
-  def expand_environment_variables(variable_name, target_str)
-    value = variable_name
-    Variable.new(value).keys_and_modifiers.each do |var, _key, _modifiers|
-      # "Avoid recursion for variable '#{var}' if it is already present in target string '#{target_str}'"
-      unless target_str.include? var
-        resolved = resolve(var, var)
-        value = value.gsub(var, resolved)
-      end
-    end
-    value
-  end
-
-end
-
-
-class Variable
-
-  ENVIRONMENT_VARIABLE_REGEX = /(\$[{(]([^})]+)[})]|\$([^\W]+))/
-
-  def initialize(variable_value)
-    @value = variable_value
-  end
-
-  def apply(modifiers)
-    return unless @value
-
-    value = @value
-    modifiers.each do |modifier|
-      value = case modifier
-              when "identifier" then
-                value.gsub(/\W/, "_")
-              when "rfc1034identifier" then
-                value.gsub(/[\W_]/, "-")
-              when "lower" then
-                value.downcase
-              when "upper" then
-                value.upcase
-              else
-                value
-              end
-    end
-    value
-  end
-
-  # Parses environment variables from value and extracts key name and specified modifiers.
-  # For example:
-  #   Variable.new('$FIRST_VAR.something.${SECOND_VAR}').keys_and_modifiers
-  #     => [["$FIRST_VAR", "FIRST_VAR", []], ["${SECOND_VAR}", "SECOND_VAR", []]]
-  #   Variable.new('${FIRST-VAR:my-modifier}.something.$(SECOND_VAR:mod1:mod2)').keys_and_modifiers
-  #     => [["${FIRST-VAR:my-modifier}", "FIRST-VAR", ["my-modifier"]], ["$(SECOND_VAR:mod1:mod2)", "SECOND_VAR", ["mod1", "mod2"]]]
-  def keys_and_modifiers
-    @value.scan(ENVIRONMENT_VARIABLE_REGEX).map do |match|
-      cleaned_variable = match[1] || match[2]
-      parts = cleaned_variable.split(":")
-      key, modifiers = parts[0], parts[1..-1]
-      [match[0], key, modifiers]
-    end
-  end
-
-end
-
-
 class CodeSigningManager
 
   SKIP_SIGNING_PRODUCT_TYPES = [
-      "com.apple.product-type.bundle", # Product type Bundle
-      "com.apple.product-type.framework", # Product type Framework
-      "com.apple.product-type.bundle.ui-testing", # Product type UI test
-      "com.apple.product-type.bundle.unit-test", # Product type Unit Test
+    "com.apple.product-type.bundle", # Product type Bundle
+    "com.apple.product-type.framework", # Product type Framework
+    "com.apple.product-type.bundle.ui-testing", # Product type UI test
+    "com.apple.product-type.bundle.unit-test", # Product type Unit Test
   ]
 
   def initialize(project_path:, result_path:, profiles:)
@@ -239,7 +75,7 @@ class CodeSigningManager
         Log.info "Ignore error, this is open xcodeproj issue"
         @target_infos = []
       else
-        raise  # Unknown error, panic
+        raise # Unknown error, panic
       end
     end
     save_use_profiles_result
@@ -300,80 +136,6 @@ class CodeSigningManager
     real_target
   end
 
-  def get_bundle_id(target, build_configuration)
-    bundle_id = build_configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]
-    if not (bundle_id.nil? || bundle_id.empty?)
-      Log.info "Got bundle id '#{bundle_id}' from build settings for build configuration '#{build_configuration.name}'"
-    else
-      bundle_id = get_cf_bundle_identifier(build_configuration, target)
-      unless bundle_id
-        Log.info "Failed to obtain bundle id for build_configuration '#{build_configuration.name}'"
-        return ''
-      end
-      Log.info "Got bundle id '#{bundle_id}' from info plist for build configuration '#{build_configuration.name}'"
-    end
-
-    resolver = VariableResolver.new(target, build_configuration)
-    resolver.resolve('PRODUCT_BUNDLE_IDENTIFIER', bundle_id)
-  end
-
-  def get_bundle_id_from_root_project(build_configuration_name)
-    Log.info 'Attempt to obtain bundle id value from root object build configuration'
-    root_configurations = @project.root_object.build_configuration_list
-    unless root_configurations
-      Log.info 'Did not find root configurations from project'
-      return
-    end
-    root_configuration_settings = root_configurations.build_settings build_configuration_name
-    unless root_configuration_settings
-      Log.info "Did not find root configurations for configuration #{build_configuration_name}"
-      return
-    end
-    root_configuration_settings["PRODUCT_BUNDLE_IDENTIFIER"]
-  end
-
-  def get_bundle_id_from_base_conf(build_configuration)
-    base_configuration_reference = build_configuration.base_configuration_reference
-    if base_configuration_reference.nil?
-      return get_bundle_id_from_root_project build_configuration.name
-    end
-    unless File.exist?(base_configuration_reference.real_path)
-      return
-    end
-    xcconfig = Xcodeproj::Config.new(base_configuration_reference.real_path)
-    value = xcconfig.attributes["PRODUCT_BUNDLE_IDENTIFIER"]
-    if value.nil?
-      Log.info "Could not obtain bundle id value from base configuration reference"
-    end
-    value
-  end
-
-  def get_identifier_from_info_plist(build_configuration, infoplist_path)
-    Log.info "Build configuration '#{build_configuration.name}' info plist path is '#{infoplist_path}'"
-    infoplist_exists = File.file? infoplist_path
-    unless infoplist_exists
-      Log.info "Plist #{infoplist_path} does not exist"
-      return nil
-    end
-    info_plist = Xcodeproj::Plist.read_from_path(infoplist_path)
-    info_plist["CFBundleIdentifier"]
-  end
-
-  def get_cf_bundle_identifier(build_configuration, target)
-
-    infoplist_file = build_configuration.build_settings["INFOPLIST_FILE"]
-    resolver = VariableResolver.new(target, build_configuration)
-    infoplist_file = resolver.resolve('INFOPLIST_FILE', infoplist_file)
-
-    Log.info "Build configuration #{build_configuration.name} INFOPLIST_FILE is '#{infoplist_file}'"
-    if !infoplist_file
-      _value = get_bundle_id_from_base_conf(build_configuration)
-    else
-      infoplist_path = File.join(File.dirname(@project_path), infoplist_file)
-      _value = get_identifier_from_info_plist(build_configuration, infoplist_path)
-    end
-  end
-
   def skip_code_signing(target)
     Log.info "Setting empty code signing settings for target: #{target}"
     target.build_configurations.each do |build_configuration|
@@ -430,10 +192,12 @@ class CodeSigningManager
 
   def set_configuration_build_settings(build_target, build_configuration)
     Log.info "\n#{'-' * 50}\n"
-    bundle_id = get_bundle_id(build_target, build_configuration)
+    bundle_id = build_configuration.resolve_build_setting("PRODUCT_BUNDLE_IDENTIFIER")
     if bundle_id.nil? || bundle_id == ''
-      Log.info "No bundle id found for target '#{build_target.name}'"
+      Log.info "No bundle id found for build configuration '#{build_configuration.name}'"
       return
+    else
+      Log.info "Resolved bundle id '#{bundle_id}' for build configuration '#{build_configuration.name}'"
     end
 
     profile = nil
@@ -496,7 +260,6 @@ class CodeSigningManager
   end
 end
 
-
 def parse_args
   options = {}
   OptionParser.new do |parser|
@@ -545,16 +308,14 @@ def parse_args
   options
 end
 
-
 def main(args)
   Log.set_verbose args[:verbose]
   code_signing_manager = CodeSigningManager.new(
-      project_path: args[:project_path],
-      result_path: args[:result_path],
-      profiles: args[:profiles])
+    project_path: args[:project_path],
+    result_path: args[:result_path],
+    profiles: args[:profiles])
   code_signing_manager.set_code_signing_settings
 end
-
 
 if __FILE__ == $0
   args = parse_args


### PR DESCRIPTION
Action `xcode-project use-profiles` is using Ruby script [`code_signing_manager.rb`](https://github.com/codemagic-ci-cd/cli-tools/blob/master/bin/code_signing_manager.rb) under the hood to make changes to Xcode project files.

In there was bunch of custom made logic to retrieve bundle identifier value for Xcode project build configurations. This logic however fails to detect the bundle identifier in case build configuration inherits build settings from `xcconfig` configurations in some cases.

To make this component simpler and more robust, replace the custom code by [Xcodeproj](https://github.com/CocoaPods/Xcodeproj) Ruby gem built-in method [`XCBuildConfiguration#resolve_build_setting method`](https://www.rubydoc.info/gems/xcodeproj/Xcodeproj/Project/Object/XCBuildConfiguration#resolve_build_setting-instance_method).

**Updated actions**
- `xcode-project use-profiles`