### PR TITLE
Add option to output version string when querying latest build number from App Store Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
-Version 0.43.0
+Version 0.45.0
 -------------
 
 Additions and changes from [pull request #349](https://github.com/codemagic-ci-cd/cli-tools/pull/349). Resolves [issue #344](https://github.com/codemagic-ci-cd/cli-tools/issues/344).
 
 **Features**
-- TBD ...
+- Add new option `--include-version` to `app-store-connect` actions `get-latest-build-number`, `get-latest-app-store-build-number` and `get-latest-testflight-build-number`. If specified, the action outputs matched build's version string in addition to build number.
 
 **Bugfixes**
-- ...
+- Output valid `JSON` string with `app-store-connect` actions `get-latest-build-number`, `get-latest-app-store-build-number` and `get-latest-testflight-build-number` if `--json` option is specified.
 
 **Docs**
-- ...
+- Documentation was updated for actions:
+  - `app-store-connect get-latest-build-number`,
+  - `app-store-connect get-latest-app-store-build-number`,
+  - `app-store-connect get-latest-testflight-build-number`.
 
 Version 0.44.1
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+Version 0.43.0
+-------------
+
+Additions and changes from [pull request #349](https://github.com/codemagic-ci-cd/cli-tools/pull/349). Resolves [issue #344](https://github.com/codemagic-ci-cd/cli-tools/issues/344).
+
+**Features**
+- TBD ...
+
+**Bugfixes**
+- ...
+
+**Docs**
+- ...
+
 Version 0.44.1
 -------------
 

--- a/docs/app-store-connect/get-latest-app-store-build-number.md
+++ b/docs/app-store-connect/get-latest-app-store-build-number.md
@@ -19,6 +19,7 @@ app-store-connect get-latest-app-store-build-number [-h] [--log-stream STREAM] [
     [--profiles-dir PROFILES_DIRECTORY]
     [--version-string VERSION_STRING]
     [--platform PLATFORM]
+    [--include-version]
     APPLICATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `get-latest-app-store-build-number`
@@ -37,6 +38,10 @@ Version of the build published to App Store that identifies an iteration of the 
 
 
 Apple operating systems
+##### `--include-version`
+
+
+Explicitly show version string in command output in addition to build number
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/get-latest-build-number.md
+++ b/docs/app-store-connect/get-latest-build-number.md
@@ -18,6 +18,7 @@ app-store-connect get-latest-build-number [-h] [--log-stream STREAM] [--no-color
     [--certificates-dir CERTIFICATES_DIRECTORY]
     [--profiles-dir PROFILES_DIRECTORY]
     [--platform PLATFORM]
+    [--include-version]
     APPLICATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `get-latest-build-number`
@@ -32,6 +33,10 @@ Application Apple ID. An automatically generated ID assigned to your app
 
 
 Apple operating systems
+##### `--include-version`
+
+
+Explicitly show version string in command output in addition to build number
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/docs/app-store-connect/get-latest-testflight-build-number.md
+++ b/docs/app-store-connect/get-latest-testflight-build-number.md
@@ -21,6 +21,7 @@ app-store-connect get-latest-testflight-build-number [-h] [--log-stream STREAM] 
     [--platform PLATFORM]
     [--expired]
     [--not-expired]
+    [--include-version]
     APPLICATION_ID_RESOURCE_ID
 ```
 ### Required arguments for action `get-latest-testflight-build-number`
@@ -47,6 +48,10 @@ List only expired builds. Mutually exclusive with option `--not-expired`.
 
 
 List only not expired builds. Mutually exclusive with option `--expired`.
+##### `--include-version`
+
+
+Explicitly show version string in command output in addition to build number
 ### Optional arguments for command `app-store-connect`
 
 ##### `--log-api-calls`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.44.1"
+version = "0.45.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.44.1.dev"
+__version__ = "0.45.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/__init__.py
+++ b/src/codemagic/apple/resources/__init__.py
@@ -8,6 +8,7 @@ from .beta_app_review_submission import BetaAppReviewSubmission
 from .beta_build_localization import BetaBuildLocalization
 from .beta_group import BetaGroup
 from .build import Build
+from .build import BuildVersionInfo
 from .build_beta_detail import BuildBetaDetail
 from .bundle_id import BundleId
 from .bundle_id_capability import BundleIdCapability

--- a/src/codemagic/apple/resources/build.py
+++ b/src/codemagic/apple/resources/build.py
@@ -15,13 +15,13 @@ from .resource import ResourceId
 class BuildVersionInfo(DictSerializable):
     buildId: ResourceId
     version: str
-    build_number: str
+    buildNumber: str
 
     def __str__(self) -> str:
         lines = (
             f"Build Id: {self.buildId}",
             f"Version: {self.version}",
-            f"Build number: {self.build_number}",
+            f"Build number: {self.buildNumber}",
         )
         return "\n".join(lines)
 

--- a/src/codemagic/apple/resources/build.py
+++ b/src/codemagic/apple/resources/build.py
@@ -8,6 +8,22 @@ from .enums import BuildProcessingState
 from .resource import DictSerializable
 from .resource import Relationship
 from .resource import Resource
+from .resource import ResourceId
+
+
+@dataclass
+class BuildVersionInfo(DictSerializable):
+    buildId: ResourceId
+    version: str
+    build_number: str
+
+    def __str__(self) -> str:
+        lines = (
+            f"Build Id: {self.buildId}",
+            f"Version: {self.version}",
+            f"Build number: {self.build_number}",
+        )
+        return "\n".join(lines)
 
 
 @dataclass

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -1139,6 +1139,16 @@ class BuildArgument(cli.Argument):
     )
 
 
+class BuildNumberArgument(cli.Argument):
+    INCLUDE_VERSION = cli.ArgumentProperties(
+        key="include_version",
+        flags=("--include-version",),
+        type=bool,
+        description="Explicitly show version string in command output in addition to build number",
+        argparse_kwargs={"required": False, "action": "store_true"},
+    )
+
+
 class BundleIdArgument(cli.Argument):
     BUNDLE_ID_IDENTIFIER = cli.ArgumentProperties(
         key="bundle_id_identifier",

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -11,7 +11,6 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import Type
-from typing import TypeAlias
 from typing import Union
 
 from codemagic.apple.app_store_connect.resource_manager import R2
@@ -24,9 +23,15 @@ from codemagic.apple.resources import SigningCertificate
 from codemagic.cli import Colors
 from codemagic.utilities import log
 
-JsonSerializable: TypeAlias = (
-    Mapping[str, "JsonSerializable"] | Sequence["JsonSerializable"] | str | int | float | bool | None
-)
+JsonSerializable = Union[
+    Mapping[str, "JsonSerializable"],
+    Sequence["JsonSerializable"],
+    str,
+    int,
+    float,
+    bool,
+    None,
+]
 
 
 class ResourcePrinter:

--- a/src/codemagic/tools/_app_store_connect/resource_printer.py
+++ b/src/codemagic/tools/_app_store_connect/resource_printer.py
@@ -20,12 +20,16 @@ from codemagic.apple.resources import Profile
 from codemagic.apple.resources import Resource
 from codemagic.apple.resources import ResourceId
 from codemagic.apple.resources import SigningCertificate
+from codemagic.apple.resources.resource import DictSerializable
 from codemagic.cli import Colors
+from codemagic.models import JsonSerializable
 from codemagic.utilities import log
 
-JsonSerializable = Union[
-    Mapping[str, "JsonSerializable"],
-    Sequence["JsonSerializable"],
+JsonSerializableT = Union[
+    Mapping[str, "JsonSerializableT"],
+    Sequence["JsonSerializableT"],
+    JsonSerializable,
+    DictSerializable,
     str,
     int,
     float,
@@ -40,11 +44,17 @@ class ResourcePrinter:
         self.logger = log.get_logger(self.__class__)
         self.print = print_function
 
-    def print_value(self, value: JsonSerializable, should_print: bool):
+    def print_value(self, value: JsonSerializableT, should_print: bool):
         if not should_print:
             return
         if self.print_json:
-            self.print(json.dumps(value, indent=4))
+            if isinstance(value, JsonSerializable):
+                serialized = value.json(indent=4)
+            elif isinstance(value, DictSerializable):
+                serialized = json.dumps(value.dict(), indent=4)
+            else:
+                serialized = json.dumps(value, indent=4)
+            self.print(serialized)
         else:
             self.print(str(value))
 

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -384,7 +384,7 @@ class AppStoreConnect(
             return None
 
         self._log_latest_build_info(latest_build_info)
-        self.printer.print_value(latest_build_info.build.attributes.version, True)
+        self.echo(latest_build_info.build.attributes.version)
         return latest_build_info.build.attributes.version
 
     def _log_latest_build_info(self, latest_build_info: _LatestBuildInfo):

--- a/src/codemagic/tools/app_store_connect.py
+++ b/src/codemagic/tools/app_store_connect.py
@@ -409,7 +409,7 @@ class AppStoreConnect(
             build_version_info = BuildVersionInfo(
                 buildId=latest_build_info.build.id,
                 version=version_number,
-                build_number=build_number,
+                buildNumber=build_number,
             )
             self.logger.info(Colors.BLUE("-- Build Version Info --"))
             self.printer.print_value(build_version_info, True)


### PR DESCRIPTION
**Resolves #344.**

Add an option `--include-version` to output build's version name together with build number when querying latest build number with actions
- `app-store-connect get-latest-build-number`,
- `app-store-connect get-latest-app-store-build-number`,
- `app-store-connect get-latest-testflight-build-number`.

<details>
<summary>Example usage</summary>

<img width="1067" alt="Screenshot 2023-09-15 at 13 42 07" src="https://github.com/codemagic-ci-cd/cli-tools/assets/2756611/aa08c37f-66f7-4ca8-8290-53da81c64261">
</details>

If `--include-version` is not specified then the actions still outputs just the build number without any additional fields, even if `--json` is given. That is, constructing next build number using something like
```shell
CURRENT_LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number "$APP_ID")
NEXT_BUILD_NUMBER=$(($CURRENT_LATEST_BUILD_NUMBER + 1))
```
will still work as before.

<details>
<summary>Example usages of obtaining latest build number with and without version inclusion and <code>JSON</code> output.</summary>

<img width="1088" alt="Screenshot 2023-09-15 at 13 41 47" src="https://github.com/codemagic-ci-cd/cli-tools/assets/2756611/7d5b8968-687f-40c0-b8ed-290c5575cf3b">

</details>

**Updated actions**
- `app-store-connect get-latest-build-number`
- `app-store-connect get-latest-app-store-build-number`
- `app-store-connect get-latest-testflight-build-number`