### PR TITLE
Improvement: Show error message if devices are not provided on development or ad-hoc profile creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Version 0.31.3
 -------------
 
-**Development**:
-- Show error message when no matching test device is found in the Apple Developer Portal when creating an Ad Hoc or development provisioning profile.
+**Bugfixes**
+- Show error message when no matching test device is found in the Apple Developer Portal when creating an Ad Hoc or development provisioning profile. [PR #256](https://github.com/codemagic-ci-cd/cli-tools/pull/256)
 
 Version 0.31.2
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.31.3
+-------------
+
+**Development**:
+- Show error message when no matching test device is found in the Apple Developer Portal when creating an Ad Hoc or development provisioning profile.
+
 Version 0.31.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.31.2"
+version = "0.31.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -57,6 +57,21 @@ class Profiles(ResourceManager[Profile]):
         """
         if profile_type.devices_not_allowed() and devices:
             raise ValueError(f'Cannot assign devices to profile with type {profile_type}')
+        elif profile_type.devices_required() and not devices:
+            if profile_type.is_tvos_profile:
+                device_type = 'tvOS'
+            elif profile_type.is_macos_profile:
+                device_type = 'macOS'
+            elif profile_type.is_ios_profile:
+                device_type = 'iOS'
+            else:
+                raise ValueError(f'Device type for profile type {profile_type} is unknown')
+
+            raise ValueError(
+                f'Cannot create profile: Apple requires that you register at least one {device_type} '
+                f'testing device on the Apple Developer Portal to create a {profile_type} profile'
+            )
+
         if devices is None:
             devices = []
         attributes = {

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -70,7 +70,7 @@ class Profiles(ResourceManager[Profile]):
             raise ValueError(
                 f'Cannot create profile: the request does not include any {device_type} testing devices '
                 f'while they are required for creating a {profile_type} profile. If the profile creation is automatic, '
-                'ensure that at least one suitable testing device is registered on the Apple Developer Portal.'
+                'ensure that at least one suitable testing device is registered on the Apple Developer Portal.',
             )
 
         if devices is None:

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -68,8 +68,9 @@ class Profiles(ResourceManager[Profile]):
                 raise ValueError(f'Device type for profile type {profile_type} is unknown')
 
             raise ValueError(
-                f'Cannot create profile: Apple requires that you register at least one {device_type} '
-                f'testing device on the Apple Developer Portal to create a {profile_type} profile',
+                f'Cannot create profile: the request does not include any {device_type} testing devices '
+                f'while they are required for creating a {profile_type} profile. If the profile creation is automatic, '
+                'ensure that at least one suitable testing device is registered on the Apple Developer Portal.'
             )
 
         if devices is None:

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -69,7 +69,7 @@ class Profiles(ResourceManager[Profile]):
 
             raise ValueError(
                 f'Cannot create profile: Apple requires that you register at least one {device_type} '
-                f'testing device on the Apple Developer Portal to create a {profile_type} profile'
+                f'testing device on the Apple Developer Portal to create a {profile_type} profile',
             )
 
         if devices is None:

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -228,7 +228,7 @@ class ProfileType(ResourceEnum):
             '"devices_allowed" is deprecated in favor of "devices_required" in version 0.31.3 '
             'and is subject for removal in future releases.'
         )
-        log.get_logger(self.__class__).warning(Colors.RED(warning))
+        log.get_logger(self.__class__).warning(Colors.YELLOW(warning))
         return self.devices_required()
 
     def devices_required(self) -> bool:

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -206,6 +206,10 @@ class ProfileType(ResourceEnum):
         return self.value.endswith('_DEVELOPMENT')
 
     @property
+    def is_ios_profile(self) -> bool:
+        return self.value.startswith('IOS_')
+
+    @property
     def is_macos_profile(self) -> bool:
         return self.value.startswith('MAC_')
 
@@ -214,9 +218,9 @@ class ProfileType(ResourceEnum):
         return self.value.startswith('TVOS_')
 
     def devices_not_allowed(self) -> bool:
-        return not self.devices_allowed()
+        return not self.devices_required()
 
-    def devices_allowed(self) -> bool:
+    def devices_required(self) -> bool:
         return self.is_development_type or self.is_ad_hoc_type
 
 

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from codemagic.cli import Colors
 from codemagic.models.enums import ResourceEnum
+from codemagic.utilities import log
 
 
 class AppStoreState(ResourceEnum):
@@ -219,6 +221,15 @@ class ProfileType(ResourceEnum):
 
     def devices_not_allowed(self) -> bool:
         return not self.devices_required()
+
+    def devices_allowed(self) -> bool:
+        warning = (
+            'Deprecation warning! Method '
+            '"devices_allowed" is deprecated in favor of "devices_required" in version 0.31.3 '
+            'and is subject for removal in future releases.'
+        )
+        log.get_logger(self.__class__).warning(Colors.RED(warning))
+        return self.devices_required()
 
     def devices_required(self) -> bool:
         return self.is_development_type or self.is_ad_hoc_type

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -682,7 +682,7 @@ class AppStoreConnect(
             devices=[],
             omit_keys=['devices'],
         )
-        if profile_type.devices_allowed():
+        if profile_type.devices_required():
             create_params['devices'] = device_resource_ids
         profile = self._create_resource(self.api_client.profiles, should_print, **create_params)
 

--- a/tests/apple/app_store_connect/provisioning/test_profiles.py
+++ b/tests/apple/app_store_connect/provisioning/test_profiles.py
@@ -56,8 +56,11 @@ def test_create_profile_failure_without_devices(profile_type, device_type, app_s
             certificates=[ResourceId('certificate_resource_id')],
             devices=None,
         )
-    expected_error_msg = f'Cannot create profile: Apple requires that you register at least one {device_type} ' \
-                         f'testing device on the Apple Developer Portal to create a {profile_type} profile'
+    expected_error_msg = (
+        f'Cannot create profile: the request does not include any {device_type} testing devices '
+        f'while they are required for creating a {profile_type} profile. If the profile creation is automatic, '
+        'ensure that at least one suitable testing device is registered on the Apple Developer Portal.'
+    )
     assert str(error_info.value) == expected_error_msg
 
 

--- a/tests/apple/app_store_connect/provisioning/test_profiles.py
+++ b/tests/apple/app_store_connect/provisioning/test_profiles.py
@@ -81,23 +81,6 @@ class ProfilesTest(ResourceManagerTestsBase):
         assert profile.attributes.name == name
         assert profile.attributes.profileType is profile_type
 
-    def test_create_fail_if_no_devices_but_devices_are_required(self):
-        name = 'test profile'
-        profile_type = ProfileType.IOS_APP_DEVELOPMENT
-        bundle_id_resource_id = ResourceId('F88J43FA9J')
-        certificate_id = ResourceId('29NU422CRF')
-        device_ids = None
-
-        with pytest.raises(ValueError) as error_info:
-            self.api_client.profiles.create(
-                name=name,
-                profile_type=profile_type,
-                bundle_id=bundle_id_resource_id,
-                certificates=[certificate_id],
-                devices=device_ids,
-            )
-        assert str(error_info.value) == 'gaga'
-
     def test_delete(self):
         profile_id = ResourceId('ZK3RZ4B465')
         self.api_client.profiles.delete(profile_id)

--- a/tests/apple/resources/enums/test_profile_type.py
+++ b/tests/apple/resources/enums/test_profile_type.py
@@ -3,7 +3,7 @@ import pytest
 from codemagic.apple.resources import ProfileType
 
 
-@pytest.mark.parametrize('profile_type, should_be_allowed', [
+@pytest.mark.parametrize('profile_type, should_be_required', [
     (ProfileType.IOS_APP_ADHOC, True),
     (ProfileType.IOS_APP_DEVELOPMENT, True),
     (ProfileType.IOS_APP_INHOUSE, False),

--- a/tests/apple/resources/enums/test_profile_type.py
+++ b/tests/apple/resources/enums/test_profile_type.py
@@ -19,5 +19,5 @@ from codemagic.apple.resources import ProfileType
     (ProfileType.TVOS_APP_INHOUSE, False),
     (ProfileType.TVOS_APP_STORE, False),
 ])
-def test_devices_allowed(profile_type, should_be_allowed):
-    assert profile_type.devices_allowed() is should_be_allowed
+def test_devices_required(profile_type, should_be_required):
+    assert profile_type.devices_required() is should_be_required


### PR DESCRIPTION
When creating development and ad hoc provisioning profiles, Apple requires the existence of suitable test devices on the Apple Developer Portal.

Previous implementations did not check whether appropriate devices were included in the API call.

This lead to `409` responses from [App Store Connect API Create Profile](https://developer.apple.com/documentation/appstoreconnectapi/create_a_profile) endpoint. For example a `POST` request to the `https://api.appstoreconnect.apple.com/v1/profiles` endpoint with the following content:
```json
{
   "data":{
      "type":"profiles",
      "attributes":{
         "name":"profile name",
         "profileType":"IOS_APP_DEVELOPMENT"
      },
      "relationships":{
         "certificates":{
            "data":[
               {
                  "id":"13CO2HS7YE",
                  "type":"certificates"
               }
            ]
         },
         "devices":{},
         "bundleId":{
            "data":{
               "type":"bundleIds",
               "id":"22JL9M6NPV"
            }
         }
      }
   }
}
```

Results in the following response:
```json
{
  "errors" : [ {
    "id" : "97c1dc61-f853-43c1-9996-36997eff095d",
    "status" : "409",
    "code" : "ENTITY_ERROR.RELATIONSHIP.REQUIRED",
    "title" : "Relationship is required but was not provided.",
    "detail" : "The relationship 'devices' is required but was not provided with this request.",
    "source" : {
      "pointer" : "data/relationships/devices"
    }
  } ]
}
```
