### PR TITLE
Bugfix: Python 3.11.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.36.5
+-------------
+
+**Bugfix**
+- Support Python 3.11.1 [PR #295](https://github.com/codemagic-ci-cd/cli-tools/pull/295).
+
 Version 0.36.4
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.4"
+version = "0.36.5"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.36.4.dev'
+__version__ = '0.36.5.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/cli/argument/argument.py
+++ b/src/codemagic/cli/argument/argument.py
@@ -38,7 +38,10 @@ class Argument(ArgumentProperties, enum.Enum):
         for argument in arguments:
             if argument in exclude:
                 continue
-            updated_properties = argument.duplicate(argument_group_name=argument_group_name)
+            updated_properties = cls.duplicate(
+                argument,
+                argument_group_name=argument_group_name,
+            )
             argument_class: Type[Argument] = Argument(  # type: ignore
                 argument.__class__.__name__,
                 {argument.name: updated_properties},  # type: ignore
@@ -50,9 +53,11 @@ class Argument(ArgumentProperties, enum.Enum):
             yield new_argument
 
     @classmethod
-    def resolve_optional_two_way_switch(cls,
-                                        is_switched_on: Optional[bool],
-                                        is_switched_off: Optional[bool]) -> Optional[bool]:
+    def resolve_optional_two_way_switch(
+        cls,
+        is_switched_on: Optional[bool],
+        is_switched_off: Optional[bool],
+    ) -> Optional[bool]:
         if {is_switched_on, is_switched_off} in ({True}, {False}):
             raise ValueError('Neither of the switches, or exactly one can be truthy at the time')
         if is_switched_on is True:

--- a/src/codemagic/cli/argument/argument_properties.py
+++ b/src/codemagic/cli/argument/argument_properties.py
@@ -20,7 +20,13 @@ class ArgumentProperties(NamedTuple):
     argparse_kwargs: Optional[Dict[str, Any]] = None
     argument_group_name: Optional[str] = None
 
-    def duplicate(self, **overwrites) -> ArgumentProperties:
+    @classmethod
+    def duplicate(cls, template: Union[Tuple, ArgumentProperties], **overwrites) -> ArgumentProperties:
+        if not isinstance(template, ArgumentProperties):
+            template = cls(*template)
+        return template._duplicate(**overwrites)
+
+    def _duplicate(self, **overwrites) -> ArgumentProperties:
         kwargs = {}
         for field in self._fields:
             if field in overwrites:
@@ -29,6 +35,14 @@ class ArgumentProperties(NamedTuple):
                 kwargs[field] = copy.deepcopy(getattr(self, field))
 
         return ArgumentProperties(**kwargs)
+
+    @classmethod
+    def get_flag(cls, argument_properties: Union[Tuple, ArgumentProperties], flag_index: int = 0) -> str:
+        if isinstance(argument_properties, ArgumentProperties):
+            flags = argument_properties.flags
+        else:
+            flags = argument_properties[3]
+        return flags[flag_index]
 
     def _get_parser_argument(self):
         return getattr(self, '__parser_argument')

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -562,7 +562,8 @@ class AppStoreVersionArgument(cli.Argument):
             'default': Platform.IOS,
         },
     )
