### PR TITLE
Improvement: hide environment variables in `altool` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.27.3
+-------------
+
+**Features**:
+- Sanitize environment variable values in `altool` error logs when publishing to App Store Connect using `app-store-connect publish` fails. [PR #238](https://github.com/codemagic-ci-cd/cli-tools/pull/238)
+
 Version 0.27.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.27.2'
+__version__ = '0.27.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -234,9 +234,9 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
                 error_message,
                 self._hide_environment_variable_values(cpe.stdout),
             )
-        else:
-            self._log_process_output(stdout, cli_app)
-            return self._get_action_result(stdout)
+
+        self._log_process_output(stdout, cli_app)
+        return self._get_action_result(stdout)
 
     @classmethod
     def _hide_environment_variable_values(cls, altool_output: Optional[AnyStr]) -> str:

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -253,7 +253,9 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
         env_match = re.search(r'ENV: \{(.*)\}', output)
 
         if env_match is not None:
-            environment_variable_names = re.findall(r',?"([^"]+)"\s?=>\s?"', env_match.group(1))
+            # Ruby hashes are represented as `{ "name" => "value", "key" => "other value", ... }
+            # This pattern captures the variable name before `=>`.
+            environment_variable_names = re.findall(r',?"([^"]+)"\s?=>', env_match.group(1))
             sanitized_environment = ', '.join(f'"{name}"=>"..."' for name in environment_variable_names)
             output = (
                 f'{output[:env_match.span()[0]]}'

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -226,42 +226,43 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
                     stderr=subprocess.STDOUT,
                 ).decode()
         except subprocess.CalledProcessError as cpe:
-            stdout = self._hide_environment_variable_values(cpe.stdout)
             result = self._get_action_result(cpe.stdout)
             if result and result.product_errors:
                 product_errors = '\n'.join(pe.message for pe in result.product_errors)
                 error_message = f'{error_message}:\n{product_errors}'
-            raise AltoolCommandError(error_message, self._str(stdout or ''))
-
-        stdout = self._hide_environment_variable_values(stdout)
-        self._log_process_output(stdout, cli_app)
-        return self._get_action_result(stdout)
+            raise AltoolCommandError(
+                error_message,
+                self._hide_environment_variable_values(cpe.stdout),
+            )
+        else:
+            self._log_process_output(stdout, cli_app)
+            return self._get_action_result(stdout)
 
     @classmethod
-    def _hide_environment_variable_values(cls, stdout: Optional[AnyStr]) -> Optional[str]:
+    def _hide_environment_variable_values(cls, altool_output: Optional[AnyStr]) -> str:
         """
         With certain Xcode versions all defined environment variables
         are printed out by ipatool as Ruby mapping in case an error occurs.
         Since environment variables can contain all kinds of secrets
         it is not desirable to have them in the publishing output.
         """
-        if stdout is None:
-            return None
+        if altool_output is None:
+            return ''
 
-        stdout = cls._str(stdout)
-        env_match = re.search(r'ENV: \{(.*)\}', stdout)
+        output = cls._str(altool_output)
+        env_match = re.search(r'ENV: \{(.*)\}', output)
 
         if env_match is not None:
             environment_variables = env_match.group(1).split('", "')
             environment_variable_names = (variable.split('"=>"')[0].strip('"') for variable in environment_variables)
             sanitized_environment = ', '.join(f'"{name}"=>"..."' for name in environment_variable_names)
-            stdout = (
-                f'{stdout[:env_match.span()[0]]}'
+            output = (
+                f'{output[:env_match.span()[0]]}'
                 f'ENV: {{{sanitized_environment}}}'
-                f'{stdout[env_match.span()[1]:]}'
+                f'{output[env_match.span()[1]:]}'
             )
 
-        return stdout
+        return output
 
     @classmethod
     def _should_retry_command(cls, process_output: str):
@@ -289,7 +290,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
             result = json.loads(output)
             prettified_result = json.dumps(result, indent=4)
         except ValueError:
-            prettified_result = cls._str(output)
+            prettified_result = cls._hide_environment_variable_values(output)
 
         if cli_app:
             cli_app.echo(prettified_result)

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -253,8 +253,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
         env_match = re.search(r'ENV: \{(.*)\}', output)
 
         if env_match is not None:
-            environment_variables = env_match.group(1).split('", "')
-            environment_variable_names = (variable.split('"=>"')[0].strip('"') for variable in environment_variables)
+            environment_variable_names = re.findall(r',?"([^"]+)"\s?=>\s?"', env_match.group(1))
             sanitized_environment = ', '.join(f'"{name}"=>"..."' for name in environment_variable_names)
             output = (
                 f'{output[:env_match.span()[0]]}'


### PR DESCRIPTION
Action `app-store-connect publish` uses `xcrun altool` to perform the package upload to App Store Connect. With some Xcode versions `altool` logs out all environment variables and their values as a Ruby hashmap in case of an error.
Usually this is not a desired behaviour, especially in a CI envioronment. This is because environment variables can contain various secrets such as private keys, passwords etc, and they would leak to build logs that way.

In order to tackle this, replace environment variable values in `altool` output with ellipsis. That is
```
ENV: {"VARIABLE_1" => "value", "KEY" => "other value"}
```

becomes

```
ENV: {"VARIABLE_1" => "...", "KEY" => "..."}
```

in the output.

Note that in the verbose logs full unmodified `altool` output is available for inspection.

**Updated actions**
- `app-store-connect publish`
