### PR TITLE
Bugfix: App Store and Testflight latest build numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 0.36.6
+-------------
+
+This is a bugfix release including changes from [PR #300](https://github.com/codemagic-ci-cd/cli-tools/pull/300).
+
+- Fixes the actions that detect the latest build number from App Store Connect for App Store or Pre Release (TestFlight) versions:
+  - `app-store-connect get-latest-testflight-build-number`,
+  - `app-store-connect get-latest-app-store-build-number` and
+  - `app-store-connect get-latest-build-number`.
+
 Version 0.36.5
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.36.5"
+version = "0.36.6"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.36.5.dev'
+__version__ = '0.36.6.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -266,9 +266,8 @@ class AppStoreConnect(
         )
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
-    @classmethod
     def _get_latest_build_number(
-        cls,
+        self,
         versions_and_builds: Iterable[Tuple[Union[PreReleaseVersion, AppStoreVersion], Build]],
     ) -> Optional[str]:
         def comparator(
@@ -283,12 +282,19 @@ class AppStoreConnect(
             return version_name, LooseVersion(build.attributes.version)
 
         try:
-            _version, most_recent_build = max(versions_and_builds, key=comparator)
+            version, most_recent_build = max(versions_and_builds, key=comparator)
         except ValueError:  # Cannot find maximum from empy sequence
             return None
 
-        cls.echo(most_recent_build.attributes.version)
-        return most_recent_build.attributes.version
+        build_number = most_recent_build.attributes.version
+        if isinstance(version, AppStoreVersion):
+            container_version = f'App Store version {version.attributes.versionString}'
+        else:
+            container_version = f'TestFlight version {version.attributes.version}'
+        self.logger.info(f'Found build number {build_number} from {container_version}')
+
+        self.echo(build_number)
+        return build_number
 
     @cli.action(
         'get-latest-build-number',

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -316,10 +316,10 @@ class AppStoreConnect(
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
 
-        versions_and_builds: List[Tuple[Union[PreReleaseVersion, AppStoreVersion], Build]] = [
-            *zip(testflight_versions, testflight_builds),
-            *zip(app_store_versions, app_store_builds),
-        ]
+        versions_and_builds: Iterable[Tuple[Union[PreReleaseVersion, AppStoreVersion], Build]] = chain(
+            zip(testflight_versions, testflight_builds),
+            zip(app_store_versions, app_store_builds),
+        )
         return self._get_latest_build_number(versions_and_builds)
 
     @cli.action(

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -10,6 +10,7 @@ import time
 from distutils.version import LooseVersion
 from functools import lru_cache
 from itertools import chain
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -23,6 +24,7 @@ from codemagic.apple import AppStoreConnectApiError
 from codemagic.apple.app_store_connect import AppStoreConnectApiClient
 from codemagic.apple.app_store_connect import IssuerId
 from codemagic.apple.app_store_connect import KeyIdentifier
+from codemagic.apple.resources import AppStoreVersion
 from codemagic.apple.resources import Build
 from codemagic.apple.resources import BuildProcessingState
 from codemagic.apple.resources import BundleId
@@ -31,6 +33,7 @@ from codemagic.apple.resources import CertificateType
 from codemagic.apple.resources import Device
 from codemagic.apple.resources import DeviceStatus
 from codemagic.apple.resources import Platform
+from codemagic.apple.resources import PreReleaseVersion
 from codemagic.apple.resources import Profile
 from codemagic.apple.resources import ProfileState
 from codemagic.apple.resources import ProfileType
@@ -264,13 +267,28 @@ class AppStoreConnect(
         return self._list_resources(builds_filter, self.api_client.builds, should_print)
 
     @classmethod
-    def _get_latest_build_number(cls, builds: List[Build]) -> Optional[str]:
-        if not builds:
+    def _get_latest_build_number(
+        cls,
+        versions_and_builds: Iterable[Tuple[Union[PreReleaseVersion, AppStoreVersion], Build]],
+    ) -> Optional[str]:
+        def comparator(
+            version_and_build: Tuple[Union[PreReleaseVersion, AppStoreVersion], Build],
+        ) -> Tuple[LooseVersion, LooseVersion]:
+            version, build = version_and_build
+            if isinstance(version, AppStoreVersion):
+                version_name = LooseVersion(version.attributes.versionString)
+            else:
+                version_name = LooseVersion(version.attributes.version)
+
+            return version_name, LooseVersion(build.attributes.version)
+
+        try:
+            _version, most_recent_build = max(versions_and_builds, key=comparator)
+        except ValueError:  # Cannot find maximum from empy sequence
             return None
-        most_recent_build = max(builds, key=lambda b: LooseVersion(b.attributes.version))
-        version = most_recent_build.attributes.version
-        cls.echo(version)
-        return version
+
+        cls.echo(most_recent_build.attributes.version)
+        return most_recent_build.attributes.version
 
     @cli.action(
         'get-latest-build-number',
@@ -286,11 +304,11 @@ class AppStoreConnect(
         Get the highest build number used for the given app considering both TestFlight and App Store submissions
         """
         try:
-            _testflight_versions, testflight_builds = self.api_client.pre_release_versions.list_with_include(
+            testflight_versions, testflight_builds = self.api_client.pre_release_versions.list_with_include(
                 Build,
                 resource_filter=self.api_client.pre_release_versions.Filter(app=application_id, platform=platform),
             )
-            _app_store_versions, app_store_builds = self.api_client.app_store_versions.list_with_include(
+            app_store_versions, app_store_builds = self.api_client.app_store_versions.list_with_include(
                 application_id,
                 Build,
                 resource_filter=self.api_client.app_store_versions.Filter(platform=platform),
@@ -298,7 +316,11 @@ class AppStoreConnect(
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
 
-        return self._get_latest_build_number([*testflight_builds, *app_store_builds])
+        versions_and_builds: List[Tuple[Union[PreReleaseVersion, AppStoreVersion], Build]] = [
+            *zip(testflight_versions, testflight_builds),
+            *zip(app_store_versions, app_store_builds),
+        ]
+        return self._get_latest_build_number(versions_and_builds)
 
     @cli.action(
         'get-latest-app-store-build-number',
@@ -319,14 +341,14 @@ class AppStoreConnect(
         versions_client = self.api_client.app_store_versions
         versions_filter = versions_client.Filter(version_string=version_string, platform=platform)
         try:
-            _versions, builds = versions_client.list_with_include(
+            versions, builds = versions_client.list_with_include(
                 application_id, Build, resource_filter=versions_filter,
             )
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
         self.printer.log_found(Build, builds, versions_filter)
         self.printer.print_resources(builds, should_print)
-        return self._get_latest_build_number(builds)
+        return self._get_latest_build_number(zip(versions, builds))
 
     @cli.action(
         'get-latest-testflight-build-number',
@@ -347,12 +369,12 @@ class AppStoreConnect(
         versions_client = self.api_client.pre_release_versions
         versions_filter = versions_client.Filter(app=application_id, platform=platform, version=pre_release_version)
         try:
-            _versions, builds = versions_client.list_with_include(Build, resource_filter=versions_filter)
+            versions, builds = versions_client.list_with_include(Build, resource_filter=versions_filter)
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
         self.printer.log_found(Build, builds, versions_filter)
         self.printer.print_resources(builds, should_print)
-        return self._get_latest_build_number(builds)
+        return self._get_latest_build_number(zip(versions, builds))
 
     @cli.action(
         'list-devices',

--- a/tests/tools/app_store_connect/test_get_latest_build_number.py
+++ b/tests/tools/app_store_connect/test_get_latest_build_number.py
@@ -1,38 +1,58 @@
 import dataclasses
 import uuid
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
 from unittest import mock
 
 import pytest
 
 from codemagic.apple.resources import Build
+from codemagic.apple.resources import PreReleaseVersion
+from codemagic.apple.resources import Resource
 from codemagic.apple.resources import ResourceType
 from codemagic.tools.app_store_connect import AppStoreConnect
+
+R = TypeVar('R', bound=Resource)
 
 
 def _mock_echo(*_args, **_kwargs):
     pass
 
 
-def _get_build(version) -> Build:
-    attributes = {f.name: None for f in dataclasses.fields(Build.Attributes)}
-    attributes['version'] = version
-    return Build({
-        'attributes': attributes,
+def _get_resource(version: str, resource_type: ResourceType, resource_class: Type[R]) -> R:
+    return resource_class({
+        'attributes': {
+            **{f.name: None for f in dataclasses.fields(resource_class.Attributes)},
+            'version': version,
+        },
         'id': str(uuid.uuid4()),
         'links': {'self': None},
-        'type': ResourceType.BUILDS.value,
+        'type': resource_type.value,
     })
 
 
-@pytest.mark.parametrize('versions, expected_latest_build_number', [
-    ([], None),
-    (['1.0.1', '2', '0.1'], '2'),
-    (['2.0', '2'], '2.0'),
-    (['11', '13', '14', '15', '12'], '15'),
-    (['13.0.1.2.3.4.5'], '13.0.1.2.3.4.5'),
-])
+def _get_version_and_build(versions: Tuple[str, str]) -> Tuple[PreReleaseVersion, Build]:
+    version_name, build_number = versions
+
+    pre_release_version = _get_resource(version_name, ResourceType.PRE_RELEASE_VERSIONS, PreReleaseVersion)
+    build = _get_resource(build_number, ResourceType.BUILDS, Build)
+    return pre_release_version, build
+
+
+@pytest.mark.parametrize(
+    'version_pairs, expected_latest_build_number', [
+        (iter([]), None),
+        ([('1.0', '12345')], '12345'),
+        ([('1.2.3', '1.0.1'), ('1.2.3', '2'), ('1.2.3', '0.1')], '2'),
+        ([('1.2.3', '2.0'), ('1.2.3', '2')], '2.0'),
+        ([('1.0', '11'), ('1.0', '13'), ('1.0', '14'), ('1.0', '15'), ('1.0', '12')], '15'),
+        ([('3.0', '13.0.1.2.3.4.5')], '13.0.1.2.3.4.5'),
+        ([('3.0.9', '1'), ('3.0.9', '2'), ('3.0.8', '3')], '2'),
+    ],
+)
 @mock.patch.object(AppStoreConnect, 'echo', _mock_echo)
-def test_get_latest_build_number(versions, expected_latest_build_number):
-    builds = list(map(_get_build, versions))
-    latest_build_number = AppStoreConnect._get_latest_build_number(builds)
+def test_get_latest_build_number(version_pairs, expected_latest_build_number):
+    versions_and_builds = map(_get_version_and_build, version_pairs)
+    latest_build_number = AppStoreConnect._get_latest_build_number(versions_and_builds)
     assert latest_build_number == expected_latest_build_number

--- a/tests/tools/app_store_connect/test_get_latest_build_number.py
+++ b/tests/tools/app_store_connect/test_get_latest_build_number.py
@@ -16,8 +16,11 @@ from codemagic.tools.app_store_connect import AppStoreConnect
 R = TypeVar('R', bound=Resource)
 
 
-def _mock_echo(*_args, **_kwargs):
-    pass
+@pytest.fixture
+@mock.patch.object(AppStoreConnect, 'echo', lambda *_: None)
+@mock.patch.object(AppStoreConnect, '_get_api_client', lambda _: None)
+def app_store_connect() -> AppStoreConnect:
+    return AppStoreConnect(None, None, None)
 
 
 def _get_resource(version: str, resource_type: ResourceType, resource_class: Type[R]) -> R:
@@ -51,8 +54,7 @@ def _get_version_and_build(versions: Tuple[str, str]) -> Tuple[PreReleaseVersion
         ([('3.0.9', '1'), ('3.0.9', '2'), ('3.0.8', '3')], '2'),
     ],
 )
-@mock.patch.object(AppStoreConnect, 'echo', _mock_echo)
-def test_get_latest_build_number(version_pairs, expected_latest_build_number):
+def test_get_latest_build_number(version_pairs, expected_latest_build_number, app_store_connect):
     versions_and_builds = map(_get_version_and_build, version_pairs)
-    latest_build_number = AppStoreConnect._get_latest_build_number(versions_and_builds)
+    latest_build_number = app_store_connect._get_latest_build_number(versions_and_builds)
     assert latest_build_number == expected_latest_build_number


### PR DESCRIPTION
Changes in this pull request fix the actions that detect the latest build number from App Store Connect for App Store or Pre Release (TestFlight) versions:
- `app-store-connect get-latest-testflight-build-number`,
- `app-store-connect get-latest-app-store-build-number` and 
- `app-store-connect get-latest-build-number`.

In previous versions if `--pre-release-version` or `--app-store-version` argument was omitted, then the global latest version for an app was detected only based on build versions, which can lead to wrong results. For example consider the case where we have
- TestFlight version `1.0.1` with builds `1`, `2`,`3` and 
- TestFlight version `1.0.0` with builds `1`, `2`, ..., `5`, `6`.
- TestFlight version `0.0.1` with builds ..., `5`, `999`.

In this case the expected latest build is from TestFlight version `1.0.1` with version number `3`. But the previous versions pick build with number `999` from TestFlight version `0.0.1` since TestFlight versions were omitted from comparison entirely. Similar issue applies to App Store versions and their build.

Another minor change is that now the detected build number and TestFlight / App Store versions are logged out to STDERR stream. This is useful as the most common use-case for these actions is to capture the current latest build number into a shell variable, which can then be used to set the version of next build.

<details>
<summary>Example</summary>


Old version:
```shell
$ app-store-connect get-latest-build-number 1481211155
2.0.320.508
$ CURRENT_VERSION=$(app-store-connect get-latest-build-number 1481211155)
$ echo $CURRENT_VERSION
2.0.320.508
```

Updated version:
```shell
$ app-store-connect get-latest-build-number 1481211155
Found build number 2.0.320.508 from TestFlight version 2.0.320
2.0.320.508
$ CURRENT_VERSION=$(app-store-connect get-latest-build-number 1481211155)
Found build number 2.0.320.508 from TestFlight version 2.0.320
$ echo $CURRENT_VERSION
2.0.320.508
```
</details>

**Updated actions**:
- `app-store-connect get-latest-testflight-build-number`
- `app-store-connect get-latest-app-store-build-number` 
- `app-store-connect get-latest-build-number`

