### PR TITLE
Highest build  number of highest version uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Version 0.38.3
+-------------
+
+**Docs**
+- Documentation was updated for actions:
+  - `app-store-connect get-latest-build-number`,
+  - `app-store-connect get-latest-app-store-build-number`,
+  - `app-store-connect get-latest-testflight-build-number`.
+
 Version 0.38.2
 -------------
 

--- a/docs/app-store-connect/README.md
+++ b/docs/app-store-connect/README.md
@@ -100,9 +100,9 @@ Enable verbose logging for commands
 |[`fetch-signing-files`](fetch-signing-files.md)|Fetch provisioning profiles and code signing certificates         for Bundle ID with given identifier|
 |[`get-bundle-id`](get-bundle-id.md)|Get specified Bundle ID from Apple Developer portal|
 |[`get-certificate`](get-certificate.md)|Get specified Signing Certificate from Apple Developer portal|
-|[`get-latest-app-store-build-number`](get-latest-app-store-build-number.md)|Get the latest App Store build number for the given application|
-|[`get-latest-build-number`](get-latest-build-number.md)|Get the highest build number used for the given app considering both TestFlight and App Store submissions|
-|[`get-latest-testflight-build-number`](get-latest-testflight-build-number.md)|Get the latest Testflight build number for the given application|
+|[`get-latest-app-store-build-number`](get-latest-app-store-build-number.md)|Get the latest App Store build number of the highest version for the given application|
+|[`get-latest-build-number`](get-latest-build-number.md)|Get the highest build number of the highest version used for the given app.|
+|[`get-latest-testflight-build-number`](get-latest-testflight-build-number.md)|Get the latest Testflight build number of the highest version for the given application|
 |[`get-profile`](get-profile.md)|Get specified Profile from Apple Developer portal|
 |[`list-builds`](list-builds.md)|List Builds from Apple Developer Portal matching given constraints|
 |[`list-bundle-id-profiles`](list-bundle-id-profiles.md)|List provisioning profiles from Apple Developer Portal for specified Bundle IDs|

--- a/docs/app-store-connect/get-latest-app-store-build-number.md
+++ b/docs/app-store-connect/get-latest-app-store-build-number.md
@@ -3,7 +3,7 @@ get-latest-app-store-build-number
 =================================
 
 
-**Get the latest App Store build number for the given application**
+**Get the latest App Store build number of the highest version for the given application**
 ### Usage
 ```bash
 app-store-connect get-latest-app-store-build-number [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]

--- a/docs/app-store-connect/get-latest-build-number.md
+++ b/docs/app-store-connect/get-latest-build-number.md
@@ -3,7 +3,7 @@ get-latest-build-number
 =======================
 
 
-**Get the highest build number used for the given app considering both TestFlight and App Store submissions**
+**Get the highest build number of the highest version used for the given app.**
 ### Usage
 ```bash
 app-store-connect get-latest-build-number [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]

--- a/docs/app-store-connect/get-latest-testflight-build-number.md
+++ b/docs/app-store-connect/get-latest-testflight-build-number.md
@@ -3,7 +3,7 @@ get-latest-testflight-build-number
 ==================================
 
 
-**Get the latest Testflight build number for the given application**
+**Get the latest Testflight build number of the highest version for the given application**
 ### Usage
 ```bash
 app-store-connect get-latest-testflight-build-number [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.38.2"
+version = "0.38.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.38.2.dev'
+__version__ = '0.38.3.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -292,7 +292,7 @@ class AppStoreConnect(
         platform: Optional[Platform] = None,
     ) -> Optional[str]:
         """
-        Get the highest build number of the highest version used for the given app considering both TestFlight and App Store submissions
+        Get the highest build number of the highest version used for the given app.
         """
         app_store_build_info = self._get_max_app_store_version_and_build(application_id, platform=platform)
         testflight_build_info = self._get_max_testflight_version_and_build(application_id, platform=platform)

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -292,7 +292,7 @@ class AppStoreConnect(
         platform: Optional[Platform] = None,
     ) -> Optional[str]:
         """
-        Get the highest build number used for the given app considering both TestFlight and App Store submissions
+        Get the highest build number of the highest version used for the given app considering both TestFlight and App Store submissions
         """
         app_store_build_info = self._get_max_app_store_version_and_build(application_id, platform=platform)
         testflight_build_info = self._get_max_testflight_version_and_build(application_id, platform=platform)
@@ -327,7 +327,7 @@ class AppStoreConnect(
         platform: Optional[Platform] = None,
     ) -> Optional[str]:
         """
-        Get the latest App Store build number for the given application
+        Get the latest App Store build number of the highest version for the given application
         """
         latest_build_info = self._get_max_app_store_version_and_build(
             application_id,
@@ -359,7 +359,7 @@ class AppStoreConnect(
         not_expired: Optional[bool] = None,
     ) -> Optional[str]:
         """
-        Get the latest Testflight build number for the given application
+        Get the latest Testflight build number of the highest version for the given application
         """
         try:
             expired_value: Optional[bool] = Argument.resolve_optional_two_way_switch(expired, not_expired)


### PR DESCRIPTION
Update documentation for actions
- `app-store-connect get-latest-build-number`,
- `app-store-connect get-latest-app-store-build-number`,
- `app-store-connect get-latest-testflight-build-number`.