### PR TITLE
Development: Make `iter_backwards` work on file-like objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+Version 0.31.2
+-------------
+
+**Development**:
+- Support file-like objects for `codemagic.utilities.backwards_file_reader.iter_backwards` in addition to file paths. [PR #255](https://github.com/codemagic-ci-cd/cli-tools/pull/255)
+
 Version 0.31.1
 -------------
 
 **Development**:
-- Save timestamp along with other failed App Store Connect HTTP request info. [PR #253](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+- Save timestamp along with other failed App Store Connect HTTP request info. [PR #254](https://github.com/codemagic-ci-cd/cli-tools/pull/254)
 
 Version 0.31.0
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.31.1"
+version = "0.31.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.31.1.dev'
+__version__ = '0.31.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/utilities/backwards_file_reader.py
+++ b/src/codemagic/utilities/backwards_file_reader.py
@@ -1,39 +1,51 @@
 import io
 from pathlib import Path
 from typing import Iterable
+from typing import Optional
+from typing import TextIO
 from typing import Union
 
 
-def iter_backwards(file_path: Union[Path, str], buffer_size=8192) -> Iterable[str]:
+def _iter_backwards(file_descriptor: TextIO, buffer_size: int, file_size: Optional[int] = None):
+    current_segment = None
+    offset_from_end = 0
+    unprocessed_size = file_descriptor.seek(0, io.SEEK_END)
+    if file_size is None:
+        file_size = unprocessed_size
+
+    while unprocessed_size > 0:
+        offset_from_end = min(file_size, offset_from_end + buffer_size)
+        file_descriptor.seek(file_size - offset_from_end)
+        buffer = file_descriptor.read(min(unprocessed_size, buffer_size))
+        unprocessed_size -= buffer_size
+        lines = buffer.splitlines()
+
+        if buffer.endswith('\n'):  # Previous segment was not a half line.
+            yield current_segment or ''
+        else:  # Previous segment did not end at a line break.
+            lines[-1] += current_segment or ''
+
+        # Retain the first line for next iteration as it might have some
+        # portion not captured by current buffer.
+        current_segment = lines[0]
+        for line in reversed(lines[1:]):
+            yield line
+
+    if current_segment is not None:
+        yield current_segment
+
+
+def iter_backwards(
+    file_or_path: Union[TextIO, Path, str],
+    buffer_size=8192,
+) -> Iterable[str]:
     """
     A generator that returns the lines of a file in reverse order
     """
 
-    file_path = Path(file_path)
-    file_size = file_path.stat().st_size
-
-    with file_path.open() as fd:
-        current_segment = None
-        offset_from_end = 0
-        unprocessed_size = fd.seek(0, io.SEEK_END)
-
-        while unprocessed_size > 0:
-            offset_from_end = min(file_size, offset_from_end + buffer_size)
-            fd.seek(file_size - offset_from_end)
-            buffer = fd.read(min(unprocessed_size, buffer_size))
-            unprocessed_size -= buffer_size
-            lines = buffer.splitlines()
-
-            if buffer.endswith('\n'):  # Previous segment was not a half line.
-                yield current_segment or ''
-            else:  # Previous segment did not end at a line break.
-                lines[-1] += current_segment or ''
-
-            # Retain the first line for next iteration as it might have some
-            # portion not captured by current buffer.
-            current_segment = lines[0]
-            for line in reversed(lines[1:]):
-                yield line
-
-        if current_segment is not None:
-            yield current_segment
+    if isinstance(file_or_path, (Path, str)):
+        file_path = Path(file_or_path)
+        with file_path.open() as fd:
+            yield from _iter_backwards(fd, buffer_size, file_size=file_path.stat().st_size)
+    else:
+        yield from _iter_backwards(file_or_path, buffer_size)

--- a/tests/utilities/test_backwards_file_reader.py
+++ b/tests/utilities/test_backwards_file_reader.py
@@ -36,7 +36,19 @@ def test_backwards_file_reader_with_path(buffer_size, random_lines):
 
 
 @pytest.mark.parametrize('buffer_size', [2**i for i in range(5, 15)])
-def test_backwards_file_reader_with_io(buffer_size, random_lines):
+def test_backwards_file_reader_with_in_memory_file(buffer_size, random_lines):
+    with tempfile.TemporaryFile(mode='r+') as tf:
+        _write_file_contents(tf, random_lines)
+        tf.flush()
+
+        iterator = iter_backwards(tf, buffer_size)
+        backwards_lines = list(iterator)
+
+    assert list(reversed(backwards_lines)) == random_lines
+
+
+@pytest.mark.parametrize('buffer_size', [2**i for i in range(5, 15)])
+def test_backwards_file_reader_with_stringio(buffer_size, random_lines):
     sio = io.StringIO()
     _write_file_contents(sio, random_lines)
 

--- a/tests/utilities/test_backwards_file_reader.py
+++ b/tests/utilities/test_backwards_file_reader.py
@@ -1,3 +1,4 @@
+import io
 import random
 import string
 import tempfile
@@ -15,16 +16,31 @@ def random_lines():
     return lines
 
 
+def _write_file_contents(file_descriptor, lines):
+    for i, line in enumerate(lines, 1):
+        # Do not write double line break in the very end
+        line_end = '\n' if i < len(lines) else ''
+        file_descriptor.write(f'{line}{line_end}')
+
+
 @pytest.mark.parametrize('buffer_size', [2**i for i in range(5, 15)])
-def test_backwards_file_reader(buffer_size, random_lines):
+def test_backwards_file_reader_with_path(buffer_size, random_lines):
     with tempfile.NamedTemporaryFile(mode='w') as tf:
-        for i, line in enumerate(random_lines, 1):
-            # Do not write double line break in the very end
-            line_end = '\n' if i < len(random_lines) else ''
-            tf.write(f'{line}{line_end}')
+        _write_file_contents(tf, random_lines)
         tf.flush()
 
         iterator = iter_backwards(tf.name, buffer_size)
         backwards_lines = list(iterator)
+
+    assert list(reversed(backwards_lines)) == random_lines
+
+
+@pytest.mark.parametrize('buffer_size', [2**i for i in range(5, 15)])
+def test_backwards_file_reader_with_io(buffer_size, random_lines):
+    sio = io.StringIO()
+    _write_file_contents(sio, random_lines)
+
+    iterator = iter_backwards(sio, buffer_size)
+    backwards_lines = list(iterator)
 
     assert list(reversed(backwards_lines)) == random_lines


### PR DESCRIPTION
In utilities package `codemagic.utilities.backwards_file_reader` there is a function `iter_backwards` that can be used to iterate over lines in file from bottom to top.
Currently it only works with files that are saved to disk and the function takes file path (as a string or `pathlib.Path` object) as an argument.

But in reality the files are not always saved to the disk, and can be stored in-memory. In such cases the path is not available and as a result `iter_backwards` function cannot be used.

Changes in this PR add support to iterate lines on file-like objects too.

**Examples of updated usage:**

- Iterate backwards over a file that is saved to disk</summary>

```python
import tempfile

from codemagic.utilities.backwards_file_reader import iter_backwards

with tempfile.NamedTemporaryFile('w') as tf:
    tf.write('one\ntwo\nthree')
    tf.flush()
    print(list(iter_backwards(tf.name)))  # prints ['three', 'two', 'one']
```

- Iterate backwards over an in-memory file</summary>

```python
import io
import tempfile

from codemagic.utilities.backwards_file_reader import iter_backwards

sio = StringIO('one\ntwo\nthree')
print(list(iter_backwards(sio)))  # prints ['three', 'two', 'one']

with tempfile.TemporaryFile('r+') as tf:
    tf.write('one\ntwo\nthree')
    tf.flush()
    print(list(iter_backwards(tf)))  # prints ['three', 'two', 'one']
```
