### PR TITLE
Bugfix: Resolve bundle identifiers from Info.plist files for `xcode-project use-profiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.29.1
+-------------
+
+This is a bugfix release including changes from [PR #245](https://github.com/codemagic-ci-cd/cli-tools/pull/245).
+
+**Bugfixes**
+- Fix `xcode-project use-profiles` for cases when bundle identifier is defined in information property list files. Add fallback bundle identifier detection from Info.plist file to code signing setup script if `PRODUCT_BUNDLE_IDENTIFIER` is not resolved from build configuration.
+
 Version 0.29.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.29.0"
+version = "0.29.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.29.0.dev'
+__version__ = '0.29.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/scripts/code_signing_manager.rb
+++ b/src/codemagic/scripts/code_signing_manager.rb
@@ -37,14 +37,14 @@ class VariableResolver
   end
 
   def keys_and_modifiers(unresolved_value)
-    # Parses environment variables from value and extracts key name and specified modifiers.
+    # Parse environment variables from value and extract key name and specified modifiers.
     # For example:
-    #   Variable.new('$FIRST_VAR.something.${SECOND_VAR}').keys_and_modifiers
+    #   variable_resolver.keys_and_modifiers '$FIRST_VAR.something.${SECOND_VAR}'
     #     => [
     #          ["$FIRST_VAR", "FIRST_VAR", []],
     #          ["${SECOND_VAR}", "SECOND_VAR", []]
     #        ]
-    #   Variable.new('${FIRST-VAR:my-modifier}.something.$(SECOND_VAR:mod1:mod2)').keys_and_modifiers
+    #   variable_resolver.keys_and_modifiers '${FIRST-VAR:my-modifier}.something.$(SECOND_VAR:mod1:mod2)'
     #     => [
     #          ["${FIRST-VAR:my-modifier}", "FIRST-VAR", ["my-modifier"]],
     #          ["$(SECOND_VAR:mod1:mod2)", "SECOND_VAR", ["mod1", "mod2"]]


### PR DESCRIPTION
Mechanism of how bundle identifiers are detected from Xcode projects for `xcode-project use-profiles` was changed in version [v0.27.0](https://github.com/codemagic-ci-cd/cli-tools/releases/tag/v0.27.0). Namely the script [`code_signing_manager.rb`](https://github.com/codemagic-ci-cd/cli-tools/pull/232/files#diff-d49c5b1f0a323fabce10f56a5b783485494ae12650faa1db910a8870bfdeeeb4) was edited and sadly those edits introduced some regressions.

In case bundle identifier is defined in information property list (Info.plist) file, then it will not be resolved from target's build configuration settings. As a result we don't know what bundle identifier corresponds to given build configuration, which in turn means that we cannot assign proper code signing settings to this configuration. Eventually this leads to a failed iOS build as code signign settings are not properly configured.

With the changes here, in case `PRODUCT_BUNDLE_IDENTIFIER` cannot be resolved from build settings, then check `CFBundleIdentifier` value from build configuration's Info.plist file. The definitions there might contain variables that need to be resolved on their own. To do that, `VariableResolver` class was restored. There
variable substitution logic is almost a verbatim copy-paste from the [previously working revision](https://github.com/codemagic-ci-cd/cli-tools/pull/232/files#diff-d49c5b1f0a323fabce10f56a5b783485494ae12650faa1db910a8870bfdeeeb4L51) as it was extensively used and tested in the past. The old spahgetty variable value resolving mechanism was however replaced by [`Xcodeproj`](https://github.com/CocoaPods/Xcodeproj) built-in method [`XCBuildConfiguration#resolve_build_setting`](https://www.rubydoc.info/gems/xcodeproj/Xcodeproj%2FProject%2FObject%2FXCBuildConfiguration:resolve_build_setting).

**Updated actions:**
- `xcode-project use-profiles`