### PR TITLE
Google Play release promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+Version 0.44.0
+-------------
+
+Additions and changes from [pull request #345](https://github.com/codemagic-ci-cd/cli-tools/pull/345).
+
+**Features**
+- Add new action `google-play tracks promote-release` to promote a release from one Google Play release track to another.
+
+**Development**
+- Define new common argument type `bounded_number` for CLI usage that can be used to load floats and integers from CLI inputs within specified ranges.
+- Add new client method `update_track` to update release track in Google Play API client `codemagic.google_play.api_client.GooglePlayDeveloperAPIClient`.
+-
+**Documentation**
+- Update documentation for action group `google-play tracks`.
+- Add documentation for action `google-play tracks promote-release`.
+
 Version 0.43.0
 -------------
 

--- a/docs/google-play/README.md
+++ b/docs/google-play/README.md
@@ -15,7 +15,7 @@ google-play [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/get-latest-build-number.md
+++ b/docs/google-play/get-latest-build-number.md
@@ -28,7 +28,7 @@ Get the build number from the specified track(s). If not specified, the highest 
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/tracks.md
+++ b/docs/google-play/tracks.md
@@ -15,7 +15,7 @@ google-play tracks [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/tracks.md
+++ b/docs/google-play/tracks.md
@@ -48,3 +48,4 @@ Enable verbose logging for commands
 | :--- | :--- |
 |[`get`](tracks/get.md)|Get information about specified track from Google Play Developer API|
 |[`list`](tracks/list.md)|Get information about specified track from Google Play Developer API|
+|[`promote-release`](tracks/promote-release.md)|Promote releases from source track to target track. If filters for source         track release are not specified, then the latest release will be promoted|

--- a/docs/google-play/tracks/get.md
+++ b/docs/google-play/tracks/get.md
@@ -33,7 +33,7 @@ Whether to show the request response in JSON format
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/tracks/list.md
+++ b/docs/google-play/tracks/list.md
@@ -28,7 +28,7 @@ Whether to show the request response in JSON format
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/tracks/promote-release.md
+++ b/docs/google-play/tracks/promote-release.md
@@ -30,13 +30,13 @@ Name of the track from where releases are promoted from. For example `internal`
 ##### `--target-track=TARGET_TRACK_NAME`
 
 
-Name of the track to which releases are promoted to. For example `alpha`
+Name of the track to which releases are promoted. For example `alpha`
 ### Optional arguments for action `promote-release`
 
 ##### `--release-status=statusUnspecified | draft | inProgress | halted | completed`
 
 
-Promoted release status in the target track. Default:&nbsp;`completed`
+Status of the promoted release in the target track. Default:&nbsp;`completed`
 ##### `--user-fraction=PROMOTED_USER_FRACTION`
 
 
@@ -44,11 +44,11 @@ Fraction of users who are eligible for a staged promoted release in the target t
 ##### `--version-code-filter=PROMOTE_VERSION_CODE`
 
 
-Promote only release from source track that contains specified version code
+Promote only a source track release that contains the specified version code
 ##### `--release-status-filter=statusUnspecified | draft | inProgress | halted | completed`
 
 
-Promote only release from source track with specified status
+Promote only a source track release with the specified status
 ##### `--json, -j`
 
 
@@ -58,7 +58,7 @@ Whether to show the request response in JSON format
 ##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
 
 
-Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
 ### Common options
 
 ##### `-h, --help`

--- a/docs/google-play/tracks/promote-release.md
+++ b/docs/google-play/tracks/promote-release.md
@@ -36,11 +36,11 @@ Name of the track to which releases are promoted to. For example `alpha`
 ##### `--release-status=statusUnspecified | draft | inProgress | halted | completed`
 
 
-Release status in a promoted track. Default:&nbsp;`completed`
+Promoted release status in the target track. Default:&nbsp;`completed`
 ##### `--user-fraction=PROMOTED_USER_FRACTION`
 
 
-Fraction of users who are eligible for a staged release in promoted track. Number from interval `0 < fraction < 1`. Can only be set when status is `inProgress` or `halted`
+Fraction of users who are eligible for a staged promoted release in the target track. Number from interval `0 < fraction < 1`. Can only be set when status is `inProgress` or `halted`
 ##### `--version-code-filter=PROMOTE_VERSION_CODE`
 
 

--- a/docs/google-play/tracks/promote-release.md
+++ b/docs/google-play/tracks/promote-release.md
@@ -26,7 +26,7 @@ Package name of the app in Google Play Console. For example `com.example.app`
 ##### `--source-track=SOURCE_TRACK_NAME`
 
 
-Name of the track from where releases are promoted from. For example `internal`
+Name of the track from where releases are promoted. For example `internal`
 ##### `--target-track=TARGET_TRACK_NAME`
 
 

--- a/docs/google-play/tracks/promote-release.md
+++ b/docs/google-play/tracks/promote-release.md
@@ -1,0 +1,87 @@
+
+promote-release
+===============
+
+
+**Promote releases from source track to target track. If filters for source         track release are not specified, then the latest release will be promoted**
+### Usage
+```bash
+google-play tracks promote-release [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--credentials GCLOUD_SERVICE_ACCOUNT_CREDENTIALS]
+    [--release-status PROMOTED_STATUS]
+    [--user-fraction PROMOTED_USER_FRACTION]
+    [--version-code-filter PROMOTE_VERSION_CODE]
+    [--release-status-filter PROMOTE_STATUS]
+    [--json]
+    --package-name PACKAGE_NAME
+    --source-track SOURCE_TRACK_NAME
+    --target-track TARGET_TRACK_NAME
+```
+### Required arguments for action `promote-release`
+
+##### `--package-name, -p=PACKAGE_NAME`
+
+
+Package name of the app in Google Play Console. For example `com.example.app`
+##### `--source-track=SOURCE_TRACK_NAME`
+
+
+Name of the track from where releases are promoted from. For example `internal`
+##### `--target-track=TARGET_TRACK_NAME`
+
+
+Name of the track to which releases are promoted to. For example `alpha`
+### Optional arguments for action `promote-release`
+
+##### `--release-status=statusUnspecified | draft | inProgress | halted | completed`
+
+
+Release status in a promoted track. Default:&nbsp;`completed`
+##### `--user-fraction=PROMOTED_USER_FRACTION`
+
+
+Fraction of users who are eligible for a staged release in promoted track. Number from interval `0 < fraction < 1`. Can only be set when status is `inProgress` or `halted`
+##### `--version-code-filter=PROMOTE_VERSION_CODE`
+
+
+Promote only release from source track that contains specified version code
+##### `--release-status-filter=statusUnspecified | draft | inProgress | halted | completed`
+
+
+Promote only release from source track with specified status
+##### `--json, -j`
+
+
+Whether to show the request response in JSON format
+### Optional arguments for command `google-play`
+
+##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
+
+
+Gcloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.43.0"
+version = "0.44.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.43.0.dev"
+__version__ = "0.44.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/cli/argument/common_argument_types.py
+++ b/src/codemagic/cli/argument/common_argument_types.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import pathlib
 from datetime import datetime
+from typing import Callable
 from typing import Dict
 
 
@@ -74,3 +75,22 @@ class CommonArgumentTypes:
             except ValueError:
                 continue
         raise argparse.ArgumentTypeError(f'"{iso_8601_timestamp}" is not a valid ISO 8601 timestamp')
+
+    @staticmethod
+    def bounded_float(lower_limit: float, upper_limit: float, inclusive: bool) -> Callable[[str], float]:
+        def _bounded_float(number: str):
+            try:
+                f = float(number)
+            except ValueError:
+                raise argparse.ArgumentTypeError(f"Value {number} is not a valid floating point number")
+
+            if inclusive and lower_limit > f or f > upper_limit:
+                error = f"Value {f} is out of allowed bounds, {lower_limit} <= value <= {upper_limit}"
+                raise argparse.ArgumentTypeError(error)
+            if not inclusive and lower_limit >= f or f >= upper_limit:
+                error = f"Value {f} is out of allowed bounds, {lower_limit} < value < {upper_limit}"
+                raise argparse.ArgumentTypeError(error)
+
+            return f
+
+        return _bounded_float

--- a/src/codemagic/google_play/api_client.py
+++ b/src/codemagic/google_play/api_client.py
@@ -171,34 +171,26 @@ class GooglePlayDeveloperAPIClient:
         package_name: str,
         track: Track,
     ) -> Track:
-        with self.use_app_edit(package_name) as _edit:
-            return self._update_track(package_name, track, _edit.id)
-
-    def _update_track(
-        self,
-        package_name: str,
-        track: Track,
-        edit_id: str,
-    ) -> Track:
-        track_update = track.dict()
-        self._logger.debug(
-            f"Update track {track.track!r} for package {package_name} using edit {edit_id} with {track_update!r}",
-        )
-        track_request = self.edits_service.tracks().update(
-            packageName=package_name,
-            editId=edit_id,
-            track=track.track,
-            body=track_update,
-        )
-        commit_request = self.edits_service.commit(
-            packageName=package_name,
-            editId=edit_id,
-        )
-        try:
-            track_response = track_request.execute()
-            commit_response = commit_request.execute()
-        except (errors.Error, errors.HttpError) as e:
-            raise UpdateResourceError("track", package_name, e) from e
+        with self.use_app_edit(package_name) as edit:
+            track_update = track.dict()
+            self._logger.debug(
+                f"Update track {track.track!r} for package {package_name} using edit {edit.id} with {track_update!r}",
+            )
+            track_request = self.edits_service.tracks().update(
+                packageName=package_name,
+                editId=edit.id,
+                track=track.track,
+                body=track_update,
+            )
+            commit_request = self.edits_service.commit(
+                packageName=package_name,
+                editId=edit.id,
+            )
+            try:
+                track_response = track_request.execute()
+                commit_response = commit_request.execute()
+            except (errors.Error, errors.HttpError) as e:
+                raise UpdateResourceError("track", package_name, e) from e
 
         self._logger.debug(f"Track {track.track!r} update response for package {package_name!r}: {track_response}")
         self._logger.debug(f"Track {track.track!r} commit response for package {package_name!r}: {commit_response}")

--- a/src/codemagic/google_play/api_client.py
+++ b/src/codemagic/google_play/api_client.py
@@ -102,6 +102,7 @@ class GooglePlayDeveloperAPIClient:
             self._logger.debug(f"Deleted edit {edit_id} for package {package_name!r}")
         except (errors.Error, errors.HttpError) as e:
             if isinstance(e, errors.HttpError) and "edit has already been successfully committed" in e.error_details:
+                # This can be ignored as the commit has already been exhausted
                 return
             raise EditError("delete", package_name, e) from e
 

--- a/src/codemagic/google_play/api_error.py
+++ b/src/codemagic/google_play/api_error.py
@@ -60,3 +60,11 @@ class ListResourcesError(_RequestError):
             f'Failed to list {resource_description} from Google Play for package "{self.package_name}". '
             f"{self._get_reason()}"
         )
+
+
+class UpdateResourceError(_RequestError):
+    def _get_message(self, resource_description: str) -> str:
+        return (
+            f'Failed to update {resource_description} in Google Play for package "{self.package_name}". '
+            f"{self._get_reason()}"
+        )

--- a/src/codemagic/google_play/resources/__init__.py
+++ b/src/codemagic/google_play/resources/__init__.py
@@ -1,3 +1,4 @@
 from .edit import Edit
+from .enums import ReleaseStatus
 from .resource import Resource
 from .track import Track

--- a/src/codemagic/google_play/resources/__init__.py
+++ b/src/codemagic/google_play/resources/__init__.py
@@ -1,4 +1,5 @@
 from .edit import Edit
 from .enums import ReleaseStatus
 from .resource import Resource
+from .track import Release
 from .track import Track

--- a/src/codemagic/google_play/resources/resource.py
+++ b/src/codemagic/google_play/resources/resource.py
@@ -96,9 +96,9 @@ class Resource(DictSerializable, JsonSerializable):
             return str(value)
 
     def __str__(self) -> str:
-        return "".join(
+        return "\n".join(
             [
-                f"\n{self._format_attribute_name(k)}: {self._format_attribute_value(v)}"
+                f"{self._format_attribute_name(k)}: {self._format_attribute_value(v)}"
                 for k, v in self.__dict__.items()
                 if v is not None
             ],

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -74,7 +74,9 @@ class Track(Resource):
 
     def __post_init__(self):
         if isinstance(self.releases, list):
-            self.releases = [Release(**release) for release in self.releases]
+            self.releases = [
+                release if isinstance(release, Release) else Release(**release) for release in self.releases
+            ]
 
     def get_max_version_code(self) -> int:
         error_prefix = f'Failed to get version code from "{self.track}" track'

--- a/src/codemagic/tools/google_play/action_groups/tracks_action_group.py
+++ b/src/codemagic/tools/google_play/action_groups/tracks_action_group.py
@@ -124,9 +124,8 @@ class TracksActionGroup(GooglePlayBaseAction, metaclass=ABCMeta):
         release_to_promote = dataclasses.replace(
             source_releases[0],
             status=promoted_status,
+            userFraction=promoted_user_fraction,
         )
-        if promoted_user_fraction:
-            release_to_promote.userFraction = promoted_user_fraction
 
         promoted_version_codes = ", ".join(release_to_promote.versionCodes or ["version code N/A"])
         self.logger.info(

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -70,7 +70,7 @@ class PromoteArgument(cli.Argument):
     PROMOTED_USER_FRACTION = cli.ArgumentProperties(
         key="promoted_user_fraction",
         flags=("--user-fraction",),
-        type=cli.CommonArgumentTypes.bounded_float(0, 1, inclusive=False),
+        type=cli.CommonArgumentTypes.bounded_number(float, 0, 1, inclusive=False),
         description=(
             "Fraction of users who are eligible for a staged release in promoted track. "
             f"Number from interval `{Colors.WHITE('0 < fraction < 1')}`. Can only be set when status is "

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -1,4 +1,5 @@
 from codemagic import cli
+from codemagic.cli import Colors
 from codemagic.google_play.resources import ReleaseStatus
 
 from .argument_types import CredentialsArgument
@@ -27,36 +28,69 @@ class TracksArgument(cli.Argument):
         key="package_name",
         flags=("--package-name", "-p"),
         type=PackageName,
-        description="Package name of the app in Google Play Console. For example `com.example.app`",
+        description=(
+            f"Package name of the app in Google Play Console. For example `{Colors.WHITE('com.example.app')}`"
+        ),
         argparse_kwargs={"required": True},
     )
     TRACK_NAME = cli.ArgumentProperties(
         key="track_name",
         flags=("--track", "-t"),
-        description="Release track name. For example `alpha` or `production`",
+        description=f"Release track name. For example `{Colors.WHITE('alpha')}` or `{Colors.WHITE('production')}`",
         argparse_kwargs={"required": True},
     )
 
+
+class PromoteArgument(cli.Argument):
     SOURCE_TRACK_NAME = cli.ArgumentProperties(
         key="source_track_name",
         flags=("--source-track",),
-        description="Name of the track from where releases are promoted from. For example `internal`",
+        description=(
+            f"Name of the track from where releases are promoted from. For example `{Colors.WHITE('internal')}`"
+        ),
         argparse_kwargs={"required": True},
     )
     TARGET_TRACK_NAME = cli.ArgumentProperties(
         key="target_track_name",
         flags=("--target-track",),
-        description="Name of the track to where releases are promoted to. For example `alpha`",
+        description=f"Name of the track to which releases are promoted to. For example `{Colors.WHITE('alpha')}`",
         argparse_kwargs={"required": True},
     )
-    TRACK_PROMOTED_RELEASE_STATUS = cli.ArgumentProperties(
-        key="promoted_release_status",
-        flags=("--promoted-release-status",),
+    PROMOTED_STATUS = cli.ArgumentProperties(
+        key="promoted_status",
+        flags=("--release-status",),
         type=ReleaseStatus,
         description="Release status in a promoted track",
         argparse_kwargs={
             "required": False,
             "default": ReleaseStatus.COMPLETED,
+            "choices": list(ReleaseStatus),
+        },
+    )
+    PROMOTED_USER_FRACTION = cli.ArgumentProperties(
+        key="promoted_user_fraction",
+        flags=("--user-fraction",),
+        type=cli.CommonArgumentTypes.bounded_float(0, 1, inclusive=False),
+        description=(
+            "Fraction of users who are eligible for a staged release in promoted track. "
+            f"Number from interval `{Colors.WHITE('0 < fraction < 1')}`. Can only be set when status is "
+            f"`{Colors.WHITE(str(ReleaseStatus.IN_PROGRESS))}` or `{Colors.WHITE(str(ReleaseStatus.HALTED))}`"
+        ),
+        argparse_kwargs={"required": False},
+    )
+    PROMOTE_VERSION_CODE = cli.ArgumentProperties(
+        key="promote_version_code",
+        flags=("--version-code-filter",),
+        description="Promote only release from source track that contains specified version code",
+        argparse_kwargs={"required": False},
+    )
+    PROMOTE_STATUS = cli.ArgumentProperties(
+        key="promote_status",
+        flags=("--release-status-filter",),
+        type=ReleaseStatus,
+        description="Promote only release from source track with specified status",
+        argparse_kwargs={
+            "required": False,
             "choices": list(ReleaseStatus),
         },
     )

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -11,7 +11,7 @@ class GooglePlayArgument(cli.Argument):
         key="credentials",
         flags=("--credentials",),
         type=CredentialsArgument,
-        description="Gcloud service account credentials with `JSON` key type to access Google Play Developer API",
+        description="Gcloud service account credentials with the `JSON` key type to access Google Play Developer API",
         argparse_kwargs={"required": False},
     )
     JSON_OUTPUT = cli.ArgumentProperties(
@@ -53,14 +53,14 @@ class PromoteArgument(cli.Argument):
     TARGET_TRACK_NAME = cli.ArgumentProperties(
         key="target_track_name",
         flags=("--target-track",),
-        description=f"Name of the track to which releases are promoted to. For example `{Colors.WHITE('alpha')}`",
+        description=f"Name of the track to which releases are promoted. For example `{Colors.WHITE('alpha')}`",
         argparse_kwargs={"required": True},
     )
     PROMOTED_STATUS = cli.ArgumentProperties(
         key="promoted_status",
         flags=("--release-status",),
         type=ReleaseStatus,
-        description="Promoted release status in the target track",
+        description="Status of the promoted release in the target track",
         argparse_kwargs={
             "required": False,
             "default": ReleaseStatus.COMPLETED,
@@ -81,14 +81,14 @@ class PromoteArgument(cli.Argument):
     PROMOTE_VERSION_CODE = cli.ArgumentProperties(
         key="promote_version_code",
         flags=("--version-code-filter",),
-        description="Promote only release from source track that contains specified version code",
+        description="Promote only a source track release that contains the specified version code",
         argparse_kwargs={"required": False},
     )
     PROMOTE_STATUS = cli.ArgumentProperties(
         key="promote_status",
         flags=("--release-status-filter",),
         type=ReleaseStatus,
-        description="Promote only release from source track with specified status",
+        description="Promote only a source track release with the specified status",
         argparse_kwargs={
             "required": False,
             "choices": list(ReleaseStatus),

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -1,4 +1,5 @@
 from codemagic import cli
+from codemagic.google_play.resources import ReleaseStatus
 
 from .argument_types import CredentialsArgument
 from .argument_types import PackageName
@@ -34,6 +35,30 @@ class TracksArgument(cli.Argument):
         flags=("--track", "-t"),
         description="Release track name. For example `alpha` or `production`",
         argparse_kwargs={"required": True},
+    )
+
+    SOURCE_TRACK_NAME = cli.ArgumentProperties(
+        key="source_track_name",
+        flags=("--source-track",),
+        description="Name of the track from where releases are promoted from. For example `internal`",
+        argparse_kwargs={"required": True},
+    )
+    TARGET_TRACK_NAME = cli.ArgumentProperties(
+        key="target_track_name",
+        flags=("--target-track",),
+        description="Name of the track to where releases are promoted to. For example `alpha`",
+        argparse_kwargs={"required": True},
+    )
+    TRACK_PROMOTED_RELEASE_STATUS = cli.ArgumentProperties(
+        key="promoted_release_status",
+        flags=("--promoted-release-status",),
+        type=ReleaseStatus,
+        description="Release status in a promoted track",
+        argparse_kwargs={
+            "required": False,
+            "default": ReleaseStatus.COMPLETED,
+            "choices": list(ReleaseStatus),
+        },
     )
 
 

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -45,9 +45,7 @@ class PromoteArgument(cli.Argument):
     SOURCE_TRACK_NAME = cli.ArgumentProperties(
         key="source_track_name",
         flags=("--source-track",),
-        description=(
-            f"Name of the track from where releases are promoted from. For example `{Colors.WHITE('internal')}`"
-        ),
+        description=(f"Name of the track from where releases are promoted. For example `{Colors.WHITE('internal')}`"),
         argparse_kwargs={"required": True},
     )
     TARGET_TRACK_NAME = cli.ArgumentProperties(

--- a/src/codemagic/tools/google_play/arguments.py
+++ b/src/codemagic/tools/google_play/arguments.py
@@ -60,7 +60,7 @@ class PromoteArgument(cli.Argument):
         key="promoted_status",
         flags=("--release-status",),
         type=ReleaseStatus,
-        description="Release status in a promoted track",
+        description="Promoted release status in the target track",
         argparse_kwargs={
             "required": False,
             "default": ReleaseStatus.COMPLETED,
@@ -72,7 +72,7 @@ class PromoteArgument(cli.Argument):
         flags=("--user-fraction",),
         type=cli.CommonArgumentTypes.bounded_number(float, 0, 1, inclusive=False),
         description=(
-            "Fraction of users who are eligible for a staged release in promoted track. "
+            "Fraction of users who are eligible for a staged promoted release in the target track. "
             f"Number from interval `{Colors.WHITE('0 < fraction < 1')}`. Can only be set when status is "
             f"`{Colors.WHITE(str(ReleaseStatus.IN_PROGRESS))}` or `{Colors.WHITE(str(ReleaseStatus.HALTED))}`"
         ),

--- a/tests/cli/argument/common_argument_types/test_bounded_number.py
+++ b/tests/cli/argument/common_argument_types/test_bounded_number.py
@@ -52,27 +52,21 @@ def test_within_bounds(number_as_string, inclusive_comparison, expected_number):
     assert resolved_value == expected_number
 
 
-@pytest.mark.parametrize(
-    ("out_of_bounds_number_string", "inclusive_comparison"),
-    (
-        ("-1", True),
-        ("0", True),
-        ("11", True),
-        ("20", True),
-        ("-1", False),
-        ("1", False),
-        ("10", False),
-        ("11", False),
-        ("20", False),
-    ),
-)
-def test_out_of_bounds(out_of_bounds_number_string, inclusive_comparison):
-    constructor = CommonArgumentTypes.bounded_number(int, 1, 10, inclusive=inclusive_comparison)
+@pytest.mark.parametrize("out_of_bounds_number_string", ("-1", "0", "11", "20"))
+def test_out_of_bounds_inclusive(out_of_bounds_number_string):
+    constructor = CommonArgumentTypes.bounded_number(int, 1, 10, inclusive=True)
     with pytest.raises(ArgumentTypeError) as error_info:
         constructor(out_of_bounds_number_string)
 
-    comparison_op = "<=" if inclusive_comparison else "<"
-    expected_error_message = (
-        f"Value {out_of_bounds_number_string} is out of allowed bounds, 1 {comparison_op} value {comparison_op} 10"
-    )
+    expected_error_message = f"Value {out_of_bounds_number_string} is out of allowed bounds, 1 <= value <= 10"
+    assert str(error_info.value) == expected_error_message
+
+
+@pytest.mark.parametrize("out_of_bounds_number_string", ("-1", "1", "10", "11", "20"))
+def test_out_of_bounds_exclusive(out_of_bounds_number_string):
+    constructor = CommonArgumentTypes.bounded_number(int, 1, 10, inclusive=False)
+    with pytest.raises(ArgumentTypeError) as error_info:
+        constructor(out_of_bounds_number_string)
+
+    expected_error_message = f"Value {out_of_bounds_number_string} is out of allowed bounds, 1 < value < 10"
     assert str(error_info.value) == expected_error_message

--- a/tests/cli/argument/common_argument_types/test_bounded_number.py
+++ b/tests/cli/argument/common_argument_types/test_bounded_number.py
@@ -1,0 +1,78 @@
+from argparse import ArgumentTypeError
+
+import pytest
+from codemagic.cli.argument import CommonArgumentTypes
+
+
+@pytest.mark.parametrize(
+    ("number_as_string", "requested_type", "expected_number"),
+    (
+        ("1", int, 1),
+        ("1.0", float, 1.0),
+        ("2", int, 2),
+        ("2", float, 2.0),
+    ),
+)
+def test_successful_conversion(number_as_string, requested_type, expected_number):
+    constructor = CommonArgumentTypes.bounded_number(requested_type, -100, 100, inclusive=True)
+    resolved_number = constructor(number_as_string)
+    assert isinstance(resolved_number, requested_type)
+    assert resolved_number == expected_number
+
+
+@pytest.mark.parametrize(
+    ("invalid_number_input", "requested_type", "expected_error_message"),
+    (
+        ("1.0", int, "Value 1.0 is not a valid integer"),
+        ("a", int, "Value a is not a valid integer"),
+        ("?", int, "Value ? is not a valid integer"),
+        ("?", float, "Value ? is not a valid floating point number"),
+        ("x", float, "Value x is not a valid floating point number"),
+    ),
+)
+def test_invalid_input(invalid_number_input, requested_type, expected_error_message):
+    constructor = CommonArgumentTypes.bounded_number(requested_type, -100, 100, inclusive=True)
+    with pytest.raises(ArgumentTypeError) as error_info:
+        constructor(invalid_number_input)
+    assert str(error_info.value) == expected_error_message
+
+
+@pytest.mark.parametrize(
+    ("number_as_string", "inclusive_comparison", "expected_number"),
+    (
+        ("1", True, 1),
+        ("10", True, 10),
+        ("2", False, 2),
+        ("9", False, 9),
+    ),
+)
+def test_within_bounds(number_as_string, inclusive_comparison, expected_number):
+    constructor = CommonArgumentTypes.bounded_number(int, 1, 10, inclusive=inclusive_comparison)
+    resolved_value = constructor(number_as_string)
+    assert resolved_value == expected_number
+
+
+@pytest.mark.parametrize(
+    ("out_of_bounds_number_string", "inclusive_comparison"),
+    (
+        ("-1", True),
+        ("0", True),
+        ("11", True),
+        ("20", True),
+        ("-1", False),
+        ("1", False),
+        ("10", False),
+        ("11", False),
+        ("20", False),
+    ),
+)
+def test_out_of_bounds(out_of_bounds_number_string, inclusive_comparison):
+    constructor = CommonArgumentTypes.bounded_number(int, 1, 10, inclusive=inclusive_comparison)
+    with pytest.raises(ArgumentTypeError) as error_info:
+        constructor(out_of_bounds_number_string)
+
+    comparison_op = "<=" if inclusive_comparison else "<"
+    expected_error_message = (
+        f"Value {out_of_bounds_number_string} is out of allowed bounds, 1 {comparison_op} value {comparison_op} 10"
+    )
+    assert str(error_info.value) == expected_error_message

--- a/tests/google_play/resources/test_resource_print.py
+++ b/tests/google_play/resources/test_resource_print.py
@@ -6,7 +6,6 @@ from codemagic.google_play.resources import Track
 def test_track_string(api_track):
     track = Track(**api_track)
     expected_output = (
-        "\n"
         "Track: internal\n"
         "Releases: [\n"
         "    Status: draft\n"


### PR DESCRIPTION
In Google Play is is possible to promote a release from one release track to another. For example, one might initially publish the release binary (`aab` or `apk`) to be internally tested. Once is tested, then the same version could be promoted to either some broader test track like or directly to production.

This PR introduces new action `google-play tracks promote-release` to promote release from one track to another.

**Example usage:**
```shell
$ google-play tracks promote-release --package-name "io.codemagic.capybara" --source-track "internal" --target-track "alpha" --release-status "draft"
Promote release 1.0.2 (437) from track "internal" to track "alpha"
Successfully completed release promotion to track alpha
Track: alpha
Releases: [
        Status: draft
        Name: 1.0.2
        Version codes: [
                437
        ]
]
```

**New actions**
- `google-play tracks promote-release`