-    PLATFORM_OPTIONAL = PLATFORM.duplicate(
+    PLATFORM_OPTIONAL = cli.ArgumentProperties.duplicate(
+        PLATFORM,
         argparse_kwargs={
             'required': False,
             'choices': list(Platform),
@@ -645,7 +646,8 @@ class AppStoreVersionLocalizationArgument(cli.Argument):
             'choices': list(Locale),
         },
     )
-    LOCALE_DEFAULT = LOCALE.duplicate(
+    LOCALE_DEFAULT = cli.ArgumentProperties.duplicate(
+        LOCALE,
         flags=('--locale', '-l'),
         description=(
             'The locale code name for App Store metadata in different languages. '
@@ -921,7 +923,7 @@ class PublishArgument(cli.Argument):
             'For how long (in seconds) should the tool wait between the retries of package validation or '
             'upload action retries in case they failed due to a known `altool` issues '
             '(authentication failure or request timeout). '
-            f'See also {ALTOOL_RETRIES_COUNT.flags[0]} for more configuration options.'
+            f'See also {cli.ArgumentProperties.get_flag(ALTOOL_RETRIES_COUNT)} for more configuration options.'
         ),
         argparse_kwargs={
             'required': False,
@@ -1015,7 +1017,8 @@ class BuildArgument(cli.Argument):
             'choices': list(Locale),
         },
     )
-    LOCALE_DEFAULT = LOCALE_OPTIONAL.duplicate(
+    LOCALE_DEFAULT = cli.ArgumentProperties.duplicate(
+        LOCALE_OPTIONAL,
         description=(
             'The locale code name for displaying localized "What\'s new" content in TestFlight. '
             "In case not provided, application's primary locale from test information is used instead. "
@@ -1041,7 +1044,7 @@ class BuildArgument(cli.Argument):
         description=(
             "Localized beta test info for what's new in the uploaded build as a JSON encoded list. "
             f'For example, "{Colors.WHITE(Types.BetaBuildLocalizations.example_value)}". '
-            f'See "{Colors.WHITE(LOCALE_OPTIONAL.flags[0])}" for possible locale options.'
+            f'See "{Colors.WHITE(cli.ArgumentProperties.get_flag(LOCALE_OPTIONAL))}" for possible locale options.'
         ),
         argparse_kwargs={
             'required': False,
@@ -1058,7 +1061,8 @@ class BuildArgument(cli.Argument):
             'required': True,
         },
     )
-    BETA_GROUP_NAMES_OPTIONAL = BETA_GROUP_NAMES_REQUIRED.duplicate(
+    BETA_GROUP_NAMES_OPTIONAL = cli.ArgumentProperties.duplicate(
+        BETA_GROUP_NAMES_REQUIRED,
         argparse_kwargs={
             'nargs': '+',
             'metavar': 'beta-group',
@@ -1155,7 +1159,8 @@ class DeviceArgument(cli.Argument):
         description='Name of the Device',
         argparse_kwargs={'required': True},
     )
-    DEVICE_NAME_OPTIONAL = DEVICE_NAME.duplicate(
+    DEVICE_NAME_OPTIONAL = cli.ArgumentProperties.duplicate(
+        DEVICE_NAME,
         argparse_kwargs={'required': False},
     )
     DEVICE_UDID = cli.ArgumentProperties(

--- a/src/codemagic/tools/android_app_bundle.py
+++ b/src/codemagic/tools/android_app_bundle.py
@@ -62,7 +62,10 @@ class AndroidAppBundleArgument(cli.Argument):
             'required': False,
         },
     )
-    KEYSTORE_PATH_REQUIRED = KEYSTORE_PATH.duplicate(argparse_kwargs={'required': True})
+    KEYSTORE_PATH_REQUIRED = cli.ArgumentProperties.duplicate(
+        KEYSTORE_PATH,
+        argparse_kwargs={'required': True},
+    )
     KEYSTORE_PASSWORD = cli.ArgumentProperties(
         flags=('--ks-pass',),
         key='keystore_password',
@@ -73,7 +76,10 @@ class AndroidAppBundleArgument(cli.Argument):
             'required': False,
         },
     )
-    KEYSTORE_PASSWORD_REQUIRED = KEYSTORE_PASSWORD.duplicate(argparse_kwargs={'required': True})
+    KEYSTORE_PASSWORD_REQUIRED = cli.ArgumentProperties.duplicate(
+        KEYSTORE_PASSWORD,
+        argparse_kwargs={'required': True},
+    )
     KEY_ALIAS = cli.ArgumentProperties(
         flags=('--ks-key-alias',),
         key='key_alias',
@@ -84,7 +90,10 @@ class AndroidAppBundleArgument(cli.Argument):
             'required': False,
         },
     )
-    KEY_ALIAS_REQUIRED = KEY_ALIAS.duplicate(argparse_kwargs={'required': True})
+    KEY_ALIAS_REQUIRED = cli.ArgumentProperties.duplicate(
+        KEY_ALIAS,
+        argparse_kwargs={'required': True},
+    )
     KEY_PASSWORD = cli.ArgumentProperties(
         flags=('--key-pass',),
         key='key_password',
@@ -95,7 +104,10 @@ class AndroidAppBundleArgument(cli.Argument):
             'required': False,
         },
     )
-    KEY_PASSWORD_REQUIRED = KEY_PASSWORD.duplicate(argparse_kwargs={'required': True})
+    KEY_PASSWORD_REQUIRED = cli.ArgumentProperties.duplicate(
+        KEY_PASSWORD,
+        argparse_kwargs={'required': True},
+    )
     BUILD_APKS_MODE = cli.ArgumentProperties(
         flags=('--mode',),
         key='mode',
@@ -189,7 +201,8 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             keystore_path: pathlib.Path,
             keystore_password: KeystorePassword,
             key_alias: KeyAlias,
-            key_password: KeyPassword) -> AndroidSigningInfo:
+            key_password: KeyPassword,
+    ) -> AndroidSigningInfo:
         ...
 
     @classmethod
@@ -199,7 +212,8 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             keystore_path: Optional[pathlib.Path],
             keystore_password: Optional[KeystorePassword],
             key_alias: Optional[KeyAlias],
-            key_password: Optional[KeyPassword]) -> Optional[AndroidSigningInfo]:
+            key_password: Optional[KeyPassword],
+    ) -> Optional[AndroidSigningInfo]:
         ...
 
     @classmethod
