### PR TITLE
Bugfix: wait for submissions to exit canceling state before creating a new submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.38.1
+-------------
+
+**Bugfix**
+- Update flag `--cancel-previous-submissions` for the `app-store-connect builds submit-to-app-store` action to wait for Apple's confirmation that the submission is cancelled before attempting to submit a new build.
+
 Version 0.38.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.38.0"
+version = "0.38.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.38.0.dev'
+__version__ = '0.38.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
This PR fixes a bug introduced in #306.

In the scenario where the cancelling of previous submissions is delayed on Apple's side, the creation of new submissions will still fail as previously, even though the previous submission is cancelled.

The flag `--cancel-previous-submissions` for the `app-store-connect builds submit-to-app-store` action was updated to take this into account and wait for the response from Apple.

**QA:**
- submission with `--cancel-previous-submissions` flag waits for Apple's response and submission is successful ✅ 
- behaviour without specifying the flag is not changed and submission fails as usual ✅ 