### PR TITLE
Add note that `--cancel-previous-submissions` does not work for TestFlight submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version UNRELEASED
+-------------
+
+**Docs**
+- Update option `--cancel-previous-submissions` documentation for actions `app-store-connect builds submit-to-app-store` and `app-store-connect publish`. [PR #353](https://github.com/codemagic-ci-cd/cli-tools/pull/353)
+
+
 Version 0.45.3
 -------------
 

--- a/docs/app-store-connect/builds/submit-to-app-store.md
+++ b/docs/app-store-connect/builds/submit-to-app-store.md
@@ -50,7 +50,7 @@ Maximum amount of minutes to wait for the freshly uploaded build to be processed
 ##### `--cancel-previous-submissions`
 
 
-Cancels previous App Store submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible. This option is not available for TestFlight submissions.
+Cancels previous submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible.
 ##### `--app-store-version-info, -vi=APP_STORE_VERSION_INFO`
 
 

--- a/docs/app-store-connect/builds/submit-to-app-store.md
+++ b/docs/app-store-connect/builds/submit-to-app-store.md
@@ -50,7 +50,7 @@ Maximum amount of minutes to wait for the freshly uploaded build to be processed
 ##### `--cancel-previous-submissions`
 
 
-Cancels previous submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible.
+Cancels previous App Store submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible. This option is not available for TestFlight submissions.
 ##### `--app-store-version-info, -vi=APP_STORE_VERSION_INFO`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -113,7 +113,7 @@ App Store Version platform
 ##### `--cancel-previous-submissions`
 
 
-Cancels previous submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible.
+Cancels previous App Store submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible. This option is not available for TestFlight submissions.
 ##### `--app-store-version-info, -vi=APP_STORE_VERSION_INFO`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -113,7 +113,7 @@ App Store Version platform
 ##### `--cancel-previous-submissions`
 
 
-Cancels previous App Store submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible. This option is not available for TestFlight submissions.
+Cancels previous submissions for the application in App Store Connect before creating a new submission if the submissions are in a state where it is possible.
 ##### `--app-store-version-info, -vi=APP_STORE_VERSION_INFO`
 
 

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -931,8 +931,9 @@ class PublishArgument(cli.Argument):
         flags=("--cancel-previous-submissions",),
         type=bool,
         description=(
-            "Cancels previous submissions for the application in App Store Connect "
-            "before creating a new submission if the submissions are in a state where it is possible."
+            "Cancels previous App Store submissions for the application in App Store Connect "
+            "before creating a new submission if the submissions are in a state where it is possible. "
+            "This option is not available for TestFlight submissions."
         ),
         argparse_kwargs={
             "required": False,


### PR DESCRIPTION
From what I understand, is it not possible to cancel TestFlight submissions, right? I found the question "[Delete Beta App Review Submission via App Store Connect API](https://developer.apple.com/forums/thread/680143)" in the apple forum which asks this question. Still today, I can't find a delete option in the [API docs](https://developer.apple.com/documentation/appstoreconnectapi/prerelease_versions_and_beta_testers/beta_app_review_submissions).

When reading the docs for `app-store-connect publish` I thought it would also delete the previous TestFlight submissions when using the `--testflight` flag. I tried it out, but it didn't work (see [logs](https://github.com/SharezoneApp/sharezone-app/actions/runs/6248488396/job/16963390721)). Therefore, I clarified the docs about `--cancel-previous-submissions`.