@@ -208,7 +222,8 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             keystore_path: Optional[pathlib.Path],
             keystore_password: Optional[KeystorePassword],
             key_alias: Optional[KeyAlias],
-            key_password: Optional[KeyPassword]) -> Optional[AndroidSigningInfo]:
+            key_password: Optional[KeyPassword],
+    ) -> Optional[AndroidSigningInfo]:
         keystore_password_value = cls._get_password_value(keystore_password)
         key_password_value = cls._get_password_value(key_password)
         if keystore_path and keystore_password_value and key_alias and key_password_value:
@@ -216,7 +231,8 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
                 store_path=keystore_path,
                 store_pass=keystore_password_value,
                 key_alias=str(key_alias),
-                key_pass=key_password_value)
+                key_pass=key_password_value,
+            )
         elif keystore_path or keystore_password_value or key_alias or key_password_value:
             error_msg = 'Either all signing info arguments should be specified, or none of them should'
             raise AndroidAppBundleArgument.KEYSTORE_PATH.raise_argument_error(error_msg)
@@ -238,13 +254,15 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
 
         return aab_paths
 
-    @cli.action('build-apks',
-                AndroidAppBundleArgument.BUNDLE_PATTERN,
-                AndroidAppBundleArgument.KEYSTORE_PATH,
-                AndroidAppBundleArgument.KEYSTORE_PASSWORD,
-                AndroidAppBundleArgument.KEY_ALIAS,
-                AndroidAppBundleArgument.KEY_PASSWORD,
-                AndroidAppBundleArgument.BUILD_APKS_MODE)
+    @cli.action(
+        'build-apks',
+        AndroidAppBundleArgument.BUNDLE_PATTERN,
+        AndroidAppBundleArgument.KEYSTORE_PATH,
+        AndroidAppBundleArgument.KEYSTORE_PASSWORD,
+        AndroidAppBundleArgument.KEY_ALIAS,
+        AndroidAppBundleArgument.KEY_PASSWORD,
+        AndroidAppBundleArgument.BUILD_APKS_MODE,
+    )
     def build_apks(
             self,
             aab_pattern: pathlib.Path,
@@ -253,14 +271,16 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             key_alias: Optional[KeyAlias] = None,
             key_password: Optional[KeyPassword] = None,
             mode: Optional[str] = None,
-            should_print: bool = True) -> List[pathlib.Path]:
+            should_print: bool = True,
+    ) -> List[pathlib.Path]:
         """
         Generates an APK Set archive containing either all possible split APKs and
         standalone APKs or APKs optimized for the connected device (see connected-
         device flag). Returns list of generated APK set archives
         """
         signing_info = self._convert_cli_args_to_signing_info(
-            keystore_path, keystore_password, key_alias, key_password)
+            keystore_path, keystore_password, key_alias, key_password,
+        )
 
         apks_paths = []
         for aab_path in self._get_aab_paths_from_pattern(aab_pattern):
