### PR TITLE
Feature: Add decorator to mark functions as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Version 0.40.4
+-------------
+
+**Deprecations**
+- Method `list_capabilility_ids` of `codemagic.apple.app_store_connect.provisioning.BundleIds` is deprecated and shows a deprecation warning on calls. Use `list_capability_ids` of the same class instead. [PR #326](https://github.com/codemagic-ci-cd/cli-tools/pull/326)
+
+**Development**
+- Define `deprecated` decorator in `codemagic.utilities.decorators` to mark functions and methods as obsolete. [PR #326](https://github.com/codemagic-ci-cd/cli-tools/pull/326)
+
 Version 0.40.3
 -------------
 **Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.40.3"
+version = "0.40.4"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = 'codemagic-cli-tools'
 __description__ = 'CLI tools used in Codemagic builds'
-__version__ = '0.40.3.dev'
+__version__ = '0.40.4.dev'
 __url__ = 'https://github.com/codemagic-ci-cd/cli-tools'
 __licence__ = 'GNU General Public License v3.0'

--- a/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
+++ b/src/codemagic/apple/app_store_connect/provisioning/bundle_ids.py
@@ -15,6 +15,7 @@ from codemagic.apple.resources import LinkedResourceData
 from codemagic.apple.resources import Profile
 from codemagic.apple.resources import ResourceId
 from codemagic.apple.resources import ResourceType
+from codemagic.utilities.decorators import deprecated
 
 if TYPE_CHECKING:
     from .profiles import Profiles
@@ -53,11 +54,13 @@ class BundleIds(ResourceManager[BundleId]):
         PLATFORM = 'platform'
         SEED_ID = 'seedId'
 
-    def create(self,
-               identifier: str,
-               name: str,
-               platform: BundleIdPlatform,
-               seed_id: Optional[str] = None) -> BundleId:
+    def create(
+        self,
+        identifier: str,
+        name: str,
+        platform: BundleIdPlatform,
+        seed_id: Optional[str] = None,
+    ) -> BundleId:
         """
         https://developer.apple.com/documentation/appstoreconnectapi/register_a_new_bundle_id
         """
@@ -81,7 +84,8 @@ class BundleIds(ResourceManager[BundleId]):
         bundle_id_resource_id = self._get_resource_id(bundle_id)
         payload = self._get_update_payload(bundle_id_resource_id, ResourceType.BUNDLE_ID, attributes={'name': name})
         response = self.client.session.patch(
-            f'{self.client.API_URL}/bundleIds/{bundle_id_resource_id}', json=payload).json()
+            f'{self.client.API_URL}/bundleIds/{bundle_id_resource_id}', json=payload,
+        ).json()
         return BundleId(response['data'])
 
     def delete(self, bundle_id: Union[LinkedResourceData, ResourceId]) -> None:
@@ -91,10 +95,12 @@ class BundleIds(ResourceManager[BundleId]):
         bundle_id_resource_id = self._get_resource_id(bundle_id)
         self.client.session.delete(f'{self.client.API_URL}/bundleIds/{bundle_id_resource_id}')
 
-    def list(self,
-             resource_filter: Filter = Filter(),
-             ordering=Ordering.NAME,
-             reverse=False) -> List[BundleId]:
+    def list(
+        self,
+        resource_filter: Filter = Filter(),
+        ordering=Ordering.NAME,
+        reverse=False,
+    ) -> List[BundleId]:
         """
         https://developer.apple.com/documentation/appstoreconnectapi/list_bundle_ids
         """
@@ -122,9 +128,11 @@ class BundleIds(ResourceManager[BundleId]):
             url = f'{self.client.API_URL}/bundleIds/{bundle_id}/relationships/profiles'
         return [LinkedResourceData(bundle_id_profile) for bundle_id_profile in self.client.paginate(url)]
 
-    def list_profiles(self,
-                      bundle_id: Union[BundleId, ResourceId],
-                      resource_filter: Optional[Profiles.Filter] = None) -> List[Profile]:
+    def list_profiles(
+        self,
+        bundle_id: Union[BundleId, ResourceId],
+        resource_filter: Optional[Profiles.Filter] = None,
+    ) -> List[Profile]:
         """
         https://developer.apple.com/documentation/appstoreconnectapi/list_all_profiles_for_a_bundle_id
         """
@@ -138,7 +146,11 @@ class BundleIds(ResourceManager[BundleId]):
             return [profile for profile in profiles if resource_filter.matches(profile)]
         return profiles
 
-    def list_capabilility_ids(self, bundle_id: Union[BundleId, ResourceId]) -> List[LinkedResourceData]:
+    @deprecated('0.40.4', 'Use "BundleIds.list_capability_ids" instead.')
+    def list_capabilility_ids(self, *args, **kwargs):
+        return self.list_capability_ids(*args, **kwargs)
+
+    def list_capability_ids(self, bundle_id: Union[BundleId, ResourceId]) -> List[LinkedResourceData]:
         """
         https://developer.apple.com/documentation/appstoreconnectapi/get_all_capabilility_ids_for_a_bundle_id
         """
@@ -147,7 +159,7 @@ class BundleIds(ResourceManager[BundleId]):
             url = bundle_id.relationships.bundleIdCapabilities.links.self
         if url is None:
             url = f'{self.client.API_URL}/bundleIds/{bundle_id}/relationships/bundleIdCapabilities'
-        return [LinkedResourceData(capabilility) for capabilility in self.client.paginate(url, page_size=None)]
+        return [LinkedResourceData(capability) for capability in self.client.paginate(url, page_size=None)]
 
     def list_capabilities(self, bundle_id: Union[BundleId, ResourceId]) -> List[BundleIdCapability]:
         """

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from codemagic.cli import Colors
 from codemagic.models.enums import ResourceEnum
-from codemagic.utilities import log
+from codemagic.utilities.decorators import deprecated
 
 
 class AppStoreState(ResourceEnum):
@@ -222,13 +221,8 @@ class ProfileType(ResourceEnum):
     def devices_not_allowed(self) -> bool:
         return not self.devices_required()
 
+    @deprecated('0.31.3', 'Use "ProfileType.devices_required" instead.')
     def devices_allowed(self) -> bool:
-        warning = (
-            'Deprecation warning! Method '
-            '"devices_allowed" is deprecated in favor of "devices_required" in version 0.31.3 '
-            'and is subject for removal in future releases.'
-        )
-        log.get_logger(self.__class__).warning(Colors.YELLOW(warning))
         return self.devices_required()
 
     def devices_required(self) -> bool:

--- a/src/codemagic/utilities/decorators.py
+++ b/src/codemagic/utilities/decorators.py
@@ -1,0 +1,36 @@
+from functools import wraps
+from typing import Optional
+
+from codemagic.cli import Colors
+from codemagic.utilities import log
+
+
+def deprecated(
+    deprecation_version: str,
+    comment: Optional[str] = None,
+    color: Optional[Colors] = Colors.YELLOW,
+):
+    def decorator(function):
+        if '<locals>' in function.__qualname__:
+            qualifier = function.__qualname__.split('>.')[-1]
+        else:
+            qualifier = function.__qualname__
+
+        message = (
+            'Deprecation warning! '
+            f'"{qualifier}" was deprecated in version {deprecation_version} '
+            'and is subject for removal in future releases.'
+        )
+        if comment:
+            message = f'{message} {comment}'
+        if color:
+            message = color(message)
+
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            log.get_logger(function).warning(message)
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
+++ b/tests/apple/app_store_connect/provisioning/test_bundle_ids.py
@@ -76,8 +76,8 @@ class BundleIdsTest(ResourceManagerTestsBase):
             assert isinstance(profile, Profile)
             assert profile.type is ResourceType.PROFILES
 
-    def test_list_capabilility_ids(self):
-        linked_capabilities = self.api_client.bundle_ids.list_capabilility_ids(CAPYBARA_ID)
+    def test_list_capability_ids(self):
+        linked_capabilities = self.api_client.bundle_ids.list_capability_ids(CAPYBARA_ID)
         assert len(linked_capabilities) > 0
         for capability in linked_capabilities:
             assert isinstance(capability, LinkedResourceData)

--- a/tests/utilities/decorators/test_deprecated.py
+++ b/tests/utilities/decorators/test_deprecated.py
@@ -1,0 +1,117 @@
+from unittest import mock
+
+import pytest
+
+from codemagic.cli import Colors
+from codemagic.utilities.decorators import deprecated
+
+
+@pytest.fixture
+def mock_logger():
+    mock_logger = mock.MagicMock()
+    with mock.patch('codemagic.utilities.log.get_logger', return_value=mock_logger):
+        yield mock_logger
+
+
+def test_on_function(mock_logger: mock.MagicMock):
+    @deprecated(deprecation_version='0.0.1', comment='This is an optional comment.', color=None)
+    def function():
+        return 1
+
+    assert function.__name__ == 'function'
+    assert function() == 1
+    expected_warning = (
+        'Deprecation warning! "function" was deprecated in version 0.0.1 '
+        'and is subject for removal in future releases. This is an optional comment.'
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+def test_on_static_method(mock_logger: mock.MagicMock):
+    class K:
+        @staticmethod
+        @deprecated(deprecation_version='0.0.1', comment='This is an optional comment.', color=None)
+        def static_method():
+            return 1
+
+    assert K.static_method.__name__ == 'static_method'
+    assert K.static_method() == 1
+    expected_warning = (
+        'Deprecation warning! "K.static_method" was deprecated in version 0.0.1 '
+        'and is subject for removal in future releases. This is an optional comment.'
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+def test_on_class_method(mock_logger: mock.MagicMock):
+    class K:
+        @classmethod
+        @deprecated(deprecation_version='0.0.1', comment='This is an optional comment.', color=None)
+        def class_method(cls):
+            return 1
+
+    assert K.class_method.__name__ == 'class_method'
+    assert K.class_method() == 1
+    expected_warning = (
+        'Deprecation warning! "K.class_method" was deprecated in version 0.0.1 '
+        'and is subject for removal in future releases. This is an optional comment.'
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+def test_on_instance_method(mock_logger: mock.MagicMock):
+    class K:
+        @deprecated(deprecation_version='0.0.1', comment='This is an optional comment.', color=None)
+        def instance_method(self):
+            return 1
+
+    assert K.instance_method.__name__ == 'instance_method'
+    assert K().instance_method() == 1
+    expected_warning = (
+        'Deprecation warning! "K.instance_method" was deprecated in version 0.0.1 '
+        'and is subject for removal in future releases. This is an optional comment.'
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+@pytest.mark.parametrize(
+    ('comment', 'expected_comment'),
+    (
+        (None, ''),
+        ('', ''),
+        ('Optional comment', ' Optional comment'),
+    ),
+)
+def test_comment(comment, expected_comment, mock_logger: mock.MagicMock):
+    @deprecated('0.0.0', comment=comment, color=None)
+    def f():
+        pass
+
+    f()
+    expected_warning = (
+        'Deprecation warning! "f" was deprecated in version 0.0.0 '
+        f'and is subject for removal in future releases.{expected_comment}'
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+def test_default_color(mock_logger: mock.MagicMock):
+    @deprecated('0.0.0')
+    def f(): pass
+
+    f()
+    expected_warning = Colors.YELLOW(
+        'Deprecation warning! "f" was deprecated in version 0.0.0 and is subject for removal in future releases.',
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)
+
+
+def test_color(mock_logger: mock.MagicMock):
+    @deprecated('0.0.0', color=Colors.BLUE)
+    def f(): pass
+
+    f()
+    expected_warning = Colors.BLUE(
+        'Deprecation warning! "f" was deprecated in version 0.0.0 and is subject for removal in future releases.',
+    )
+    mock_logger.warning.assert_called_once_with(expected_warning)


### PR DESCRIPTION
Add decorator `deprecated` to mark functions and methods as obsolete in a uniform way.

Use this new decorator to replace inlined warnings in `ProfileType.devices_allowed`. Also mark `BundleIds.list_capabilility_ids` as deprecated, and create new method without typo in the name to replace that. Original method is persisted as a mere proxy for now.

**Updated actions:**
- None

An example use-case of how this works can be seen from this mocked action:

![Screenshot 2023-06-28 at 16 35 52](https://github.com/codemagic-ci-cd/cli-tools/assets/2756611/1a35d0c1-1987-426e-ae1a-f3222b1f9583)
