### PR TITLE
Bugfix: review submission creation error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.27.2
+-------------
+
+**Bugfixes**:
+- Fix `AttributeError` that can occur on review submission creation error handling as part of action `app-store-connect builds submit-to-app-store`. [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+
 Version 0.27.1
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.27.1'
+__version__ = '0.27.2'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -279,15 +279,19 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             existing_submission_error_patt = re.compile(
                 r'There is another reviewSubmissions with id ([\w-]+) still in progress',
             )
-            existing_submission_matches = [
+
+            existing_submission_matches = (
                 existing_submission_error_patt.search(error.detail)
                 for error in api_error.error_response.errors
-            ]
-            if not existing_submission_matches:
+            )
+
+            try:
+                existing_submission_match = next(filter(bool, existing_submission_matches))
+            except StopIteration:
                 raise AppStoreConnectError(str(api_error)) from api_error
 
             self.logger.warning('Review submission already exists, reuse it')
-            existing_review_submission_id = ResourceId(existing_submission_matches[0].group(1))
+            existing_review_submission_id = ResourceId(existing_submission_match.group(1))
             review_submission = self.api_client.review_submissions.read(existing_review_submission_id)
 
         self.printer.print_resource(review_submission, True)


### PR DESCRIPTION
Action `app-store-connect builds submit-to-app-store` relies on creating [`ReviewSubmission`](https://developer.apple.com/documentation/appstoreconnectapi/reviewsubmission) resource for [`Build`](https://developer.apple.com/documentation/appstoreconnectapi/build) on App Store Connect.

As there can only be one review submission associated with any single build, then there is a graceful error handling for review submission creation that checks whether the creation request failed with error saying there already exists review submission for this build.

The check for such error is faulty as it does not check whether such an error exists, but rather whether there are any errors at all. And then `None` value is possibly treated as a `re.Match` instance. Stacktrace:

```python
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py" line 215 in submit_to_app_store [args] [locals]
    return self._submit_to_app_store(
File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py" line 259 in _submit_to_app_store [args] [locals]
    review_submission = self._create_review_submission(app, platform)
File "/usr/local/lib/python3.8/site-packages/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py" line 290 in _create_review_submission [args] [locals]
    existing_review_submission_id = ResourceId(existing_submission_matches[0].group(1))
AttributeError: 'NoneType' object has no attribute 'group'
```

To fix it, find first error whose message matches the predefined pattern and use that one to obtain the existing review submission, or fail the action normally with `AppStoreConnectError` as expected. 

**Updated actions**
- `app-store-connect builds submit-to-app-store`