@@ -270,19 +290,22 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
                 self.echo(str(apks_path))
         return apks_paths
 
-    @cli.action('build-universal-apk',
-                AndroidAppBundleArgument.BUNDLE_PATTERN,
-                AndroidAppBundleArgument.KEYSTORE_PATH,
-                AndroidAppBundleArgument.KEYSTORE_PASSWORD,
-                AndroidAppBundleArgument.KEY_ALIAS,
-                AndroidAppBundleArgument.KEY_PASSWORD)
+    @cli.action(
+        'build-universal-apk',
+        AndroidAppBundleArgument.BUNDLE_PATTERN,
+        AndroidAppBundleArgument.KEYSTORE_PATH,
+        AndroidAppBundleArgument.KEYSTORE_PASSWORD,
+        AndroidAppBundleArgument.KEY_ALIAS,
+        AndroidAppBundleArgument.KEY_PASSWORD,
+    )
     def build_universal_apks(
             self,
             aab_pattern: pathlib.Path,
             keystore_path: Optional[pathlib.Path] = None,
             keystore_password: Optional[KeystorePassword] = None,
             key_alias: Optional[KeyAlias] = None,
-            key_password: Optional[KeyPassword] = None) -> List[pathlib.Path]:
+            key_password: Optional[KeyPassword] = None,
+    ) -> List[pathlib.Path]:
         """
         Shortcut for `build-apks` to build universal APKs from bundles
         """
@@ -306,10 +329,12 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
 
         return apk_paths
 
