### PR TITLE
Bugfix: Invalid values for grouped arguments via environment variables are not handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.27.3
+-------------
+
+**Bugfixes**:
+- Fix handling invalid argument errors for grouped CLI arguments that are defined via environment variables. [PR #239](https://github.com/codemagic-ci-cd/cli-tools/pull/239)
+
 Version 0.27.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.27.2'
+__version__ = '0.27.3'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument/argument.py
+++ b/src/codemagic/cli/argument/argument.py
@@ -45,8 +45,8 @@ class Argument(ArgumentProperties, enum.Enum):
             )
             new_argument = argument_class[argument.name]
             new_argument.register = argument.register  # type: ignore
-            new_argument._get_parser_argument = argument._get_parser_argument
-            new_argument._set_parser_argument = argument._set_parser_argument
+            new_argument._get_parser_argument = argument._get_parser_argument  # type: ignore
+            new_argument._set_parser_argument = argument._set_parser_argument  # type: ignore
             yield new_argument
 
     @classmethod

--- a/src/codemagic/cli/argument/argument.py
+++ b/src/codemagic/cli/argument/argument.py
@@ -45,6 +45,8 @@ class Argument(ArgumentProperties, enum.Enum):
             )
             new_argument = argument_class[argument.name]
             new_argument.register = argument.register  # type: ignore
+            new_argument._get_parser_argument = argument._get_parser_argument
+            new_argument._set_parser_argument = argument._set_parser_argument
             yield new_argument
 
     @classmethod
@@ -67,11 +69,14 @@ class Argument(ArgumentProperties, enum.Enum):
         kwargs = self.value.argparse_kwargs or {}
         if 'action' not in kwargs:
             kwargs['type'] = self.value.type
-        self._parser_argument = argument_group.add_argument(
-            *self.value.flags,
-            help=self.get_description().replace('`', ''),
-            dest=self.value.key,
-            **kwargs)
+        if self.argument_group_name is None:
+            parser_argument = argument_group.add_argument(
+                *self.value.flags,
+                help=self.get_description().replace('`', ''),
+                dest=self.value.key,
+                **kwargs,
+            )
+            self._set_parser_argument(parser_argument)
 
     def is_required(self) -> bool:
         return (self.value.argparse_kwargs or {}).get('required', True)
@@ -122,7 +127,7 @@ class Argument(ArgumentProperties, enum.Enum):
         """
         if message is None:
             message = self.get_missing_value_error_message()
-        raise argparse.ArgumentError(self._parser_argument, message)
+        raise argparse.ArgumentError(self._get_parser_argument(), message)
 
     def _is_function_argument(self):
         return isinstance(self.value.type, (types.FunctionType, types.MethodType))

--- a/src/codemagic/cli/argument/argument_properties.py
+++ b/src/codemagic/cli/argument/argument_properties.py
@@ -30,10 +30,8 @@ class ArgumentProperties(NamedTuple):
 
         return ArgumentProperties(**kwargs)
 
-    @property
-    def _parser_argument(self):
+    def _get_parser_argument(self):
         return getattr(self, '__parser_argument')
 
-    @_parser_argument.setter
-    def _parser_argument(self, parser_argument):
+    def _set_parser_argument(self, parser_argument):
         setattr(self, '__parser_argument', parser_argument)

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -121,7 +121,7 @@ class TypedCliArgument(Generic[T], metaclass=TypedCliArgumentMeta):
     def _apply_type(cls, non_typed_value: str) -> T:
         value = cls.argument_type(non_typed_value)
         if not cls._is_valid(value):
-            raise argparse.ArgumentTypeError(f'Provided value "{value}" is not valid')
+            raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
         return value
 
     def _parse_value(self) -> T:

--- a/tests/tools/app_store_connect/test_publish_action.py
+++ b/tests/tools/app_store_connect/test_publish_action.py
@@ -240,7 +240,13 @@ def test_skip_package_upload_or_validation_argument_from_env(argument, environme
     assert parsed_value.value is True
 
 
-@pytest.mark.parametrize('argument', (PublishArgument.SKIP_PACKAGE_VALIDATION, PublishArgument.SKIP_PACKAGE_UPLOAD))
+@pytest.mark.parametrize(
+    'argument',
+    (
+        PublishArgument.SKIP_PACKAGE_VALIDATION,
+        PublishArgument.SKIP_PACKAGE_UPLOAD,
+    ),
+)
 def test_no_skip_package_upload_or_validation_argument_from_env(cli_argument_group, argument):
     """
     Non "truthy" value is not valid as this action just turns the switch on.
