### PR TITLE
Feature: register-device supports multiple UDIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+Version 0.41.0
+-------------
+
+Changes in this release improve `app-store-connect register-device` action by allowing to pass multiple UDIDs from different sources.
+
+**None of the breaking changes have an effect on command line usage**, only the Python API of is affected.
+
+**Features**
+- Update `app-store-connect register-device` action:
+  - The `--udid` argument now accepts multiple UDIDs.
+  - The `--udid` argument now accepts a file or an environment variable as a source for UDIDs.
+  - Introduce `--ignore-registration-errors` flag to continue registering devices despite errors
+  - Introduce short flags:
+    - `-n` flag for the device name,
+    - `-u` flag for the UDIDs.
+
+**Development**
+- **Breaking**: `AppStoreConnect.register_device` action method update:
+  - It now accepts a list of UDIDs for registration at the positional argument `device_udids`.
+  - It returns a list of registered devices.
+- Add `ignore_registration_errors` keyword argument to continue registering devices despite errors.
+
+**Documentation**
+- Update documentation for `app-store-connect register-device` action:
+  - Add new short flags: `-n` and `-u`.
+  - Add the description for the new `--ignore-registration-errors` option.
+  - Update the action description.
+
 Version 0.40.5
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ Changes in this release improve `app-store-connect register-device` action by al
     - `-u` flag for the UDIDs.
 
 **Development**
-- **Breaking**: `AppStoreConnect.register_device` action method update:
-  - It now accepts a list of UDIDs for registration at the positional argument `device_udids`.
-  - It returns a list of registered devices.
+- `AppStoreConnect.register_device` action method update:
+  - It now accepts a list of UDIDs for registration at the positional argument `device_udids_argument`.
+  - **Breaking**: `AppStoreConnect.register_device` now returns a list of registered devices.
 - Add `ignore_registration_errors` keyword argument to continue registering devices despite errors.
 
 **Documentation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes in this release improve `app-store-connect register-device` action by al
 
 **Development**
 - `AppStoreConnect.register_device` action method update:
-  - It now accepts a list of UDIDs for registration at the positional argument `device_udids`.
+  - It now accepts a list of UDIDs for registration at the keyword argument `device_udids`.
   - **Breaking**: `AppStoreConnect.register_device` now returns a list of registered devices.
 - Add `ignore_registration_errors` keyword argument to continue registering devices despite errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes in this release improve `app-store-connect register-device` action by al
 
 **Development**
 - `AppStoreConnect.register_device` action method update:
-  - It now accepts a list of UDIDs for registration at the positional argument `device_udids_argument`.
+  - It now accepts a list of UDIDs for registration at the positional argument `device_udids`.
   - **Breaking**: `AppStoreConnect.register_device` now returns a list of registered devices.
 - Add `ignore_registration_errors` keyword argument to continue registering devices despite errors.
 

--- a/docs/app-store-connect/README.md
+++ b/docs/app-store-connect/README.md
@@ -111,7 +111,7 @@ Enable verbose logging for commands
 |[`list-devices`](list-devices.md)|List Devices from Apple Developer portal matching given constraints|
 |[`list-profiles`](list-profiles.md)|List Profiles from Apple Developer portal matching given constraints|
 |[`publish`](publish.md)|Publish application packages to App Store, submit them to Testflight, and release to the groups of beta testers|
-|[`register-device`](register-device.md)|Register a new device for app development|
+|[`register-device`](register-device.md)|Register new Devices for app development|
 
 ### Action groups
 

