### PR TITLE
Add support for large iOS application packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+Version 0.42.2
+-------------
+
+**Bugfixes**
+- Fix iOS application package abstraction layer in `codemagic.models.application_package.Ipa` to support large archives (exceeding 4GB in size). [PR #342](https://github.com/codemagic-ci-cd/cli-tools/pull/342)
+
 Version 0.42.1
 -------------
 
 **Bugfixes**
-- Do not require certificate private key to show certificate information using `app-store-connect get-certificate` if certificate is not saved to disk. [PR #XYZ](https://github.com/codemagic-ci-cd/cli-tools/pull/XYZ)
+- Do not require certificate private key to show certificate information using `app-store-connect get-certificate` if certificate is not saved to disk. [PR #337](https://github.com/codemagic-ci-cd/cli-tools/pull/337)
 
 Version 0.42.0
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.42.1"
+version = "0.42.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.42.1.dev"
+__version__ = "0.42.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/application_package/ipa.py
+++ b/src/codemagic/models/application_package/ipa.py
@@ -9,6 +9,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 from codemagic.models.certificate import Certificate
@@ -36,7 +37,7 @@ class Ipa(AbstractPackage):
                 with zf.open(found_file_name, "r") as fd:
                     return fd.read()
             except zipfile.BadZipFile as e:
-                extract_command: tuple[Union[str | pathlib.Path], ...]
+                extract_command: Tuple[Union[str | pathlib.Path], ...]
 
                 if str(e) == "Bad magic number for file header":
                     # Big ipas are compressed using lzfse compression format which adds extra bytes to Info-Zip

--- a/src/codemagic/models/application_package/ipa.py
+++ b/src/codemagic/models/application_package/ipa.py
@@ -1,5 +1,6 @@
 import pathlib
 import plistlib
+import shutil
 import subprocess
 import zipfile
 from functools import lru_cache
@@ -21,8 +22,8 @@ class Ipa(AbstractPackage):
     def _validate_package(self):
         try:
             return bool(self.info_plist)
-        except zipfile.BadZipFile as bad_zip_file:
-            raise IOError(f"Not a valid iOS application package at {self.path}") from bad_zip_file
+        except (subprocess.CalledProcessError, zipfile.BadZipFile) as error:
+            raise IOError(f"Not a valid iOS application package at {self.path}") from error
 
     def _extract_file(self, filename_filter: Callable[[str], bool]) -> bytes:
         with zipfile.ZipFile(self.path) as zf:
@@ -35,14 +36,26 @@ class Ipa(AbstractPackage):
                 with zf.open(found_file_name, "r") as fd:
                     return fd.read()
             except zipfile.BadZipFile as e:
+                extract_command: tuple[Union[str | pathlib.Path], ...]
+
                 if str(e) == "Bad magic number for file header":
                     # Big ipas are compressed using lzfse compression format which adds extra bytes to Info-Zip
                     # Unfortunately Python's built-in zip library is not capable to handle those
-                    pass
+                    extract_command = ("unzip", "-p", self.path, found_file_name)
+                elif str(e) == "Truncated file header":
+                    # If the archive size exceeds 4GB then macOS created "corrupt" zip files as it doesn't
+                    # use zip64 specification. 7-Zip is capable of extracting such archives. Let's try that.
+                    if not shutil.which("7z"):
+                        error_message = (
+                            f"Failed to inspect iOS application package at {self.path}. "
+                            f"Please ensure 7-Zip is installed and 7z executable in available in $PATH."
+                        )
+                        raise IOError(error_message) from e
+                    extract_command = ("7z", "x", "-so", self.path, found_file_name)
                 else:
                     raise
 
-            completed_process = subprocess.run(["unzip", "-p", self.path, found_file_name], capture_output=True)
+            completed_process = subprocess.run(extract_command, capture_output=True, check=True)
             return completed_process.stdout
 
     def _get_app_file_contents(self, filename: str) -> bytes:

--- a/src/codemagic/models/application_package/ipa.py
+++ b/src/codemagic/models/application_package/ipa.py
@@ -37,7 +37,7 @@ class Ipa(AbstractPackage):
                 with zf.open(found_file_name, "r") as fd:
                     return fd.read()
             except zipfile.BadZipFile as e:
-                extract_command: Tuple[Union[str | pathlib.Path], ...]
+                extract_command: Tuple[Union[str, pathlib.Path], ...]
 
                 if str(e) == "Bad magic number for file header":
                     # Big ipas are compressed using lzfse compression format which adds extra bytes to Info-Zip


### PR DESCRIPTION
Creating `Ipa` instances from large archives (4+GB) results in the following exception:
```python
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/models/application_package/ipa.py", line 23, in _validate_package
    return bool(self.info_plist)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/models/application_package/ipa.py", line 83, in info_plist
    return self._get_info_plist()
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/models/application_package/ipa.py", line 77, in _get_info_plist
    info_plist_contents = self._get_app_file_contents("Info.plist")
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/models/application_package/ipa.py", line 57, in _get_app_file_contents
    return self._extract_file(filename_filter)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/models/application_package/ipa.py", line 35, in _extract_file
    with zf.open(found_file_name, "r") as fd:
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/zipfile.py", line 1532, in open
    raise BadZipFile("Truncated file header")
zipfile.BadZipFile: Truncated file header
```

Similar error occurs when `unzip` is used:
```shell
$ unzip -p app.ipa Payload/Runner.app/Info.plist
warning [app.ipa]:  17179869184 extra bytes at beginning or within zipfile
  (attempting to process anyway)
file #1:  bad zipfile offset (lseek):  17362427904
```

This is because macOS creates _corrupt_ zip archives when the file size exceeds 4GB (more information on the matter can be read from this SO answer: https://stackoverflow.com/a/59518097). 7-Zip is capable of handling such archives and this PR adds a fallback to use `7z` in case `zipfile.BadZipFile: Truncated file header` error is encountered.