### PR TITLE
Docs: Replace docstrings for App Store Connect profiles provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.31.4
+-------------
+
+**Docs**
+- Replace dead docstrings for `Profiles Profiles.list_device_ids`, `Profiles.list_certificate_ids`, `Profiles.get_bundle_id_resource_id` with pointers to the resources. Reported in [issue #237](https://github.com/codemagic-ci-cd/cli-tools/issues/237). [PR #259](https://github.com/codemagic-ci-cd/cli-tools/pull/259)
+
 Version 0.31.3
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.31.3"
+version = "0.31.4"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/apple/app_store_connect/provisioning/profiles.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/profiles.py
@@ -135,7 +135,7 @@ class Profiles(ResourceManager[Profile]):
 
     def get_bundle_id_resource_id(self, profile: Union[Profile, ResourceId]) -> LinkedResourceData:
         """
-        https://developer.apple.com/documentation/appstoreconnectapi/get_the_bundle_resource_id_in_a_profile
+        https://developer.apple.com/documentation/appstoreconnectapi/profile/relationships/bundleid
         """
         url = None
         if isinstance(profile, Profile) and profile.relationships is not None:
@@ -158,7 +158,7 @@ class Profiles(ResourceManager[Profile]):
 
     def list_certificate_ids(self, profile: Union[Profile, ResourceId]) -> List[LinkedResourceData]:
         """
-        https://developer.apple.com/documentation/appstoreconnectapi/get_all_certificate_ids_in_a_profile
+        https://developer.apple.com/documentation/appstoreconnectapi/profile/relationships/certificates
         """
         url = None
         if isinstance(profile, Profile) and profile.relationships is not None:
@@ -180,7 +180,7 @@ class Profiles(ResourceManager[Profile]):
 
     def list_device_ids(self, profile: Union[Profile, ResourceId]) -> List[LinkedResourceData]:
         """
-        https://developer.apple.com/documentation/appstoreconnectapi/get_all_device_resource_ids_in_a_profile
+        https://developer.apple.com/documentation/appstoreconnectapi/profile/relationships/devices
         """
         url = None
         if isinstance(profile, Profile) and profile.relationships is not None:


### PR DESCRIPTION
The current code contains some dead links to Apple API documentation, which are being replaced in this pull request by docstrings to the resources under observation.

Docstrings are updated for the following definitions:
`Profiles.list_device_ids`
`Profiles.list_certificate_ids`
`Profiles.get_bundle_id_resource_id`

Closes [issue #237](https://github.com/codemagic-ci-cd/cli-tools/issues/237). 