--- a/docs/app-store-connect/list-devices.md
+++ b/docs/app-store-connect/list-devices.md
@@ -27,7 +27,7 @@ app-store-connect list-devices [-h] [--log-stream STREAM] [--no-color] [--versio
 
 
 Bundle ID platform
-##### `--name=DEVICE_NAME_OPTIONAL`
+##### `--name, -n=DEVICE_NAME_OPTIONAL`
 
 
 Name of the Device

--- a/docs/app-store-connect/list-devices.md
+++ b/docs/app-store-connect/list-devices.md
@@ -30,7 +30,7 @@ Bundle ID platform
 ##### `--name, -n=DEVICE_NAME_OPTIONAL`
 
 
-Name of the Device
+Common name of Devices
 ##### `--status=DISABLED | ENABLED`
 
 

--- a/docs/app-store-connect/register-device.md
+++ b/docs/app-store-connect/register-device.md
@@ -3,7 +3,7 @@ register-device
 ===============
 
 
-**Register a new device for app development**
+**Register new Devices for app development**
 ### Usage
 ```bash
 app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
@@ -18,25 +18,30 @@ app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--ver
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--platform PLATFORM]
+    [--ignore-registration-errors]
     --name DEVICE_NAME
-    --udid DEVICE_UDID
+    --udid DEVICE_UDIDS
 ```
 ### Required arguments for action `register-device`
 
-##### `--name=DEVICE_NAME`
+##### `--name, -n=DEVICE_NAME`
 
 
 Name of the Device
-##### `--udid=DEVICE_UDID`
+##### `--udid, -u=DEVICE_UDIDS`
 
 
-Device ID (UDID)
+Device ID (UDID), for example: 00000000-000000000000001E. If not given, the value will be checked from the environment variable `DEVICE_UDIDS`. Alternatively to entering `DEVICE_UDIDS` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Optional arguments for action `register-device`
 
 ##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`
+##### `--ignore-registration-errors`
+
+
+Ignore device registration failures, e.g. invalid UDID or duplicate UDID submission. Proceed registering remaining UDIDs when the flag is set.
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/register-device.md
+++ b/docs/app-store-connect/register-device.md
@@ -37,7 +37,7 @@ Bundle ID platform. Default:&nbsp;`IOS`
 ##### `--udid, -u=DEVICE_UDIDS`
 
 
-Device ID (UDID), for example: 00000000-000000000000001E. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DEVICE_UDIDS`. Alternatively to entering `DEVICE_UDIDS`_ARGUMENT in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`. Multiple arguments
+Device ID (UDID), for example: 00000000-000000000000001E. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DEVICE_UDIDS`. Alternatively to entering `DEVICE_UDIDS` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`. Multiple arguments
 ##### `--ignore-registration-errors`
 
 

--- a/docs/app-store-connect/register-device.md
+++ b/docs/app-store-connect/register-device.md
@@ -18,9 +18,9 @@ app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--ver
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--platform PLATFORM]
+    [--udid DEVICE_UDIDS]
     [--ignore-registration-errors]
     --name DEVICE_NAME
-    --udid DEVICE_UDIDS
 ```
 ### Required arguments for action `register-device`
 
@@ -28,16 +28,16 @@ app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--ver
 
 
 Name of the Device
-##### `--udid, -u=DEVICE_UDIDS`
-
-
-Device ID (UDID), for example: 00000000-000000000000001E. If not given, the value will be checked from the environment variable `DEVICE_UDIDS`. Alternatively to entering `DEVICE_UDIDS` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Optional arguments for action `register-device`
 
 ##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`
 
 
 Bundle ID platform. Default:&nbsp;`IOS`
+##### `--udid, -u=DEVICE_UDIDS`
+
+
+Device ID (UDID), for example: 00000000-000000000000001E. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DEVICE_UDIDS`. Alternatively to entering `DEVICE_UDIDS`_ARGUMENT in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`. Multiple arguments
 ##### `--ignore-registration-errors`
 
 

