### PR TITLE
Bugfix: Remove mutable default usage from Keystore model declaration

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,5 +1,22 @@
-definitions:
-  steps:
+name: Checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
     - &cache
       uses: actions/cache@v1
       with:
@@ -30,41 +47,3 @@ definitions:
     - &run_tests
       name: Test with pytest
       run: poetry run pytest
-
-
-name: Checks
-
-on:
-  push:
-  pull_request:
-
-jobs:
-  test-py-3-7:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - *cache
-      - *install_dependencies
-      - *check_code_formatting
-      - *check_imports_ordering
-      - *static_type_checks
-      - *run_tests
-
-  test-py-3-11:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.11
-      - *cache
-      - *install_dependencies
-      - *check_code_formatting
-      - *check_imports_ordering
-      - *static_type_checks
-      - *run_tests

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,3 +1,37 @@
+definitions:
+  steps:
+    - &cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - &install_dependencies
+      name: Install dependencies
+      run: |
+        curl -sSL https://install.python-poetry.org | python
+        poetry config virtualenvs.in-project true
+        poetry install --no-interaction
+
+    - &check_code_formatting
+      name: Check code formatting
+      run: poetry run flake8 .
+
+    - &check_imports_ordering
+      name: Check imports sort order
+      run: poetry run isort --check-only .
+
+    - &static_type_checks
+      name: Static type checks with mypy
+      run: poetry run mypy src
+
+    - &run_tests
+      name: Test with pytest
+      run: poetry run pytest
+
+
 name: Checks
 
 on:
@@ -5,38 +39,32 @@ on:
   pull_request:
 
 jobs:
-  test:
-
+  test-py-3-7:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - *cache
+      - *install_dependencies
+      - *check_code_formatting
+      - *check_imports_ordering
+      - *static_type_checks
+      - *run_tests
 
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
-    - name: Install dependencies
-      run: |
-        curl -sSL https://install.python-poetry.org | python
-        poetry config virtualenvs.in-project true
-        poetry install --no-interaction
-
-    - name: Check code formatting
-      run: poetry run flake8 .
-
-    - name: Check imports sort order
-      run: poetry run isort --check-only .
-
-    - name: Static type checks with mypy
-      run: poetry run mypy src
-
-    - name: Test with pytest
-      run: poetry run pytest
+  test-py-3-11:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.11
+      - *cache
+      - *install_dependencies
+      - *check_code_formatting
+      - *check_imports_ordering
+      - *static_type_checks
+      - *run_tests

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
 
 jobs:
-  test:
-
+  test-py-3-7:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,33 +16,63 @@ jobs:
       with:
         python-version: 3.7
 
-    - &cache
-      uses: actions/cache@v1
+    - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - &install_dependencies
-      name: Install dependencies
+    - name: Install dependencies
       run: |
         curl -sSL https://install.python-poetry.org | python
         poetry config virtualenvs.in-project true
         poetry install --no-interaction
 
-    - &check_code_formatting
-      name: Check code formatting
+    - name: Check code formatting
       run: poetry run flake8 .
 
-    - &check_imports_ordering
-      name: Check imports sort order
+    - name: Check imports sort order
       run: poetry run isort --check-only .
 
-    - &static_type_checks
-      name: Static type checks with mypy
+    - name: Static type checks with mypy
       run: poetry run mypy src
 
-    - &run_tests
-      name: Test with pytest
+    - name: Test with pytest
+      run: poetry run pytest
+
+  test-py-3-11:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.11
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        curl -sSL https://install.python-poetry.org | python
+        poetry config virtualenvs.in-project true
+        poetry install --no-interaction
+
+    - name: Check code formatting
+      run: poetry run flake8 .
+
+    - name: Check imports sort order
+      run: poetry run isort --check-only .
+
+    - name: Static type checks with mypy
+      run: poetry run mypy src
+
+    - name: Test with pytest
       run: poetry run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.36.2
