### PR TITLE
Use timezone aware datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.39.1
 -------------
 
 **Development**
-- Marginal changes to use timezone aware datetimes with `datetime.now(timezone.utc)` as recommended in the [documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow). [PR #310](https://github.com/codemagic-ci-cd/cli-tools/pull/310)
+- Marginal changes to start using `datetime.now(timezone.utc)` in favor of `datetime.utcnow()` as recommended in the [documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow). [PR #313](https://github.com/codemagic-ci-cd/cli-tools/pull/313)
 
 Version 0.39.0
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.39.1
 -------------
 
 **Development**
-- Marginal changes to start using `datetime.now(timezone.utc)` in favor of `datetime.utcnow()` as recommended in the [documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow). [PR #313](https://github.com/codemagic-ci-cd/cli-tools/pull/313)
+- Marginal changes to start using timezone aware datetimes instead of timezone unaware datetimes. [PR #313](https://github.com/codemagic-ci-cd/cli-tools/pull/313)
 
 Version 0.39.0
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.39.1
+-------------
+
+**Development**
+- Marginal changes to use timezone aware datetimes with `datetime.now(timezone.utc)` as recommended in the [documentation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow). [PR #310](https://github.com/codemagic-ci-cd/cli-tools/pull/310)
+
 Version 0.39.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.39.0"
+version = "0.39.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.39.0.dev'
+__version__ = '0.39.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/models/certificate.py
+++ b/src/codemagic/models/certificate.py
@@ -115,7 +115,7 @@ class Certificate(JsonSerializable, RunningCliAppMixin, StringConverterMixin):
 
     @property
     def has_expired(self) -> bool:
-        current_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+        current_time = datetime.now(timezone.utc)
         return self.expires_at < current_time
 
     @property

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -179,7 +179,7 @@ class Types:
 
         @classmethod
         def validate(cls, value: datetime):
-            if value <= datetime.utcnow().replace(tzinfo=timezone.utc):
+            if value <= datetime.now(timezone.utc):
                 raise ArgumentTypeError(f'Provided value "{value}" is not valid, date cannot be in the past')
             elif (value.minute, value.second, value.microsecond) != (0, 0, 0):
                 raise ArgumentTypeError((

--- a/src/codemagic/utilities/auditing/exception_auditor.py
+++ b/src/codemagic/utilities/auditing/exception_auditor.py
@@ -5,6 +5,7 @@ import shlex
 import sys
 import traceback
 from datetime import datetime
+from datetime import timezone
 from types import TracebackType
 from typing import Type
 
@@ -50,7 +51,7 @@ class ExceptionAuditor(BaseAuditor):
             'exception_arguments': self._serialize_exception_arguments(),
             'exception_type': self._exception_type.__name__,
             'stacktrace': ''.join(traceback.format_tb(self._traceback)),
-            'timestamp': datetime.utcnow().isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
             'version': __version__,
         }
 

--- a/src/codemagic/utilities/auditing/http_request_auditor.py
+++ b/src/codemagic/utilities/auditing/http_request_auditor.py
@@ -1,6 +1,7 @@
 import re
 import urllib.parse
 from datetime import datetime
+from datetime import timezone
 from typing import Dict
 from typing import Optional
 
@@ -76,7 +77,7 @@ class HttpRequestAuditor(BaseAuditor):
                 'content': self._serialize_response_content(),
                 'elapsed': self._response.elapsed.total_seconds(),
             },
-            'timestamp': datetime.utcnow().isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
             'version': __version__,
         }
 


### PR DESCRIPTION
As per Python `datetime` [documentation](https://docs.python.org/3/library/datetime.html), due to the fact that naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing the current time in UTC is by calling `datetime.now(timezone.utc)`.