--- a/docs/app-store-connect/register-device.md
+++ b/docs/app-store-connect/register-device.md
@@ -27,7 +27,7 @@ app-store-connect register-device [-h] [--log-stream STREAM] [--no-color] [--ver
 ##### `--name, -n=DEVICE_NAME`
 
 
-Name of the Device
+Common name of Devices
 ### Optional arguments for action `register-device`
 
 ##### `--platform=IOS | MAC_OS | UNIVERSAL | SERVICES`

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,3 +1,0 @@
-[virtualenvs]
-create = true
-in-project = true

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.40.5"
+version = "0.41.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.40.5.dev"
+__version__ = "0.41.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -85,8 +85,8 @@ class TypedCliArgument(Generic[T], metaclass=TypedCliArgumentMeta):
 
     def __init__(self, raw_value: str, from_environment=False):
         self._raw_value = raw_value
-        self.value: T = self._parse_value()
         self._from_environment = from_environment
+        self.value: T = self._parse_value()
 
     @classmethod
     def resolve_value(cls, argument_instance: Optional[Union[T, TypedCliArgument]]) -> T:

--- a/src/codemagic/cli/argument/typed_cli_argument.py
+++ b/src/codemagic/cli/argument/typed_cli_argument.py
@@ -119,10 +119,9 @@ class TypedCliArgument(Generic[T], metaclass=TypedCliArgumentMeta):
     def _is_valid(cls, value: T) -> bool:
         return bool(value)
 
-    @classmethod
-    def _apply_type(cls, non_typed_value: str) -> T:
-        value = cls.argument_type(non_typed_value)
-        if not cls._is_valid(value):
+    def _apply_type(self, non_typed_value: str) -> T:
+        value = self.argument_type(non_typed_value)  # type: ignore
+        if not self._is_valid(value):
             raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
         return value
 
@@ -239,4 +238,4 @@ class EnvironmentArgumentValue(TypedCliArgument[T], metaclass=TypedCliArgumentMe
         return self._raw_value
 
     def __repr__(self):
-        return self._raw_value
+        return f"{self.__class__.__name__}({self._raw_value!r})"

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -364,9 +364,9 @@ class Types:
                 udids = [non_typed_value.strip()]
             else:
                 udids = [udid.strip() for udid in shlex.split(non_typed_value) if udid.strip()]
-            if not udids or not all(udids):
-                raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
-            return udids
+            if udids and all(udids):
+                return udids
+            raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
 
 
 _API_DOCS_REFERENCE = f"Learn more at {AppStoreConnectApiClient.API_KEYS_DOCS_URL}."

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -359,7 +359,11 @@ class Types:
         example_value = "00000000-000000000000001E"
 
         def _apply_type(self, non_typed_value: str) -> List[str]:
-            udids = [udid.strip() for udid in shlex.split(non_typed_value) if udid.strip()]
+            is_from_cli = not (self._is_from_environment() or self._is_from_file() or self._from_environment)
+            if is_from_cli:
+                udids = [non_typed_value]
+            else:
+                udids = [udid.strip() for udid in shlex.split(non_typed_value) if udid.strip()]
             if not udids or not all(udids):
                 raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
             return udids
@@ -1228,7 +1232,7 @@ class DeviceArgument(cli.Argument):
         argparse_kwargs={"required": False},
     )
     DEVICE_UDIDS = cli.ArgumentProperties(
-        key="device_udids_argument",
+        key="device_udids",
         flags=("--udid", "-u"),
         type=Types.DeviceUdidsArgument,
         description=f"Device ID (UDID), for example: {Types.DeviceUdidsArgument.example_value}",

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -355,18 +355,13 @@ class Types:
 
     class DeviceUdidsArgument(cli.EnvironmentArgumentValue[List[str]]):
         argument_type = List[str]
-        environment_variable_key = "DEVICE_UDIDS"
+        environment_variable_key = "APP_STORE_CONNECT_DEVICE_UDIDS"
         example_value = "00000000-000000000000001E"
 
         def _apply_type(self, non_typed_value: str) -> List[str]:
-            if self._is_from_environment() or self._is_from_file():
-                udids = [udid.strip() for udid in shlex.split(non_typed_value)]
-            else:
-                udids = [non_typed_value.strip()]
-
+            udids = [udid.strip() for udid in shlex.split(non_typed_value) if udid.strip()]
             if not udids or not all(udids):
                 raise argparse.ArgumentTypeError(f'Provided value "{non_typed_value}" is not valid')
-
             return udids
 
 
@@ -1233,7 +1228,7 @@ class DeviceArgument(cli.Argument):
         argparse_kwargs={"required": False},
     )
     DEVICE_UDIDS = cli.ArgumentProperties(
-        key="device_udids",
+        key="device_udids_argument",
         flags=("--udid", "-u"),
         type=Types.DeviceUdidsArgument,
         description=f"Device ID (UDID), for example: {Types.DeviceUdidsArgument.example_value}",

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -361,7 +361,7 @@ class Types:
         def _apply_type(self, non_typed_value: str) -> List[str]:
             is_from_cli = not (self._is_from_environment() or self._is_from_file() or self._from_environment)
             if is_from_cli:
-                udids = [non_typed_value]
+                udids = [non_typed_value.strip()]
             else:
                 udids = [udid.strip() for udid in shlex.split(non_typed_value) if udid.strip()]
             if not udids or not all(udids):
@@ -1224,7 +1224,7 @@ class DeviceArgument(cli.Argument):
     DEVICE_NAME = cli.ArgumentProperties(
         key="device_name",
         flags=("--name", "-n"),
-        description="Name of the Device",
+        description="Common name of Devices",
         argparse_kwargs={"required": True},
     )
     DEVICE_NAME_OPTIONAL = cli.ArgumentProperties.duplicate(
@@ -1260,7 +1260,11 @@ class DeviceArgument(cli.Argument):
             "Ignore device registration failures, e.g. invalid UDID or duplicate UDID submission. "
             "Proceed registering remaining UDIDs when the flag is set."
         ),
-        argparse_kwargs={"required": False, "action": "store_true"},
+        argparse_kwargs={
+            "required": False,
+            "action": "store_true",
+            "default": False,
+        },
     )
 
 

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -357,6 +357,17 @@ class Types:
 
             return beta_build_infos
 
+    class DeviceUdidsArgument(cli.EnvironmentArgumentValue[List[str]]):
+        environment_variable_key = "DEVICE_UDIDS"
+        example_value = "00000000-000000000000001E"
+
+        @classmethod
+        def _apply_type(cls, non_typed_value: str) -> List[str]:
+            udids = non_typed_value.split()
+            if not udids:
+                argparse.ArgumentTypeError(f"Provided value contains no UDID: {non_typed_value}")
+            return udids
+
 
 _API_DOCS_REFERENCE = f"Learn more at {AppStoreConnectApiClient.API_KEYS_DOCS_URL}."
 _LOCALE_CODES_URL = (
@@ -1212,7 +1223,7 @@ class DeviceArgument(cli.Argument):
     )
     DEVICE_NAME = cli.ArgumentProperties(
         key="device_name",
-        flags=("--name",),
+        flags=("--name", "-n"),
         description="Name of the Device",
         argparse_kwargs={"required": True},
     )
@@ -1220,10 +1231,11 @@ class DeviceArgument(cli.Argument):
         DEVICE_NAME,
         argparse_kwargs={"required": False},
     )
