### PR TITLE
Update bundletool version to 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.36.3
+-------------
+
+**Dependencies**
+- Update [`bundletool`](https://developer.android.com/studio/command-line/bundletool) version from from [`0.15.0`](https://github.com/google/bundletool/releases/tag/0.15.0) to [`1.13.1`](https://github.com/google/bundletool/releases/tag/1.13.1). [PR #287](https://github.com/codemagic-ci-cd/cli-tools/pull/287)
+
 Version 0.36.2
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Version 0.36.3
 -------------
 
+This release updates the current version of `bundletool`, as it is outdated, and issues potentially concerning it have risen for users with newer projects. Reported in [issue #286](https://github.com/codemagic-ci-cd/cli-tools/issues/286).
+
 **Dependencies**
 - Update [`bundletool`](https://developer.android.com/studio/command-line/bundletool) version from [`0.15.0`](https://github.com/google/bundletool/releases/tag/0.15.0) to [`1.13.1`](https://github.com/google/bundletool/releases/tag/1.13.1). [PR #287](https://github.com/codemagic-ci-cd/cli-tools/pull/287)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.36.3
 -------------
 
 **Dependencies**
-- Update [`bundletool`](https://developer.android.com/studio/command-line/bundletool) version from from [`0.15.0`](https://github.com/google/bundletool/releases/tag/0.15.0) to [`1.13.1`](https://github.com/google/bundletool/releases/tag/1.13.1). [PR #287](https://github.com/codemagic-ci-cd/cli-tools/pull/287)
+- Update [`bundletool`](https://developer.android.com/studio/command-line/bundletool) version from [`0.15.0`](https://github.com/google/bundletool/releases/tag/0.15.0) to [`1.13.1`](https://github.com/google/bundletool/releases/tag/1.13.1). [PR #287](https://github.com/codemagic-ci-cd/cli-tools/pull/287)
 
 Version 0.36.2
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.2"
+version = "0.36.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Closes https://github.com/codemagic-ci-cd/cli-tools/issues/286.

The current version of [`bundletool`](https://github.com/google/bundletool) is outdated and might cause issues for users with new projects.

In this PR, the `bundletool` version is pumped from [`0.15.0`](https://github.com/google/bundletool/releases/tag/0.15.0) to [`1.13.1`](https://github.com/google/bundletool/releases/tag/1.13.1)

**QA:**
- no breaking changes observed in `bundletool` release history 
- successful builds for a basic React Native and Flutter application using a [`codemagic`](https://codemagic.io/) pipeline with an upgraded version of `cli-tools` via PyPi test environment (version update and apk extraction from bundle) were run

The following `android-app-bundle` actions work as expected in a local environment (with a basic React native android bundle):
- `android-app-bundle bundletool version`
- `android-app-bundle dump` (tested with targets `config`, `manifest`, and `resources`)
- `android-app-bundle validate`
- `android-app-bundle build-universal-apk`