### PR TITLE
Improvement: Check if failed tests were retried successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.27.5
+Version 0.27.6
 -------------
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Version 0.27.5
 -------------
 
+**Features**:
+- Action `xcode-project run-tests` will now respect retried testcase outcome. In case the initial testcase execution fails, but retrying is turned on (by `-retry-tests-on-failure` Xcode testing flag) and subsequent testcase run turns out to be successful, then this testcase will not be considered as _failed_ in the context of whole test suite. [PR #242](https://github.com/codemagic-ci-cd/cli-tools/pull/242)
+
+Version 0.27.5
+-------------
+
 **Dependencies**:
 - Remove upper bound version limit `<37` from [`cryptography`](https://cryptography.io/) dependency, but exclude version [`37.0.0`](https://cryptography.io/en/latest/changelog/#v37-0-1) as it conflicts with `pyOpenSSL`. [PR #241](https://github.com/codemagic-ci-cd/cli-tools/pull/241)
 - Remove upper bound version limit from [`google-api-python-client`](https://github.com/googleapis/google-api-python-client) as all used functionality works also with recent versions. [PR #241](https://github.com/codemagic-ci-cd/cli-tools/pull/241)

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.27.5'
+__version__ = '0.27.6'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -433,8 +433,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         self._save_test_suite(xcresult, test_suites, output_dir, output_extension)
 
         if not graceful_exit:
-            has_failing_tests = test_suites and (test_suites.failures or test_suites.errors)
-            if testing_failed or has_failing_tests:
+            if testing_failed or (test_suites and test_suites.has_failed_tests()):
                 raise XcodeProjectException('Tests failed')
 
     @cli.action('test-summary',


### PR DESCRIPTION
When running Xcode tests using action `xcode-project run-tests` by specifying `xcodebuild` flag `-retry-tests-on-failure`, then Xcode automatically retries failed tests. The testcases that initially failed, but succeded later during retry attempts are not considered as successful tests and contribute to overall test suite failure. This is not a desired outcome, and the action should take the retried attempts into account to resolve overall test execution status.

The changes in this PR will check if any of the failed or errored testcases had a successful retry attempt.

**Updated actions:**
- `xcode-project run-tests`