-    DEVICE_UDID = cli.ArgumentProperties(
-        key="device_udid",
-        flags=("--udid",),
-        description="Device ID (UDID)",
+    DEVICE_UDIDS = cli.ArgumentProperties(
+        key="device_udids",
+        flags=("--udid", "-u"),
+        type=Types.DeviceUdidsArgument,
+        description=f"Device ID (UDID), for example: {Types.DeviceUdidsArgument.example_value}",
         argparse_kwargs={"required": True},
     )
     DEVICE_STATUS = cli.ArgumentProperties(
@@ -1235,6 +1247,16 @@ class DeviceArgument(cli.Argument):
             "required": False,
             "choices": list(DeviceStatus),
         },
+    )
+    IGNORE_REGISTRATION_ERRORS = cli.ArgumentProperties(
+        key="ignore_registration_errors",
+        flags=("--ignore-registration-errors",),
+        type=bool,
+        description=(
+            "Ignore device registration failures, e.g. invalid UDID or duplicate UDID submission. "
+            "Proceed registering remaining UDIDs when the flag is set."
+        ),
+        argparse_kwargs={"required": False, "action": "store_true"},
     )
 
 

--- a/src/codemagic/tools/_xcode_project/arguments.py
+++ b/src/codemagic/tools/_xcode_project/arguments.py
@@ -33,8 +33,7 @@ class CustomExportOptions(cli.EnvironmentArgumentValue[dict]):
         },
     )
 
-    @classmethod
-    def _apply_type(cls, non_typed_value: str) -> Dict:
+    def _apply_type(self, non_typed_value: str) -> Dict:
         try:
             given_custom_export_options = json.loads(non_typed_value)
             if not isinstance(given_custom_export_options, dict):

--- a/src/codemagic/tools/android_keystore/argument_types.py
+++ b/src/codemagic/tools/android_keystore/argument_types.py
@@ -4,8 +4,7 @@ from codemagic import cli
 
 
 class Password(cli.EnvironmentArgumentValue[str]):
