### PR TITLE
Bugfix: Match profile type and cert for MAC_APP_DIRECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.29.2
+-------------
+
+This is a bugfix release including changes from [PR #246](https://github.com/codemagic-ci-cd/cli-tools/pull/246).
+
+**Bugfixes**
+- Fix matching a profile in `app-store-connect fetch-signing-files` for cases where `type` is defined as `MAC_APP_DIRECT`.
+
 Version 0.29.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.29.1"
+version = "0.29.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.29.1.dev'
+__version__ = '0.29.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -125,6 +125,8 @@ class CertificateType(ResourceEnum):
             return CertificateType.MAC_APP_DEVELOPMENT
         elif profile_type is profile_type.MAC_APP_STORE:
             return CertificateType.DISTRIBUTION
+        elif profile_type is profile_type.MAC_APP_DIRECT:
+            return CertificateType.DEVELOPER_ID_APPLICATION
         elif profile_type is profile_type.TVOS_APP_DEVELOPMENT:
             return CertificateType.DEVELOPMENT
         elif profile_type is profile_type.TVOS_APP_STORE:

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -582,6 +582,8 @@ class AppStoreConnect(
                 types.add(CertificateType.IOS_DISTRIBUTION)
             elif profile_type is ProfileType.MAC_APP_STORE:
                 types.add(CertificateType.MAC_APP_DISTRIBUTION)
+            elif profile_type is ProfileType.MAC_APP_DIRECT:
+                types.add(CertificateType.DEVELOPER_ID_APPLICATION)
 
         return list(types) if types else None
 
@@ -809,6 +811,8 @@ class AppStoreConnect(
             certificate_types.append(CertificateType.IOS_DISTRIBUTION)
         elif profile_type is ProfileType.MAC_APP_STORE:
             certificate_types.append(CertificateType.MAC_APP_DISTRIBUTION)
+        elif profile_type is ProfileType.MAC_APP_DIRECT:
+            certificate_types.append(CertificateType.DEVELOPER_ID_APPLICATION)
 
         certificates = self.list_certificates(
             certificate_types=certificate_types,


### PR DESCRIPTION
Currently, setting the parameter `--type` to `MAC_APP_DIRECT` when using `app-store-connect fetch-signing-files` results in the following error:
```python
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 202, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 158, in _invoke_action
    return cli_action(**action_args)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 417, in wrapper
    return func(*args, **kwargs)
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 756, in fetch_signing_files
    certificates = self._get_or_create_certificates(
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 802, in _get_or_create_certificates
    certificate_types = [CertificateType.from_profile_type(profile_type)]
  File "/Users/builder/.pyenv/versions/3.8.7/lib/python3.8/site-packages/codemagic/apple/resources/enums.py", line 135, in from_profile_type
    raise ValueError(f'Certificate type for profile type {profile_type} is unknown')
ValueError: Certificate type for profile type MAC_APP_DIRECT is unknown
```

This PR proposes to set the certificate type to `DEVELOPER_ID_APPLICATION` when the profile type is `MAC_APP_DIRECT`.

Similar matching to what is proposed in this PR can be found in this [Fastlane PR](https://github.com/fastlane/fastlane/pull/17263/files#diff-b8a93c52bd6d9bcb9062e939f7efe765b9708c546791b4ce11babf3cf9883d33R254) on line 254.

**Updated actions:**
- `app-store-connect fetch-signing-files`