### PR TITLE
Add Changelog URL to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.29.3
 -------------
 
 **Docs**
-- Add the changelog URL to the `pyproject.toml` file.
+- Add the changelog URL to the `pyproject.toml` project file so that the changelog reference is included under project links in PyPI.
 
 Version 0.29.2
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.29.3
+-------------
+
+**Docs**
+- Add the changelog URL to the `pyproject.toml` file.
+
 Version 0.29.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.29.2"
+version = "0.29.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [
@@ -20,6 +20,7 @@ documentation = "https://github.com/codemagic-ci-cd/cli-tools/tree/master/docs#c
 
 [tool.poetry.urls]
 "Issue Tracker" = "https://github.com/codemagic-ci-cd/cli-tools/issues"
+"Changelog" = "https://github.com/codemagic-ci-cd/cli-tools/blob/master/CHANGELOG.md"
 
 [tool.poetry.scripts]
 android-app-bundle = "codemagic.tools:AndroidAppBundle.invoke_cli"


### PR DESCRIPTION
This PR adds the changelog URL to `pyproject.toml`, as per [poetry documentation](https://python-poetry.org/docs/pyproject/#urls).