### PR TITLE
Release info: Action `xcode-project use-profiles` action docs changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.34.1
+-------------
+
+This release includes changes from [PR #271](https://github.com/codemagic-ci-cd/cli-tools/pull/271).
+
+**Docs**
+- Update documentation for action `xcode-project use-profiles` option `--custom-export-options`.
+
 Version 0.34.0
 -------------
 

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -32,7 +32,7 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 ##### `--custom-export-options=CUSTOM_EXPORT_OPTIONS`
 
 
-Custom options for generated export options as JSON string. For example `{"uploadBitcode": false, "uploadSymbols": false}`.
+Custom options for generated export options as JSON string. For example `'{"uploadBitcode": false, "uploadSymbols": false}'`.
 ##### `--warn-only`
 
 

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -32,7 +32,7 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 ##### `--custom-export-options=CUSTOM_EXPORT_OPTIONS`
 
 
-Custom options for generated export options as JSON string. For example `--custom-export-options='{"uploadBitcode": false, "uploadSymbols": false}'`.
+Custom options for generated export options as JSON string. For example `{"uploadBitcode": false, "uploadSymbols": false}`.
 ##### `--warn-only`
 
 

--- a/docs/xcode-project/use-profiles.md
+++ b/docs/xcode-project/use-profiles.md
@@ -32,7 +32,7 @@ Path to the generated export options plist. Default:&nbsp;`$HOME/export_options.
 ##### `--custom-export-options=CUSTOM_EXPORT_OPTIONS`
 
 
-Custom options for generated export options as JSON string. For example `{"uploadBitcode": false, "uploadSymbols": false}`.
+Custom options for generated export options as JSON string. For example `--custom-export-options='{"uploadBitcode": false, "uploadSymbols": false}'`.
 ##### `--warn-only`
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.34.0"
+version = "0.34.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.34.0.dev'
+__version__ = '0.34.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -164,7 +164,7 @@ class ExportIpaArgument(cli.Argument):
         type=cli.CommonArgumentTypes.json_dict,
         description=(
             'Custom options for generated export options as JSON string. For example '
-            f'`{Colors.WHITE("""{"uploadBitcode": false, "uploadSymbols": false}""")}`.'
+            f'`{Colors.WHITE(repr("""{"uploadBitcode": false, "uploadSymbols": false}"""))}`.'
         ),
         argparse_kwargs={'required': False},
     )


### PR DESCRIPTION
This is a follow up to PR #271 that fills in blanks that are required to prepare a release.
- update changelog,
- bump version number,
- regenerate markdown documentation.