### PR TITLE
Feature: log project build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.32.3
+-------------
+
+**Features**:
+- `xcode-project build-ipa` command supports `--verbose` flag to output Xcode project build settings.
+
 Version 0.32.2
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Version 0.33.0
 -------------
 
 **Features**:
-- Run `xcodebuild -showBuildSettings` before `xcodebuild archive` as part of action `xcode-project build-ipa` to capture project settings. The output of build settings is hidden by default, but shown if `--verbose` flag is set. 
+- Add `xcode-project show-build-settings` action. It outputs Xcode project build setting using `xcodebuild -showBuildSettings` command.
+- Update `xcode-project build-ipa` action to run `xcodebuild -showBuildSettings` before `xcodebuild archive` to capture Xcode project build settings. The output of build settings is hidden by default, but shown if `--verbose` flag is set.
 
 Version 0.32.2
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.32.3
+Version 0.33.0
 -------------
 
 **Features**:

--- a/docs/xcode-project/README.md
+++ b/docs/xcode-project/README.md
@@ -48,5 +48,6 @@ Enable verbose logging for commands
 |[`pkg-info`](pkg-info.md)|Show information about macOS Application Package file|
 |[`test-destinations`](test-destinations.md)|List available destinations for test runs|
 |[`run-tests`](run-tests.md)|Run unit or UI tests for given Xcode project or workspace|
+|[`show-build-settings`](show-build-settings.md)|Show build settings for Xcode project|
 |[`test-summary`](test-summary.md)|Show summary of Xcode Test Result|
 |[`use-profiles`](use-profiles.md)|Set up code signing settings on specified Xcode projects         to use given provisioning profiles|

--- a/docs/xcode-project/build-ipa.md
+++ b/docs/xcode-project/build-ipa.md
@@ -13,6 +13,7 @@ xcode-project build-ipa [-h] [--log-stream STREAM] [--no-color] [--version] [-s]
     [--config CONFIGURATION_NAME]
     [--scheme SCHEME_NAME]
     [--clean]
+    [--no-show-build-settings]
     [--archive-directory ARCHIVE_DIRECTORY]
     [--archive-flags ARCHIVE_FLAGS]
     [--archive-xcargs ARCHIVE_XCARGS]
@@ -50,6 +51,10 @@ Name of the Xcode Scheme
 
 
 Whether to clean the project before building it
+##### `--no-show-build-settings`
+
+
+Do not show build settings for the project before building it. If not given, the value will be checked from the environment variable `XCODE_PROJECT_NO_SHOW_BUILD_SETTINGS`.
 ##### `--archive-directory=ARCHIVE_DIRECTORY`
 
 

--- a/docs/xcode-project/show-build-settings.md
+++ b/docs/xcode-project/show-build-settings.md
@@ -1,0 +1,63 @@
+
+show-build-settings
+===================
+
+
+**Show build settings for Xcode project**
+### Usage
+```bash
+xcode-project show-build-settings [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--project XCODE_PROJECT_PATH]
+    [--workspace XCODE_WORKSPACE_PATH]
+    [--target TARGET_NAME]
+    [--config CONFIGURATION_NAME]
+    [--scheme SCHEME_NAME]
+```
+### Optional arguments for action `show-build-settings`
+
+##### `--project=XCODE_PROJECT_PATH`
+
+
+Path to Xcode project (\*.xcodeproj)
+##### `--workspace=XCODE_WORKSPACE_PATH`
+
+
+Path to Xcode workspace (\*.xcworkspace)
+##### `--target=TARGET_NAME`
+
+
+Name of the Xcode Target
+##### `--config=CONFIGURATION_NAME`
+
+
+Name of the Xcode build configuration
+##### `--scheme=SCHEME_NAME`
+
+
+Name of the Xcode Scheme
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ xcode-project = "codemagic.tools:XcodeProject.invoke_cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-cryptography = "^37.0.0"
+cryptography = ">= 3.3, != 37.0.0"
 google-api-python-client = ">= 1.7.12"
 httplib2 = ">= 0.19.0"
 oauth2client = ">= 4.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.32.3"
