### PR TITLE
Bugfix: Configure code signing for iOS UI testing targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 Version 0.32.0
 -------------
 
-# TODO
-
-**Features**
-- TBD
+**Bugfixes**
+- Configure proper signing info settings for Xcode UI testing targets with action `xcode-project use-profiles` provided that suitable signing files exist.  [PR #258](https://github.com/codemagic-ci-cd/cli-tools/pull/258)
 
 Version 0.31.3
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.32.0
 -------------
 
 **Bugfixes**
-- Configure proper signing info settings for Xcode UI testing targets with action `xcode-project use-profiles` provided that suitable signing files exist.  [PR #258](https://github.com/codemagic-ci-cd/cli-tools/pull/258)
+- Configure proper signing info settings for Xcode UI testing targets with action `xcode-project use-profiles` provided that suitable signing files exist. [PR #258](https://github.com/codemagic-ci-cd/cli-tools/pull/258)
 
 Version 0.31.3
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.32.0
+-------------
+
+# TODO
+
+**Features**
+- TBD
+
 Version 0.31.3
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.31.3"
+version = "0.32.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.31.2.dev'
+__version__ = '0.32.0.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
When building iOS project for testing with `xcodebuild build-for-testing` while targeting real hardware it is required that UI testing targets are code signed. Otherwise the tests cannot be propery executed.

Without the changes in this PR `xcode-project use-profiles` did not configure code signing for Xcode build targets with product type `com.apple.product-type.bundle.ui-testing`. The modifications introduced here make sure that those targets are also assigned matching signing configuration, provided that suitable provisioning profiles exist.

**Updated actions**
- `xcode-project use-profiles`
