### PR TITLE
Bugfix: Do not require `detail` field from App Store Connect API error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--check-only]

--- a/src/codemagic/apple/resources/error_response.py
+++ b/src/codemagic/apple/resources/error_response.py
@@ -38,7 +38,7 @@ class Error(DictSerializable):
     code: str
     status: str
     title: str
-    detail: str
+    detail: Optional[str] = None
     id: Optional[str] = None
     source: Optional[Dict[str, str]] = None
     meta: Optional[ErrorMeta] = None
@@ -49,7 +49,11 @@ class Error(DictSerializable):
             self.meta = ErrorMeta(**self.meta)
 
     def __str__(self):
-        s = f'{self.title} - {self.detail}'
+        if self.detail is None:
+            s = self.title
+        else:
+            s = f'{self.title} - {self.detail}'
+
         if self.meta:
             meta = textwrap.indent(str(self.meta), '\t')
             if meta:
@@ -66,11 +70,14 @@ class ErrorResponse(DictSerializable):
     @classmethod
     def from_raw_response(cls, response: Response) -> ErrorResponse:
         error_response = ErrorResponse({'errors': []})
-        error_response.errors.append(Error(
-            code='NA',
-            status=str(response.status_code),
-            title='Request failed',
-            detail=f'Request failed with status code {response.status_code}'))
+        error_response.errors.append(
+            Error(
+                code='NA',
+                status=str(response.status_code),
+                title='Request failed',
+                detail=f'Request failed with status code {response.status_code}',
+            ),
+        )
         return error_response
 
     def __str__(self):

--- a/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
+++ b/src/codemagic/tools/_app_store_connect/action_groups/builds_action_group.py
@@ -398,6 +398,7 @@ class BuildsActionGroup(AbstractBaseAction, metaclass=ABCMeta):
             existing_submission_matches: Iterator[Optional[re.Match]] = (
                 existing_submission_error_patt.search(error.detail)
                 for error in api_error.error_response.errors
+                if error.detail is not None
             )
 
             try:


### PR DESCRIPTION
App Store Connect API can respond with error response that has payload like

```json
{
  "errors": [
    {
      "status": "409",
      "source": {
        "pointer": "/data/relationships/appStoreVersion"
      },
      "code": "ENTITY_ERROR.RELATIONSHIP.INVALID.NOT_ALLOWED",
      "id": "272d2697-763d-4994-99cc-e1a77f31843f",
      "title": "Only one appStoreVersion can be present in reviewSubmissions."
    }
  ]
}
```

Currently it is expected that each error contains a field `detail`, which might be missing. Make it optional to cope with such response payloads.