### PR TITLE
Bugfix: Do not require release notes for Firebase releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Version 0.40.2
 -------------
 
+**Bugfixes**
+- Do not require `releaseNotes` from Firebase App Distribution release responses. [PR #323](https://github.com/codemagic-ci-cd/cli-tools/pull/323)
+
 **Dependencies**
-- Set lower bound version limit `>= 2.84.0` to [`google-api-python-client`](https://github.com/googleapis/google-api-python-client) Python dependency in order to comply with Firebase App Distribution APIs. [PR #xyz](https://github.com/codemagic-ci-cd/cli-tools/pull/xyz)
+- Set lower bound version limit `>= 2.84.0` to [`google-api-python-client`](https://github.com/googleapis/google-api-python-client) Python dependency in order to comply with Firebase App Distribution APIs. [PR #322](https://github.com/codemagic-ci-cd/cli-tools/pull/322)
 
 Version 0.40.1
 -------------

--- a/src/codemagic/google/resources/release.py
+++ b/src/codemagic/google/resources/release.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
+from typing import Optional
 
 from .release_notes import ReleaseNotes
 from .resource import Resource
@@ -12,13 +13,13 @@ class Release(Resource):
     https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.apps.releases
     """
     name: str
-    releaseNotes: ReleaseNotes
     displayVersion: str
     buildVersion: int
     createTime: datetime
     firebaseConsoleUri: str
     testingUri: str
     binaryDownloadUri: str
+    releaseNotes: Optional[ReleaseNotes] = None
 
     def __post_init__(self):
         if isinstance(self.createTime, str):


### PR DESCRIPTION
Not all Firebase App Distribution releases have release notes attached to them. This causes related `firebase-app-distribution` actions to fail with the following exception:

```python
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 212, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 168, in _invoke_action
    return cli_action(**action_args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 463, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/firebase_app_distribution/actions/get_latest_build_version_action.py", line 23, in get_latest_build_version
    releases = self.client.releases.list(app_identifier, limit=1)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/google/resource_managers/mixins/listing_manager_mixin.py", line 68, in list
    resources.extend(self.resource_type(**item) for item in response[self.resource_type.get_label()])
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/google/resource_managers/mixins/listing_manager_mixin.py", line 68, in <genexpr>
    resources.extend(self.resource_type(**item) for item in response[self.resource_type.get_label()])
TypeError: __init__() missing 1 required positional argument: 'releaseNotes'
```

Make `releaseNotes` field on `Release` object optional.