-    @classmethod
-    def _apply_type(cls, non_typed_value: str) -> str:
+    def _apply_type(self, non_typed_value: str) -> str:
         value = super()._apply_type(non_typed_value)
         if len(value) < 6:
             raise argparse.ArgumentTypeError("Minimum required password length is 6 characters")

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -499,7 +499,7 @@ class AppStoreConnect(
         self,
         platform: BundleIdPlatform,
         device_name: str,
-        device_udid: Optional[str] = None,
+        device_udid: Optional[str] = None,  # Deprecated in https://github.com/codemagic-ci-cd/cli-tools/pull/331
         device_udids: Optional[
             Union[
                 str,

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -499,15 +499,21 @@ class AppStoreConnect(
         self,
         platform: BundleIdPlatform,
         device_name: str,
-        device_udids: Types.DeviceUdidsArgument,
+        device_udids: Union[Types.DeviceUdidsArgument, Sequence[Types.DeviceUdidsArgument]],
         ignore_registration_errors: bool = False,
         should_print: bool = True,
     ) -> List[Device]:
         """
         Register new Devices for app development
         """
+        if isinstance(device_udids, Types.DeviceUdidsArgument):
+            device_udids = [device_udids]
+        device_udid_values = [udid for arg in device_udids for udid in arg.value]
+        if not device_udid_values:
+            DeviceArgument.DEVICE_UDIDS.raise_argument_error("At least one device UDID is required")
+
         registered_devices = []
-        for i, device_udid in enumerate(Types.DeviceUdidsArgument.resolve_value(device_udids)):
+        for i, device_udid in enumerate(device_udid_values):
             if should_print:
                 self.echo("") if i != 0 else None
 

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -499,15 +499,15 @@ class AppStoreConnect(
         self,
         platform: BundleIdPlatform,
         device_name: str,
+        device_udid: Optional[str] = None,
         device_udids: Optional[
             Union[
                 str,
                 Types.DeviceUdidsArgument,
                 Sequence[Union[str, Types.DeviceUdidsArgument]],
             ]
-        ],
-        device_udid: Optional[str] = None,
-        ignore_registration_errors: bool = False,
+        ] = None,
+        ignore_registration_errors: bool = DeviceArgument.IGNORE_REGISTRATION_ERRORS.get_default(),
         should_print: bool = True,
     ) -> List[Device]:
         """

--- a/src/codemagic/tools/firebase_app_distribution/argument_types.py
+++ b/src/codemagic/tools/firebase_app_distribution/argument_types.py
@@ -9,8 +9,7 @@ class CredentialsArgument(cli.EnvironmentArgumentValue[dict]):
     argument_type = dict
     environment_variable_key = "FIREBASE_SERVICE_ACCOUNT_CREDENTIALS"
 
-    @classmethod
-    def _apply_type(cls, non_typed_value: str) -> Dict[str, str]:
+    def _apply_type(self, non_typed_value: str) -> Dict[str, str]:
         try:
             value = json.loads(non_typed_value)
         except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
1. Update `app-store-connect register-device` to accept now accepts multiple UDIDs from a file or an environment variable as a source.
2. Introduce `--ignore-registration-errors` flag for `app-store-connect register-device` to continue registering devices despite errors.
3. Introduce short flags for `app-store-connect register-device`:
    - `-n` flag for the device name,
    - `-u` flag for the UDIDs.

<details>
<summary>Demonstration of the command and its output</summary>

## File content

```
00000000-000000000000001E
00000000-000000000000002E

00000000-000000000000003X
```

UDIDs in file:

1. Valid UDID, but the device is present. 
2. Valid UDID, the device doesn't yet exists and will be registered
3. Invalid UDID


## Command
```shell
app-store-connect register-device -n iPhone -u @file:Device\ UDIDs.txt --ignore-registration-errors
```

## Output
```
Creating new Device: udid: 00000000-000000000000001E, name: iPhone, platform: IOS
Failed to register a device: POST https://api.appstoreconnect.apple.com/v1/devices returned 409: There is a problem with the request entity - A device with number '00000000-000000000000001E' already exists on this team.

Creating new Device: udid: 00000000-000000000000002E, name: iPhone, platform: IOS
-- Device (Created) --
Id: H2985X3P8Q
Type: devices
Class: IPOD
Name: iPhone
Platform: IOS
Status: ENABLED
Udid: 00000000-000000000000002E
Created Device H2985X3P8Q

Creating new Device: udid: 00000000-000000000000003X, name: iPhone, platform: IOS
Failed to register a device: POST https://api.appstoreconnect.apple.com/v1/devices returned 409: An attribute in the provided entity has invalid value - An invalid value '00000000-000000000000003X' was provided for the parameter 'udid'.
```

The syntax highlight demonstration
<img width="682" alt="image" src="https://github.com/codemagic-ci-cd/cli-tools/assets/40743076/105005be-728b-4d39-bf35-d22636716cc8">

</details>

Previous [PR](https://github.com/codemagic-ci-cd/cli-tools/pull/329) for the related functionality.