### PR TITLE
Bugfix: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.32.2
+-------------
+
+This is a bugfix release to address regression from [PR #261](https://github.com/codemagic-ci-cd/cli-tools/pull/261).
+
+**Bugfix**
+- Fix setting code signing settings for unit test targets if matching host application target is not found. [PR #262](https://github.com/codemagic-ci-cd/cli-tools/pull/262)
+
 Version 0.32.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.32.1"
+version = "0.32.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.32.1.dev'
+__version__ = '0.32.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
This PR addresses a regression from PR #261 that was released with version `0.31.1`.

When suitable host application build target's configuration is not found for unit tests target, then assigning signig files using `xcode-project use-profiles` fails with an error due to a nullpointer exception in underlying Ruby script. 

This PR adds fallback handling for such cases and restores the behaviour of the action to as it was in version `0.31.0`.

**Stacktrace:**

```ruby
/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:287:in `get_build_configuration_bundle_id': undefined method `resolve_build_setting' for nil:NilClass (NoMethodError)
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:328:in `get_profile'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:365:in `set_configuration_build_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:441:in `block in set_target_build_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:440:in `each'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:440:in `set_target_build_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:448:in `block in set_xcodeproj_build_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:447:in `each'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:447:in `set_xcodeproj_build_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:135:in `set_code_signing_settings'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:507:in `main'
	from /Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/scripts/code_signing_manager.rb:512:in `<main>'
```

**Updated actions:**
- `xcode-project use-profiles`