+version = "0.33.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.32.2"
+version = "0.32.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ xcode-project = "codemagic.tools:XcodeProject.invoke_cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-cryptography = ">= 3.3, !37.0.0"
+cryptography = "^37.0.0"
 google-api-python-client = ">= 1.7.12"
 httplib2 = ">= 0.19.0"
 oauth2client = ">= 4.1.3"

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.32.3.dev'
+__version__ = '0.33.0.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.32.2.dev'
+__version__ = '0.32.3.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -258,22 +258,22 @@ class Xcodebuild(RunningCliAppMixin):
 
     def show_build_settings(self):
         cmd = [*self._construct_base_command(None), '-showBuildSettings']
-        error_message = f'Failed to obtain build settings {self.workspace or self.project}'
+        error_message = f'Failed to show build settings {self.workspace or self.project}'
 
         cli_app = self.get_current_cli_app()
         print_streams = cli_app.verbose if cli_app else True
 
         # avoid formatting build settings output
-        self._run_command(cmd, error_message, print_streams=print_streams, format_streams=False)
+        self._run_command(cmd, error_message, print_streams=print_streams, allow_xcpretty_formatting=False)
 
     def _run_command(self,
                      command: List[str],
                      error_message: str,
                      print_streams: bool = True,
-                     format_streams: bool = True):
+                     allow_xcpretty_formatting: bool = True):
         process = None
         cli_app = self.get_current_cli_app()
-        xcpretty = self.xcpretty if format_streams else None
+        xcpretty = self.xcpretty if allow_xcpretty_formatting else None
         try:
             if cli_app:
                 process = XcodebuildCliProcess(command, xcpretty=xcpretty, print_streams=print_streams)
@@ -281,8 +281,8 @@ class Xcodebuild(RunningCliAppMixin):
                 process.execute().raise_for_returncode(include_logs=False)
             else:
                 subprocess.check_output(command)
-        except subprocess.CalledProcessError:
-            raise IOError(error_message, process)
+        except subprocess.CalledProcessError as cpe:
+            raise IOError(error_message, process) from cpe
         finally:
             self._log_process(process)
 

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -256,12 +256,9 @@ class Xcodebuild(RunningCliAppMixin):
         error_message = f'Failed to test {self.workspace or self.project}'
         self._run_command(cmd, error_message)
 
-    def show_build_settings(self):
+    def show_build_settings(self, print_streams: bool = True):
         cmd = [*self._construct_base_command(None), '-showBuildSettings']
         error_message = f'Failed to show build settings {self.workspace or self.project}'
-
-        cli_app = self.get_current_cli_app()
-        print_streams = cli_app.verbose if cli_app else True
 
         # avoid formatting build settings output
         self._run_command(cmd, error_message, print_streams=print_streams, allow_xcpretty_formatting=False)

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -36,8 +36,7 @@ class Xcodebuild(RunningCliAppMixin):
                  target_name: Optional[str] = None,
                  configuration_name: Optional[str] = None,
                  scheme_name: Optional[str] = None,
-                 xcpretty: Optional[Xcpretty] = None,
-                 verbose: bool = False):
+                 xcpretty: Optional[Xcpretty] = None):
         self.logger = log.get_logger(self.__class__)
         self.xcpretty = xcpretty
         self.workspace = xcode_workspace.expanduser() if xcode_workspace else None
@@ -47,7 +46,6 @@ class Xcodebuild(RunningCliAppMixin):
         self.configuration = configuration_name
         self._ensure_scheme_or_target()
         self.logs_path = self._get_logs_path()
-        self.verbose = verbose
 
     def _get_logs_path(self) -> pathlib.Path:
         tmp_dir = pathlib.Path('/tmp')
@@ -261,8 +259,12 @@ class Xcodebuild(RunningCliAppMixin):
     def show_build_settings(self):
         cmd = [*self._construct_base_command(None), '-showBuildSettings']
         error_message = f'Failed to obtain build settings {self.workspace or self.project}'
+
+        cli_app = self.get_current_cli_app()
+        print_streams = cli_app.verbose if cli_app else True
+
         # avoid formatting build settings output
