### PR TITLE
Bugfix: Do not rely on provisioning profile ordering on disk for `xcode-project use-profiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.38.1
+Version 0.38.2
 -------------
 
 **Bugfix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Version 0.38.1
 -------------
 
 **Bugfix**
+- Improve action `xcode-project use-profiles` stability so that different invocation with the same set  of provisioning profiles will always yield the same changeset to Xcode project settings. [PR #308](https://github.com/codemagic-ci-cd/cli-tools/pull/308)
+
+Version 0.38.1
+-------------
+
+**Bugfix**
 - Update flag `--cancel-previous-submissions` for the `app-store-connect builds submit-to-app-store` action to wait for Apple's confirmation that the submission is cancelled before attempting to submit a new build.
 
 Version 0.38.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.38.1"
+version = "0.38.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.38.1.dev'
+__version__ = '0.38.2.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/code_signing_settings_manager.py
+++ b/src/codemagic/models/code_signing_settings_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import json
 import pathlib
 import shlex
@@ -86,7 +87,7 @@ class CodeSigningSettingsManager(RunningCliAppMixin, StringConverterMixin):
         wildcard_profiles = sorted((p for p in self.profiles.values() if p.is_wildcard), key=sort_key)
         specific_profiles = sorted((p for p in self.profiles.values() if not p.is_wildcard), key=sort_key)
         # Non-wildcard profiles come first and have higher priority
-        profiles = [*specific_profiles, *wildcard_profiles]
+        profiles = itertools.chain(specific_profiles, wildcard_profiles)
 
         return json.dumps([self._serialize_profile(p) for p in profiles])
 

--- a/src/codemagic/models/code_signing_settings_manager.py
+++ b/src/codemagic/models/code_signing_settings_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import json
 import pathlib
 import shlex
@@ -7,7 +8,6 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
-from datetime import timedelta
 from datetime import timezone
 from functools import lru_cache
 from tempfile import NamedTemporaryFile
@@ -60,17 +60,42 @@ class CodeSigningSettingsManager(RunningCliAppMixin, StringConverterMixin):
 
     @lru_cache()
     def _get_json_serialized_profiles(self) -> str:
+        # Make sure profiles are serialized in a specific order so that different runs
+        # with the same profiles will always yield the same changeset to Xcode project settings.
+
+        # Partition profiles into wildcard profiles and strict matching profiles
+        wildcard_profiles = [p for p in self.profiles.values() if p.is_wildcard]
+        other_profiles = [p for p in self.profiles.values() if not p.is_wildcard]
+
         now = datetime.now(timezone.utc)
 
-        def sort_key(profile: ProvisioningProfile) -> Tuple[bool, str, timedelta]:
-            profile_age = now - profile.creation_date
-            return (
-                profile.is_wildcard,  # Non-wildcard profiles have higher priority
-                profile.bundle_id,  # General ordering by alphabetically sorting bundle identifiers
-                profile_age,  # In case of bundle identifier collision, prefer more recent profile
-            )
+        # Order non-wildcard profiles alphabetically by bundle identifier values.
+        # In case of bundle identifier collision prefer more recent profile.
+        other_profiles.sort(
+            key=lambda p: (
+                p.bundle_id,
+                now - p.creation_date,
+            ),
+        )
 
-        profiles = sorted(self.profiles.values(), key=sort_key)
+        # Order wildcard profiles so that:
+        # - More specific bundle ids come first with higher priority
+        #   ("com.example.app.*" is more specific than "com.example.*").
+        #   Detect this by counting namespace separators in bundle identifier.
+        # - Otherwise order them alphabetically by comparing bundle identifiers.
+        # - Finally in case of bundle identifier collision raise priority for more recent profile.
+        max_separators = max((p.bundle_id.count('.') for p in wildcard_profiles), default=0)
+        wildcard_profiles.sort(
+            key=lambda p: (
+                max_separators - p.bundle_id.count('.'),
+                p.bundle_id,
+                now - p.creation_date,
+            ),
+        )
+
+        # Non-wildcard profiles come first and have higher priority
+        profiles = list(itertools.chain(other_profiles, wildcard_profiles))
+
         return json.dumps([self._serialize_profile(p) for p in profiles])
 
     def _serialize_profile(self, profile):


### PR DESCRIPTION
Two invocations of `xcode-project use-profiles` can lead to different modifications to Xcode project files even though the very same set of provisioning profiles are discovered. This can happen because the script [`code_signing_manager.rb`](https://github.com/codemagic-ci-cd/cli-tools/blob/v0.38.1/src/codemagic/scripts/code_signing_manager.rb), which is used internally for updating `*.xcodeproj` files, depends on the order of provisioning profiles that are passed to it.

In order to avoid such inconsistencies, make sure that profiles are sorted in a stable manner before serializing them for `code_signing_manager.rb`. The changes in this PR ensure that profiles are ordered so that
- Non-wildcard/strict matching provisioning profiles have higher priority than wildcard profiles.
- The more specific the bundle identifier is, the higher the priority. For example
  - `com.example.app.extension` is more specific than `com.example.app` and
  - `com.example.app.*` is more specific than `com.example.*`, which is more specific than just `*`.
- Provisioning profiles with the same level of namespacing (number of dots in bundle identifier) are order alphabetically by comparing bundle identifier values.
- Finally in case of bundle identifiers are the same, more recently generated provisioning profile comes first.


For example this is how those provisioning profiles would be ordered.

| Bundle identifier                       | Created at          |
|-----------------------------------------|---------------------|
| `io.codemagic.banaan.UITests.xctrunner` | 2023-01-20 13:17:03 |
| `io.codemagic.banaan.Clip`              | 2023-01-20 13:17:03 |
| `io.codemagic.banaan`                   | 2023-01-20 13:17:02 |
| `io.codemagic.capybara`                 | 2023-01-20 13:29:58 |
| `io.codemagic.*`                        | 2022-09-28 10:40:41 |
| `io.codemagic.*`                        | 2022-03-24 10:02:42 |
| `*`                                     | 2023-02-02 13:14:11 |
| `*`                                     | 2022-11-14 10:15:54 |




**Updated actions:**
- `xcode-project use-profiles`