@@ -250,7 +256,7 @@ def test_no_skip_package_upload_or_validation_argument_from_env(cli_argument_gro
     os.environ[argument.type.environment_variable_key] = ''
     with pytest.raises(argparse.ArgumentError) as error_info:
         argument.from_args(args)
-    assert str(error_info.value) == f'argument {"/".join(argument.flags)}: Provided value "False" is not valid'
+    assert str(error_info.value) == f'argument {"/".join(argument.flags)}: Provided value "" is not valid'
 
 
 def test_add_build_to_beta_groups(publishing_namespace_kwargs):


### PR DESCRIPTION
Grouped CLI arguments that can be also defined via environment variables (not just CLI switches) can cause unexpected exceptions when invalid values are provided as environment variable value.

For example action `app-store-connect publish` has argument group "Apple's altool configuration options" that contains switch `--altool-retries`, which is supposed to be a positive integer. Its value can also be specified by environment variable `APP_STORE_CONNECT_ALTOOL_RETRIES`. It is expected that the same values either from CLI or from environment yield in exactly the same result, but it is not the case as of now. Invalid values from CLI args are handled properly
```shell
$ app-store-connect publish --path app.ipa --altool-retries -1
usage: app-store-connect publish [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v] [--path artifact-path [artifact-path ...]] ...
app-store-connect publish: error: argument --altool-retries: Provided value "-1" is not valid
```
while the same value from respective envirionment variable results in an unhandled exception:
```shell
$ APP_STORE_CONNECT_ALTOOL_RETRIES='-1' app-store-connect publish --path app.ipa
Executing AppStoreConnect action publish failed unexpectedly. Detailed logs are available at "/var/folders/vs/tcrc5cns67zgynxt6fssjdg80000gn/T/codemagic-06-06-22.log". To see more details about the error, add `--verbose` command line option.
```

with full exception traceback being

```python
[12:03:44 06-06-2022] ERROR cli_app.py:115 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 112, in from_environment_variable_default
    return cls(os.environ[cls.environment_variable_key], from_environment=True)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 37, in __call__
    return super().__call__(*args, **kwargs)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 86, in __init__
    self.value: T = self._parse_value()
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 129, in _parse_value
    return self._apply_type(value)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 124, in _apply_type
    raise argparse.ArgumentTypeError(f'Provided value "{value}" is not valid')
argparse.ArgumentTypeError: Provided value "-1" is not valid

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/argument.py", line 86, in from_args
    return self.value.type.from_environment_variable_default()
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/typed_cli_argument.py", line 114, in from_environment_variable_default
    raise ValueError(str(ate)) from ate
ValueError: Provided value "-1" is not valid

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/cli_app.py", line 202, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/cli_app.py", line 154, in _invoke_action
    action_args = {
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/cli_app.py", line 155, in <dictcomp>
    arg_type.value.key: arg_type.from_args(args, arg_type.get_default())
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/argument.py", line 88, in from_args
    self.raise_argument_error(str(ve))
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/argument.py", line 125, in raise_argument_error
    raise argparse.ArgumentError(self._parser_argument, message)
  File "/Users/priit/.pyenv/versions/3.8.10/lib/python3.8/site-packages/codemagic_cli_tools-0.27.3-py3.8.egg/codemagic/cli/argument/argument_properties.py", line 35, in _parser_argument
    return getattr(self, '__parser_argument')
AttributeError: 'PublishArgument' object has no attribute '__parser_argument'
```

This happens because the mechanism that copies duplicates argument instance with custom group had a fault that did not persist the `argparse` registered argument access. In this PR parser argument access is reworked in a way that the original argument is registered as a CLI argument, and duplicate reuses the parser argument from original when need be.