### PR TITLE
Development: Save timestamp along with other failed App Store Connect HTTP request info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.31.1
+-------------
+
+**Development**:
+- Save timestamp along with other failed App Store Connect HTTP request info. [PR #253](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+
 Version 0.31.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.31.0"
+version = "0.31.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.31.0.dev'
+__version__ = '0.31.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/utilities/auditing/http_request_auditor.py
+++ b/src/codemagic/utilities/auditing/http_request_auditor.py
@@ -76,6 +76,7 @@ class HttpRequestAuditor(BaseAuditor):
                 'content': self._serialize_response_content(),
                 'elapsed': self._response.elapsed.total_seconds(),
             },
+            'timestamp': datetime.utcnow().isoformat(),
             'version': __version__,
         }
 


### PR DESCRIPTION
This PR is a follow up to PR #248 where structured failure information was introduced. 

Often times is also improtant to know when exactly which HTTP call failed, not only what the request and response were. Hence timestamps are included in the structured (failed) HTTP request logs.