+-------------
+
+**Bugfix**
+- Remove mutable default value from `codemagic.models.Keystore` field `certificate_attributes`. [PR #284](https://github.com/codemagic-ci-cd/cli-tools/pull/284)
+
 Version 0.36.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.0"
+version = "0.36.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.1"
+version = "0.36.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.36.0.dev'
+__version__ = '0.36.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.36.1.dev'
+__version__ = '0.36.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/action_group.py
+++ b/src/codemagic/cli/action_group.py
@@ -7,5 +7,9 @@ class ActionGroupProperties(NamedTuple):
     description: str
 
 
-class ActionGroup(ActionGroupProperties, enum.Enum):
+# mypy yields a false-positive type error on enums with multiple inheritance
+# https://github.com/python/mypy/issues/9319
+
+
+class ActionGroup(ActionGroupProperties, enum.Enum):  # type: ignore
     ...

--- a/src/codemagic/cli/action_group.py
+++ b/src/codemagic/cli/action_group.py
@@ -9,7 +9,5 @@ class ActionGroupProperties(NamedTuple):
 
 # mypy yields a false-positive type error on enums with multiple inheritance
 # https://github.com/python/mypy/issues/9319
-
-
 class ActionGroup(ActionGroupProperties, enum.Enum):  # type: ignore
     ...

--- a/src/codemagic/models/keystore.py
+++ b/src/codemagic/models/keystore.py
@@ -1,5 +1,6 @@
 import pathlib
 from dataclasses import dataclass
+from dataclasses import field
 
 from .certificate_attributes import CertificateAttributes
 
@@ -10,5 +11,5 @@ class Keystore:
     key_password: str
     store_password: str
     store_path: pathlib.Path
-    certificate_attributes: CertificateAttributes = CertificateAttributes()
+    certificate_attributes: CertificateAttributes = field(default_factory=CertificateAttributes)
     validity: int = 10000  # Validity duration in days

--- a/src/codemagic/models/keystore.py
+++ b/src/codemagic/models/keystore.py
@@ -1,6 +1,5 @@
 import pathlib
 from dataclasses import dataclass
-from dataclasses import field
 
 from .certificate_attributes import CertificateAttributes
 
@@ -11,5 +10,6 @@ class Keystore:
     key_password: str
     store_password: str
     store_path: pathlib.Path
-    certificate_attributes: CertificateAttributes = field(default_factory=CertificateAttributes)
+    certificate_attributes: CertificateAttributes = CertificateAttributes()
+    # certificate_attributes: CertificateAttributes = field(default_factory=CertificateAttributes)
     validity: int = 10000  # Validity duration in days

--- a/src/codemagic/models/keystore.py
+++ b/src/codemagic/models/keystore.py
@@ -1,5 +1,6 @@
 import pathlib
 from dataclasses import dataclass
+from dataclasses import field
 
 from .certificate_attributes import CertificateAttributes
 
@@ -10,6 +11,5 @@ class Keystore:
     key_password: str
     store_password: str
     store_path: pathlib.Path
-    certificate_attributes: CertificateAttributes = CertificateAttributes()
-    # certificate_attributes: CertificateAttributes = field(default_factory=CertificateAttributes)
+    certificate_attributes: CertificateAttributes = field(default_factory=CertificateAttributes)
     validity: int = 10000  # Validity duration in days


### PR DESCRIPTION
Fixes #282.

Python 3.11 introduced a more strict check for default values of `dataclass` fields: https://docs.python.org/3/whatsnew/3.11.html#dataclasses

Since `codemagic.models.Keystore` defined field `certificate_attributes` as
```python
@dataclass
class Keystore:
    ...
    certificate_attributes: CertificateAttributes = CertificateAttributes()
```
where `CertificateAttributes` is dataclass on its own, this caused a `ValueError`.

<details>
<summary>Stacktrace</summary>
<pre>
>>> from codemagic.models import Keystore
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/site-packages/codemagic/models/__init__.py", line 12, in <module>
    from .keystore import Keystore
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/site-packages/codemagic/models/keystore.py", line 7, in <module>
    @dataclass
     ^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/dataclasses.py", line 1221, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/dataclasses.py", line 1211, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/dataclasses.py", line 959, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.11.0/lib/python3.11/dataclasses.py", line 816, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'codemagic.models.certificate_attributes.CertificateAttributes'> for field certificate_attributes is not allowed: use default_factory
</pre>
</details>