-        self._run_command(cmd, error_message, print_streams=self.verbose, format_streams=False)
+        self._run_command(cmd, error_message, print_streams=print_streams, format_streams=False)
 
     def _run_command(self,
                      command: List[str],

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -13,12 +13,24 @@ class CodeSigningSetupVerboseLogging(cli.TypedCliArgument[bool]):
     environment_variable_key = 'XCODE_PROJECT_CODE_SIGNING_SETUP_VERBOSE_LOGGING'
 
 
+class NoShowBuildSettings(cli.TypedCliArgument[bool]):
+    argument_type = bool
+    environment_variable_key = 'XCODE_PROJECT_NO_SHOW_BUILD_SETTINGS'
+
+
 class XcodeProjectArgument(cli.Argument):
     CLEAN = cli.ArgumentProperties(
         key='clean',
         flags=('--clean',),
         type=bool,
         description='Whether to clean the project before building it',
+        argparse_kwargs={'required': False, 'action': 'store_true'},
+    )
+    DISABLE_SHOW_BUILD_SETTINGS = cli.ArgumentProperties(
+        key='disable_show_build_settings',
+        flags=('--no-show-build-settings',),
+        type=NoShowBuildSettings,
+        description='Do not show build settings for the project before building it',
         argparse_kwargs={'required': False, 'action': 'store_true'},
     )
     JSON_OUTPUT = cli.ArgumentProperties(

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -214,6 +214,8 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         xcodebuild = self._get_xcodebuild(**locals(), verbose=self.verbose)
         clean and self._clean(xcodebuild)
 
+        xcodebuild.show_build_settings()
+
         self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
         try:
             xcarchive = xcodebuild.archive(
@@ -224,8 +226,6 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}\n'))
 
         self._update_export_options(xcarchive, export_options_plist, export_options)
-
-        xcodebuild.show_build_settings()
 
         self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))
         try:

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -211,7 +211,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         self._ensure_project_or_workspace(xcode_project_path, xcode_workspace_path)
 
         export_options = self._get_export_options_from_path(export_options_plist)
-        xcodebuild = self._get_xcodebuild(**locals(), verbose=self.verbose)
+        xcodebuild = self._get_xcodebuild(**locals())
         clean and self._clean(xcodebuild)
 
         xcodebuild.show_build_settings()
@@ -598,7 +598,6 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                         scheme_name: Optional[str] = None,
                         disable_xcpretty: bool = False,
                         xcpretty_options: str = '',
-                        verbose: bool = False,
                         **_) -> Xcodebuild:
         try:
             return Xcodebuild(
@@ -608,7 +607,6 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 target_name=target_name,
                 configuration_name=configuration_name,
                 xcpretty=Xcpretty(xcpretty_options) if not disable_xcpretty else None,
-                verbose=verbose,
             )
         except ValueError as error:
             raise XcodeProjectException(*error.args) from error

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -214,6 +214,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         xcodebuild = self._get_xcodebuild(**locals())
         clean and self._clean(xcodebuild)
 
+        self.logger.info(Colors.BLUE(f'Check {(xcodebuild.workspace or xcodebuild.xcode_project).name} build settings'))
         xcodebuild.show_build_settings()
 
         self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -171,51 +171,78 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         xcodebuild = self._get_xcodebuild(**locals())
         self._clean(xcodebuild)
 
