### PR TITLE
CI: Update release jobs and artifact storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Version 0.36.4
 -------------
 
+This release contains changes from [PR #290](https://github.com/codemagic-ci-cd/cli-tools/pull/290).
+
 **CI**
 - Store releases only on PyPI and GitHub releases.
 - Include wheel with fixed name under GitHub release assets so that latest version could be accessed with permalink.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.36.4
+-------------
+
+**CI**
+- Store releases only on PyPI and GitHub releases.
+- Include wheel with fixed name under GitHub release assets so that latest version could be accessed with permalink.
+
 Version 0.36.3
 -------------
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -74,6 +74,7 @@ workflows:
         script: |
           set -e
           TAG_NAME=v$(poetry version --short)
+          cp dist/codemagic_cli_tools-*-py3-none-any.whl dist/codemagic_cli_tools-py3-none-any.whl
           gh release create "${TAG_NAME}" \
               --title "${TAG_NAME}" \
               --notes "Test release of ${TAG_NAME}" \
@@ -81,6 +82,7 @@ workflows:
               --draft \
               dist/codemagic*.whl \
               dist/codemagic*.tar.gz
+          rm dist/codemagic_cli_tools-py3-none-any.whl
       - name: Publish release to PyPI Test environment
         script: |
           poetry config repositories.test-pypi https://test.pypi.org/legacy/

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -37,16 +37,6 @@ definitions:
     - &build_wheels
       name: Build wheels
       script: poetry build
-    - &upload_wheel_to_gcp
-      name: Upload wheel to GCP
-      script: |
-        set -e
-        echo "${GOOGLE_CLIENT_SECRET:?}" > $HOME/google-client-secret.json
-        gcloud auth activate-service-account --key-file $HOME/google-client-secret.json
-        SRC_PATH=$(find dist -name "*.whl" | tail -n1)
-        gsutil -h "Content-Type:application/x-wheel+zip" \
-               -h "Cache-Control:no-cache,max-age=0" \
-               cp -a public-read "$SRC_PATH" "${GCP_DST_URL:?}"
 
 workflows:
   tests:
@@ -69,10 +59,7 @@ workflows:
     cache: *cache
     environment:
       groups:
-        - gcp
         - pypi-test
-      vars:
-        GCP_DST_URL: "gs://static.codemagic.io/builder/test/codemagic_cli_tools-latest-py3-none-any.whl"
     scripts:
       - *install_dependencies
       - *check_code_formatting
@@ -83,7 +70,17 @@ workflows:
         script: poetry version "$(poetry version --short).${BUILD_NUMBER:?}"
       - *update_version_in_source
       - *build_wheels
-      - *upload_wheel_to_gcp
+      - name: Make GitHub prerelease
+        script: |
+          set -e
+          TAG_NAME=v$(poetry version --short)
+          gh release create "${TAG_NAME}" \
+              --title "${TAG_NAME}" \
+              --notes "Test release of ${TAG_NAME}" \
+              --prerelease \
+              --draft \
+              dist/codemagic*.whl \
+              dist/codemagic*.tar.gz
       - name: Publish release to PyPI Test environment
         script: |
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
@@ -99,11 +96,8 @@ workflows:
     cache: *cache
     environment:
       groups:
-        - gcp
         - github
         - pypi
-      vars:
-        GCP_DST_URL: "gs://static.codemagic.io/builder/codemagic_cli_tools-latest-py3-none-any.whl"
     scripts:
       - name: Verify branch
         script: |
@@ -119,19 +113,19 @@ workflows:
       - *run_tests
       - *update_version_in_source
       - *build_wheels
-      - name: Draft GitHub release
+      - name: Make GitHub release
         script: |
           set -e
           TAG_NAME=v$(poetry version --short)
           previous_version_line=$(grep -n "^Version " CHANGELOG.md | head -2 | tail -1 | cut -f1 -d:)
           head -n "$(($previous_version_line - 1))" CHANGELOG.md | tail +3 > release_notes.md
+          cp dist/codemagic_cli_tools-*-py3-none-any.whl dist/codemagic_cli_tools-py3-none-any.whl
           gh release create "${TAG_NAME}" \
               --title "${TAG_NAME}" \
               --notes-file release_notes.md \
-              --draft \
               dist/codemagic*.whl \
               dist/codemagic*.tar.gz
-      - *upload_wheel_to_gcp
+          rm dist/codemagic_cli_tools-py3-none-any.whl
       - name: Publish release to PyPI
         script: poetry publish --username "__token__" --password "${PYPI_TOKEN:?}"
     artifacts: *artifacts

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -59,6 +59,7 @@ workflows:
     cache: *cache
     environment:
       groups:
+        - github
         - pypi-test
     scripts:
       - *install_dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.3"
+version = "0.36.4"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.36.2.dev'
+__version__ = '0.36.4.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
While GitHub provides static links to assets on latest releases, it would be difficult to use them for this repo since Python wheels as they include version in the filename by default.

To overcome that limitation upload a copy of the wheel with fixed name too.