### PR TITLE
Fix running `app-store-connect get-certificate` without certificate private key

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -sSL https://install.python-poetry.org | python
+        curl -sSL https://install.python-poetry.org | python - --version 1.5.1
         poetry config virtualenvs.in-project true
         poetry install --no-interaction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.42.1
+-------------
+
+**Bugfixes**
+- Do not require certificate private key to show certificate information using `app-store-connect get-certificate` if certificate is not saved to disk. [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+
 Version 0.42.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.42.0"
+version = "0.42.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.42.0.dev"
+__version__ = "0.42.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -785,8 +785,11 @@ class AppStoreConnect(
                 self.logger.info(f"- {certificate.get_display_info()}")
 
         if save:
-            assert private_key is not None  # Make mypy happy
-            self._save_certificates(certificates, private_key, p12_container_password)
+            self._save_certificates(
+                certificates,
+                cast(PrivateKey, private_key),
+                p12_container_password,
+            )
 
         return certificates
 

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -19,6 +19,7 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 from typing import Union
+from typing import cast
 
 from codemagic import cli
 from codemagic.apple import AppStoreConnectApiError
@@ -700,15 +701,18 @@ class AppStoreConnect(
         """
 
         private_key = _get_certificate_key(certificate_key, certificate_key_password)
-        if save and private_key is None:
+        if save and not private_key:
             raise AppStoreConnectError("Cannot save resource without certificate private key")
-        else:
-            assert private_key is not None
 
         certificate = self._get_resource(certificate_resource_id, self.api_client.signing_certificates, should_print)
 
         if save:
-            self._save_certificate(certificate, private_key, p12_container_password, p12_container_save_path)
+            self._save_certificate(
+                certificate,
+                cast(PrivateKey, private_key),
+                p12_container_password,
+                p12_container_save_path,
+            )
         return certificate
 
     @cli.action(


### PR DESCRIPTION
When running `app-store-connect get-certificate <certificate-id>` without `--certificate-key` argument then the action crashes with the following error:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/codemagic/cli/cli_app.py", line 206, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/usr/local/lib/python3.11/site-packages/codemagic/cli/cli_app.py", line 163, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/codemagic/cli/cli_app.py", line 458, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/codemagic/tools/app_store_connect.py", line 706, in get_certificate
    assert private_key is not None
           ^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Ceritficate key is not necessary unless the certificate is to be saved. Changes in this PR remove the assertion that is causing the action to fail.

**Updated actions**
- `app-store-connect get-certificate`