### PR TITLE
Bugfix: Remove `assert` from `Certificate.from_p12`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.34.2
+-------------
+
+**Bugfix**:
+- Do not throw `AssertionError` from `Certificate.from_p12` in case the given PKCS#12 container does not contain a certificate. Raise a `ValueError` with appropriate error message instead.
+
 Version 0.34.1
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.34.2
 -------------
 
 **Bugfix**:
-- Do not throw `AssertionError` from `Certificate.from_p12` in case the given PKCS#12 container does not contain a certificate. Raise a `ValueError` with appropriate error message instead.
+- Do not throw `AssertionError` from `Certificate.from_p12` in case the given PKCS#12 container does not contain a certificate. Raise a `ValueError` with appropriate error message instead. [PR #274](https://github.com/codemagic-ci-cd/cli-tools/pull/274).
 
 Version 0.34.1
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.34.1"
+version = "0.34.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.34.1.dev'
+__version__ = '0.34.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -77,7 +77,8 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
     def from_p12(cls, p12: bytes, password: Optional[AnyStr] = None) -> Certificate:
         password_encoded = None if password is None else cls._bytes(password)
         _, x509_certificate, _ = pkcs12.load_key_and_certificates(p12, password_encoded)
-        assert x509_certificate is not None  # make mypy happy
+        if x509_certificate is None:
+            raise ValueError('Certificate was not found from PKCS#12 container')
         return Certificate(x509_certificate)
 
     @property


### PR DESCRIPTION
PKCS#12 containers can be valid even if they do not contain any certificate entries in them. Furthermore, `cryptography`'s built-in `pkcs12.load_key_and_certificates`, which is used by `Certificate.from_p12`, has a return type `Optional[x509.Certificate]` for the returned certificate.

The factory method however expected that the given PKCS#12 container always contains the certificate, which is a false assumption, and did a mere `assert x509_certificate is not None`. This can lead to unexpected results:
- in production mode assertions are ignored altogether and a snowball effect could arise with issues deeper down the line,
- unexpected `AssertionError` is thrown in case assertions are enabled.

To overcome this, check that the certificate acquired from the container is usable, and raise a descriptive `ValueError` otherwise. 