-    @cli.action('build-ipa',
-                XcodeProjectArgument.XCODE_PROJECT_PATH,
-                XcodeProjectArgument.XCODE_WORKSPACE_PATH,
-                XcodeProjectArgument.TARGET_NAME,
-                XcodeProjectArgument.CONFIGURATION_NAME,
-                XcodeProjectArgument.SCHEME_NAME,
-                XcodeProjectArgument.CLEAN,
-                ExportIpaArgument.ARCHIVE_DIRECTORY,
-                XcodeArgument.ARCHIVE_FLAGS,
-                XcodeArgument.ARCHIVE_XCARGS,
-                ExportIpaArgument.IPA_DIRECTORY,
-                ExportIpaArgument.EXPORT_OPTIONS_PATH,
-                XcodeArgument.EXPORT_FLAGS,
-                XcodeArgument.EXPORT_XCARGS,
-                ExportIpaArgument.REMOVE_XCARCHIVE,
-                XcprettyArgument.DISABLE,
-                XcprettyArgument.OPTIONS)
-    def build_ipa(self,
-                  xcode_project_path: Optional[pathlib.Path] = None,
-                  xcode_workspace_path: Optional[pathlib.Path] = None,
-                  target_name: Optional[str] = None,
-                  configuration_name: Optional[str] = None,
-                  scheme_name: Optional[str] = None,
-                  clean: bool = False,
-                  archive_directory: pathlib.Path = ExportIpaArgument.ARCHIVE_DIRECTORY.get_default(),
-                  archive_xcargs: Optional[str] = XcodeArgument.ARCHIVE_XCARGS.get_default(),
-                  archive_flags: Optional[str] = XcodeArgument.ARCHIVE_FLAGS.get_default(),
-                  ipa_directory: pathlib.Path = ExportIpaArgument.IPA_DIRECTORY.get_default(),
-                  export_options_plist: pathlib.Path = ExportIpaArgument.EXPORT_OPTIONS_PATH.get_default(),
-                  export_xcargs: Optional[str] = XcodeArgument.EXPORT_XCARGS.get_default(),
-                  export_flags: Optional[str] = XcodeArgument.EXPORT_FLAGS.get_default(),
-                  remove_xcarchive: bool = False,
-                  disable_xcpretty: bool = False,
-                  xcpretty_options: str = XcprettyArgument.OPTIONS.get_default()) -> pathlib.Path:
+    @cli.action(
+        'show-build-settings',
+        XcodeProjectArgument.XCODE_PROJECT_PATH,
+        XcodeProjectArgument.XCODE_WORKSPACE_PATH,
+        XcodeProjectArgument.TARGET_NAME,
+        XcodeProjectArgument.CONFIGURATION_NAME,
+        XcodeProjectArgument.SCHEME_NAME,
+    )
+    def show_build_settings(
+        self,
+        xcode_project_path: Optional[pathlib.Path] = None,
+        xcode_workspace_path: Optional[pathlib.Path] = None,
+        target_name: Optional[str] = None,
+        configuration_name: Optional[str] = None,
+        scheme_name: Optional[str] = None,
+    ):
+        """
+        Show build settings for Xcode project
+        """
+        xcodebuild = self._get_xcodebuild(**locals())
+        self._show_build_settings(xcodebuild, show_output=True)
+
+    @cli.action(
+        'build-ipa',
+        XcodeProjectArgument.XCODE_PROJECT_PATH,
+        XcodeProjectArgument.XCODE_WORKSPACE_PATH,
+        XcodeProjectArgument.TARGET_NAME,
+        XcodeProjectArgument.CONFIGURATION_NAME,
+        XcodeProjectArgument.SCHEME_NAME,
+        XcodeProjectArgument.CLEAN,
+        XcodeProjectArgument.DISABLE_SHOW_BUILD_SETTINGS,
+        ExportIpaArgument.ARCHIVE_DIRECTORY,
+        XcodeArgument.ARCHIVE_FLAGS,
+        XcodeArgument.ARCHIVE_XCARGS,
+        ExportIpaArgument.IPA_DIRECTORY,
+        ExportIpaArgument.EXPORT_OPTIONS_PATH,
+        XcodeArgument.EXPORT_FLAGS,
+        XcodeArgument.EXPORT_XCARGS,
+        ExportIpaArgument.REMOVE_XCARCHIVE,
+        XcprettyArgument.DISABLE,
+        XcprettyArgument.OPTIONS,
+    )
+    def build_ipa(
+        self,
+        xcode_project_path: Optional[pathlib.Path] = None,
+        xcode_workspace_path: Optional[pathlib.Path] = None,
+        target_name: Optional[str] = None,
+        configuration_name: Optional[str] = None,
+        scheme_name: Optional[str] = None,
+        clean: bool = False,
+        disable_show_build_settings: bool = False,
+        archive_directory: pathlib.Path = ExportIpaArgument.ARCHIVE_DIRECTORY.get_default(),
+        archive_xcargs: Optional[str] = XcodeArgument.ARCHIVE_XCARGS.get_default(),
+        archive_flags: Optional[str] = XcodeArgument.ARCHIVE_FLAGS.get_default(),
+        ipa_directory: pathlib.Path = ExportIpaArgument.IPA_DIRECTORY.get_default(),
+        export_options_plist: pathlib.Path = ExportIpaArgument.EXPORT_OPTIONS_PATH.get_default(),
+        export_xcargs: Optional[str] = XcodeArgument.EXPORT_XCARGS.get_default(),
+        export_flags: Optional[str] = XcodeArgument.EXPORT_FLAGS.get_default(),
+        remove_xcarchive: bool = False,
+        disable_xcpretty: bool = False,
+        xcpretty_options: str = XcprettyArgument.OPTIONS.get_default(),
+    ) -> pathlib.Path:
         """
         Build ipa by archiving the Xcode project and then exporting it
         """
         self._ensure_project_or_workspace(xcode_project_path, xcode_workspace_path)
 
