### PR TITLE
Feature: Improve Python API for `Keychain` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.39.2
 -------------
 
 **Features**
-- Improve Python API for module `codemagic.tools.keychain`. Allow passing passwords as strings in addition to `codemagic.tools.keychain.Password` for `Keychain` methods. [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+- Improve Python API for module `codemagic.tools.keychain`. Allow passing passwords as strings in addition to `codemagic.tools.keychain.Password` for `Keychain` methods. [PR #315](https://github.com/codemagic-ci-cd/cli-tools/pull/315)
 
 Version 0.39.1
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.39.1
+-------------
+
+**Features**
+- Improve Python API for module `codemagic.tools.keychain`. Allow passing passwords as strings in addition to `codemagic.tools.keychain.Password` for `Keychain` methods. [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+
 Version 0.39.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.39.0"
+version = "0.39.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.39.0.dev'
+__version__ = '0.39.1.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'


### PR DESCRIPTION
As `Keychain` methods except password argument to be passed as `Password` instance, it makes the Python API of `Keychain` really cumbersome to use. To make it more user friendly, also accept plain `str` values wherever `Password` is currently used.