### PR TITLE
Fix `app-store-connect publish` build lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.45.1
+-------------
+
+**Bugfixes**
+- Ensure that build for correct platform is looked up from App Store Connect after initial upload completes using `app-store-connect publish`. [PR #352](https://github.com/codemagic-ci-cd/cli-tools/pull/352)
+
 Version 0.45.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.45.0"
+version = "0.45.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.45.0.dev"
+__version__ = "0.45.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/app_store_connect/builds/builds.py
+++ b/src/codemagic/apple/app_store_connect/builds/builds.py
@@ -15,6 +15,7 @@ from codemagic.apple.resources import Build
 from codemagic.apple.resources import BuildBetaDetail
 from codemagic.apple.resources import BuildProcessingState
 from codemagic.apple.resources import LinkedResourceData
+from codemagic.apple.resources import Platform
 from codemagic.apple.resources import PreReleaseVersion
 from codemagic.apple.resources import Resource
 from codemagic.apple.resources import ResourceId
@@ -42,11 +43,14 @@ class Builds(ResourceManager[Build]):
         beta_app_review_submission_beta_review_state: Optional[Union[BetaReviewState, Sequence[BetaReviewState]]] = None
         version: Optional[Union[str, int]] = None
         pre_release_version_version: Optional[str] = None
+        pre_release_version_platform: Optional[Platform] = None
 
         @classmethod
         def _get_field_name(cls, field_name) -> str:
             if field_name == "pre_release_version_version":
                 field_name = "pre_release_version.version"
+            elif field_name == "pre_release_version_platform":
+                field_name = "pre_release_version.platform"
             elif field_name == "beta_app_review_submission_beta_review_state":
                 field_name = "beta_app_review_submission.beta_review_state"
             return super()._get_field_name(field_name)

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -421,6 +421,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             app=app_id,
             version=application_package.version_code,
             pre_release_version_version=application_package.version,
+            pre_release_version_platform=self._get_application_package_platform(application_package),
         )
         try:
             found_builds = self.api_client.builds.list(builds_filter)

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -424,7 +424,11 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             pre_release_version_platform=self._get_application_package_platform(application_package),
         )
         try:
-            found_builds = self.api_client.builds.list(builds_filter)
+            found_builds = self.api_client.builds.list(
+                builds_filter,
+                ordering=self.api_client.builds.Ordering.UPLOADED_DATE,
+                reverse=True,
+            )
         except AppStoreConnectApiError as api_error:
             raise AppStoreConnectError(str(api_error))
 


### PR DESCRIPTION
**Resolves #346.**

PR #340 added support to publish macOS applications to TestFlight and App Store using `app-store-connect publish`. To submit uploaded binary to either we first need to get the build reference in App Store Connect. The method which is responsible for build lookup only filtered the builds by application identifier and version, but it did not take application platform into account.

Consequently old(er) iOS build could have been found for a currently published macOS application (or vice versa) as long as both shared the same version string and build number.

To avoid such situations also filter the builds by platform and reverse order to have most recent uploads in the head of the returned builds list.

**Updated actions**
- `app-store-connect publish`