+        show_build_settings = not disable_show_build_settings
         export_options = self._get_export_options_from_path(export_options_plist)
         xcodebuild = self._get_xcodebuild(**locals())
         clean and self._clean(xcodebuild)
-
-        self.logger.info(Colors.BLUE(f'Check {(xcodebuild.workspace or xcodebuild.xcode_project).name} build settings'))
-        xcodebuild.show_build_settings()
+        show_build_settings and self._show_build_settings(xcodebuild, show_output=self.verbose)
 
         self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
         try:
@@ -487,6 +514,14 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         except IOError as error:
             raise XcodeProjectException(*error.args)
         self.logger.info(Colors.GREEN(f'Cleaned {(xcodebuild.workspace or xcodebuild.xcode_project).name}\n'))
+
+    def _show_build_settings(self, xcodebuild: Xcodebuild, *, show_output: bool = True):
+        project_name = (xcodebuild.workspace or xcodebuild.xcode_project).name
+        self.logger.info(Colors.BLUE(f'Check {project_name} build settings'))
+        try:
+            xcodebuild.show_build_settings(show_output)
+        except IOError as error:
+            raise XcodeProjectException(*error.args)
 
     def _collect_xcresults(self,
                            xcresult_patterns: Optional[Sequence[pathlib.Path]],

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -211,7 +211,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         self._ensure_project_or_workspace(xcode_project_path, xcode_workspace_path)
 
         export_options = self._get_export_options_from_path(export_options_plist)
-        xcodebuild = self._get_xcodebuild(**locals())
+        xcodebuild = self._get_xcodebuild(**locals(), verbose=self.verbose)
         clean and self._clean(xcodebuild)
 
         self.logger.info(Colors.BLUE(f'Archive {(xcodebuild.workspace or xcodebuild.xcode_project).name}'))
@@ -224,6 +224,8 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
         self.logger.info(Colors.GREEN(f'Successfully created archive at {xcarchive}\n'))
 
         self._update_export_options(xcarchive, export_options_plist, export_options)
+
+        xcodebuild.show_build_settings()
 
         self.logger.info(Colors.BLUE(f'Export {xcarchive} to {ipa_directory}'))
         try:
@@ -596,6 +598,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                         scheme_name: Optional[str] = None,
                         disable_xcpretty: bool = False,
                         xcpretty_options: str = '',
+                        verbose: bool = False,
                         **_) -> Xcodebuild:
         try:
             return Xcodebuild(
@@ -605,6 +608,7 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
                 target_name=target_name,
                 configuration_name=configuration_name,
                 xcpretty=Xcpretty(xcpretty_options) if not disable_xcpretty else None,
+                verbose=verbose,
             )
         except ValueError as error:
             raise XcodeProjectException(*error.args) from error


### PR DESCRIPTION
Run `xcodebuild -showBuildSettings` as part of `xcode-project build-ipa`. This will print out all relevant information about the project that is being built.

By default, the output is available in file CLI tools logs.

To show build settings in terminal window (or in Codemagic), use `xcode-project build-ipa` with `--verbose` flag.

*Motivation: help with debugging iOS build failures*