-    @cli.action('dump',
-                AndroidAppBundleArgument.DUMP_TARGET,
-                AndroidAppBundleArgument.BUNDLE_PATH,
-                AndroidAppBundleArgument.DUMP_XPATH)
+    @cli.action(
+        'dump',
+        AndroidAppBundleArgument.DUMP_TARGET,
+        AndroidAppBundleArgument.BUNDLE_PATH,
+        AndroidAppBundleArgument.DUMP_XPATH,
+    )
     def dump(self, target: str, aab_path: pathlib.Path, xpath: Optional[str] = None) -> str:
         """
         Get files list or extract values from the bundle in a human-readable form
@@ -331,24 +356,29 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
             raise AndroidAppBundleError(f'Unable to dump {target} for bundle {aab_path}', process)
         return process.stdout
 
-    @cli.action('sign',
-                AndroidAppBundleArgument.BUNDLE_PATH,
-                AndroidAppBundleArgument.KEYSTORE_PATH_REQUIRED,
-                AndroidAppBundleArgument.KEYSTORE_PASSWORD_REQUIRED,
-                AndroidAppBundleArgument.KEY_ALIAS_REQUIRED,
-                AndroidAppBundleArgument.KEY_PASSWORD_REQUIRED)
-    def sign(self,
-             aab_path: pathlib.Path,
-             keystore_path: pathlib.Path,
-             keystore_password: KeystorePassword,
-             key_alias: KeyAlias,
-             key_password: KeyPassword):
+    @cli.action(
+        'sign',
+        AndroidAppBundleArgument.BUNDLE_PATH,
+        AndroidAppBundleArgument.KEYSTORE_PATH_REQUIRED,
+        AndroidAppBundleArgument.KEYSTORE_PASSWORD_REQUIRED,
+        AndroidAppBundleArgument.KEY_ALIAS_REQUIRED,
+        AndroidAppBundleArgument.KEY_PASSWORD_REQUIRED,
+    )
+    def sign(
+        self,
+        aab_path: pathlib.Path,
+        keystore_path: pathlib.Path,
+        keystore_password: KeystorePassword,
+        key_alias: KeyAlias,
+        key_password: KeyPassword,
+    ):
         """
         Sign Android app bundle with specified key and keystore
         """
         self._ensure_jarsigner()
         signing_info = self._convert_cli_args_to_signing_info(
-            keystore_path, keystore_password, key_alias, key_password)
+            keystore_path, keystore_password, key_alias, key_password,
+        )
 
         self.logger.info(f'Sign {aab_path}')
         command = [
@@ -402,11 +432,13 @@ class AndroidAppBundle(cli.CliApp, PathFinderMixin):
         self.echo(version)
         return version
 
-    def _build_apk_set_archive(self,
-                               aab_path: pathlib.Path,
-                               *,
-                               signing_info: Optional[AndroidSigningInfo] = None,
-                               mode: Optional[str] = None) -> pathlib.Path:
+    def _build_apk_set_archive(
+        self,
+        aab_path: pathlib.Path,
+        *,
+        signing_info: Optional[AndroidSigningInfo] = None,
+        mode: Optional[str] = None,
+    ) -> pathlib.Path:
         self.logger.info(f'Generating APKs from bundle {aab_path}')
         apks_path = aab_path.parent / f'{aab_path.stem}.apks'
         command = [

--- a/src/codemagic/tools/android_keystore/arguments.py
+++ b/src/codemagic/tools/android_keystore/arguments.py
@@ -26,7 +26,10 @@ class AndroidKeystoreArgument(cli.Argument):
         flags=('-a', '--ks-key-alias', '--alias'),
         description='An identifying name for your keystore key',
     )
-    KEY_ALIAS = KEY_ALIAS_OPTIONAL.duplicate(argparse_kwargs={'required': True})
+    KEY_ALIAS = cli.ArgumentProperties.duplicate(
+        KEY_ALIAS_OPTIONAL,
+        argparse_kwargs={'required': True},
+    )
     KEY_PASSWORD = cli.ArgumentProperties(
         key='key_password',
         flags=('-l', '--ks-key-pass', '--key-pass'),


### PR DESCRIPTION
Fixes #293.

The way how Python treats `NamedTuple`s in version 3.11.1 is slightly different to how it used to be before (including in 3.11.0).

Consider this snippet for example:

```python
# named_tuple_valued_enums.py

import enum
import typing


class NT(typing.NamedTuple):
    s: str
    i: int


class E(NT, enum.Enum):
    A = NT(s='a', i=1)
    B = NT(s='b', i=A.i)


if __name__ == '__main__':
    assert type(E.A.value) == NT
```

In Python versions <= 3.11.0 one could access the fields of already defined enumerations. In the example above `B` is essentially defined as `NT(s='b', i=1)`, but the value for `i` is taken from `A.i`, which is defined right above. However in Python 3.11.1 the type of `A` at that point is not `NT` as it used to be, but is plain `tuple` now. 

Consequently the snippet above runs fine with Python <= 3.11.0, but fail with the following `AttributeError` on Python 3.11.1:

```python
Traceback (most recent call last):
  File "/private/tmp/named_tuple_valued_enums.py", line 10, in <module>
    class E(NT, enum.Enum):
  File "/private/tmp/named_tuple_valued_enums.py", line 12, in E
    B = NT(s='b', i=A.i)
                    ^^^
AttributeError: 'tuple' object has no attribute 'i'
```

As CLI arguments are implemented as enumerations, and some of them are defined using other previously defined arguments, then this makes the package unusable on Python 3.11.1.