### PR TITLE
Add option to configure timeout for finding build from App Store Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Version 0.46.0
+-------------
+
+**Features**
+- Add new option `--max-find-build-wait` to action `app-store-connect publish` to configure maximum waiting time to discover uploaded build from App Store Connect before failing publishing. Defaults to 10 minutes. [PR #355](https://github.com/codemagic-ci-cd/cli-tools/pull/355)
+
+**Docs**
+- Update documentation for `app-store-connect publish`.
+
 Version 0.45.1
 -------------
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -78,7 +78,7 @@ Skip package upload before doing any other TestFlight or App Store related actio
 ##### `--max-find-build-wait=MAX_BUILD_FIND_WAIT`
 
 
-The maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission to TestFlight or App Store. Works in conjunction with TestFlight beta review submission or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
+The maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect. Works in conjunction with TestFlight beta review submission or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
 ##### `--max-build-processing-wait, -w=MAX_BUILD_PROCESSING_WAIT`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -23,6 +23,7 @@ app-store-connect publish [-h] [--log-stream STREAM] [--no-color] [--version] [-
     [--enable-package-validation]
     [--skip-package-validation]
     [--skip-package-upload]
+    [--max-find-build-wait MAX_BUILD_FIND_WAIT]
     [--max-build-processing-wait MAX_BUILD_PROCESSING_WAIT]
     [--beta-build-localizations BETA_BUILD_LOCALIZATIONS]
     [--testflight]
@@ -74,6 +75,10 @@ Validate package before uploading it to App Store Connect. Use this switch to en
 
 
 Skip package upload before doing any other TestFlight or App Store related actions. Using this switch will opt out from running `altool --upload-app` as part of publishing action. Use this option in case your application package is already uploaded to App Store. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_SKIP_PACKAGE_UPLOAD`.
+##### `--max-find-build-wait=MAX_BUILD_FIND_WAIT`
+
+
+Maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission TestFlight or App Store. Works in conjunction with TestFlight beta review submission, or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. Waiting will be skipped if the value is set to 0, further actions will fail if the build is not found. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
 ##### `--max-build-processing-wait, -w=MAX_BUILD_PROCESSING_WAIT`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -78,7 +78,7 @@ Skip package upload before doing any other TestFlight or App Store related actio
 ##### `--max-find-build-wait=MAX_BUILD_FIND_WAIT`
 
 
-Maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission TestFlight or App Store. Works in conjunction with TestFlight beta review submission, or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
+The maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission to TestFlight or App Store. Works in conjunction with TestFlight beta review submission or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
 ##### `--max-build-processing-wait, -w=MAX_BUILD_PROCESSING_WAIT`
 
 

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -78,7 +78,7 @@ Skip package upload before doing any other TestFlight or App Store related actio
 ##### `--max-find-build-wait=MAX_BUILD_FIND_WAIT`
 
 
-Maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission TestFlight or App Store. Works in conjunction with TestFlight beta review submission, or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. Waiting will be skipped if the value is set to 0, further actions will fail if the build is not found. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
+Maximum amount of minutes to wait for the freshly uploaded build to become discoverable in App Store Connect before proceeding with submission TestFlight or App Store. Works in conjunction with TestFlight beta review submission, or App Store review submission and operations that depend on either one of those. If the build does not become available within the specified timeframe, further submission will be terminated. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT`. [Default: 10]
 ##### `--max-build-processing-wait, -w=MAX_BUILD_PROCESSING_WAIT`
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.45.1"
+version = "0.46.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.45.1.dev"
+__version__ = "0.46.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -429,7 +429,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             pre_release_version_platform=self._get_application_package_platform(application_package),
         )
 
-        not_found_message = "Could not find the build matching uploaded version"
+        not_found_message = "Could not find the build matching the uploaded version"
         default_retry_message = f"{not_found_message}, waiting {retry_wait_seconds} seconds to try again."
         first_retry_message = (
             f"Build has finished uploading but is not available in App Store Connect yet. "

--- a/src/codemagic/tools/_app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/_app_store_connect/actions/publish_action.py
@@ -86,6 +86,7 @@ ACTION_ARGUMENTS = (
     PublishArgument.APPLE_ID,
     PublishArgument.APP_SPECIFIC_PASSWORD,
     *ArgumentGroups.PACKAGE_UPLOAD_ARGUMENTS,
+    PublishArgument.MAX_BUILD_FIND_WAIT,
     PublishArgument.MAX_BUILD_PROCESSING_WAIT,
     *PublishArgument.with_custom_argument_group(
         "add localized What's new (what to test) information to uploaded build",
@@ -286,6 +287,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         altool_retries_count: Optional[Types.AltoolRetriesCount] = None,
         altool_retry_wait: Optional[Types.AltoolRetryWait] = None,
         altool_verbose_logging: Optional[bool] = None,
+        max_find_build_wait: Union[Types.MaxFindBuildWait, int] = PublishArgument.MAX_BUILD_FIND_WAIT.get_default(),
         **app_store_connect_submit_options,
     ) -> None:
         """
@@ -318,6 +320,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 )
                 self._process_application_after_upload(
                     application_package,
+                    Types.MaxFindBuildWait.resolve_value(max_find_build_wait),
                     *self._get_app_store_connect_submit_options(
                         application_package,
                         submit_to_testflight,
@@ -369,6 +372,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
     def _process_application_after_upload(
         self,
         application_package: Union[Ipa, MacOsPackage],
+        max_find_build_wait: int,
         testflight_options: Optional[SubmitToTestFlightOptions],
         app_store_options: Optional[SubmitToAppStoreOptions],
         beta_test_info_options: Optional[AddBetaTestInfoOptions],
@@ -378,7 +382,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             return  # Nothing to do with the application...
 
         app = self._get_uploaded_build_application(application_package)
-        build = self._get_uploaded_build(app, application_package)
+        build = self._get_uploaded_build(app, application_package, max_find_build_wait)
 
         if beta_test_info_options:
             self.add_beta_test_info(build.id, **beta_test_info_options.__dict__)
@@ -408,8 +412,8 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self,
         app_id: ResourceId,
         application_package: Union[Ipa, MacOsPackage],
-        retries: int = 20,
-        retry_wait_seconds: int = 30,
+        max_find_build_minutes: int,
+        retry_wait_seconds: int,
     ) -> Build:
         """
         Find corresponding build for the uploaded ipa or macOS package.
@@ -423,44 +427,46 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             pre_release_version_version=application_package.version,
             pre_release_version_platform=self._get_application_package_platform(application_package),
         )
-        try:
-            found_builds = self.api_client.builds.list(
-                builds_filter,
-                ordering=self.api_client.builds.Ordering.UPLOADED_DATE,
-                reverse=True,
-            )
-        except AppStoreConnectApiError as api_error:
-            raise AppStoreConnectError(str(api_error))
 
-        if found_builds:
-            return found_builds[0]
+        not_found_message = "Could not find the build matching the uploaded version"
+        default_retry_message = f"{not_found_message}, waiting {retry_wait_seconds} seconds to try again."
+        first_retry_message = (
+            f"Build has finished uploading but is not available in App Store Connect yet. "
+            f"{default_retry_message} Timeout in {max_find_build_minutes} minutes."
+        )
 
-        # Matching build was not found.
-        if retries > 0:
-            # There are retries left, wait a bit and try again.
-            self.logger.info(
-                (
-                    "Build has finished uploading but is processing on App Store Connect side. Could not find the "
-                    "build matching the uploaded version yet. Waiting %d seconds to try again, %d attempts remaining."
-                ),
-                retry_wait_seconds,
-                retries,
-            )
-            time.sleep(retry_wait_seconds)
-            return self._find_build(
-                app_id,
-                application_package,
-                retries=retries - 1,
-                retry_wait_seconds=retry_wait_seconds,
-            )
-        else:
-            # There are no more retries left, give up.
-            raise IOError(
-                "The build was successfully uploaded to App Store Connect but processing the corresponding artifact "
-                f'"{application_package.path}" by Apple took longer than expected. Further actions like updating the '
-                "What to test information or submitting the build to beta review could not be performed at the moment "
-                "but can be completed manually in TestFlight once the build has finished processing.",
-            )
+        find_started_at = time.time()
+        first_attempt = True
+        while True:
+            try:
+                found_builds = self.api_client.builds.list(
+                    builds_filter,
+                    ordering=self.api_client.builds.Ordering.UPLOADED_DATE,
+                    reverse=True,
+                )
+            except AppStoreConnectApiError as api_error:
+                raise AppStoreConnectError(str(api_error))
+
+            if found_builds:
+                return found_builds[0]
+
+            if time.time() - find_started_at < max_find_build_minutes * 60:
+                self.logger.info(first_retry_message if first_attempt else default_retry_message)
+                time.sleep(retry_wait_seconds)
+                first_attempt = False
+            else:
+                self.logger.info(f"{not_found_message}. Timeout reached, stop trying.")
+                break  # No more time left, give up.
+
+        error_message = (
+            "The build was successfully uploaded to App Store Connect but processing the corresponding artifact "
+            f'"{application_package.path}" by Apple took longer than expected. Further actions like updating the '
+            '"What to test information" or submitting the build to beta review could not be performed at the moment '
+            "but can be completed manually in TestFlight once the build has finished processing.\n"
+            f"You can configure maximum timeout using {PublishArgument.MAX_BUILD_FIND_WAIT.flag} "
+            f"command line option, or {Types.MaxFindBuildWait.environment_variable_key} environment variable."
+        )
+        raise IOError(error_message)
 
     def _get_uploaded_build_application(self, application_package: Union[Ipa, MacOsPackage]) -> App:
         bundle_id = application_package.bundle_identifier
@@ -481,9 +487,16 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self,
         app: App,
         application_package: Union[Ipa, MacOsPackage],
+        max_find_build_minutes: int,
+        retry_wait_seconds: int = 30,
     ) -> Build:
         self.logger.info(Colors.BLUE("\nFind uploaded build"))
-        build = self._find_build(app.id, application_package)
+        build = self._find_build(
+            app.id,
+            application_package,
+            max_find_build_minutes,
+            retry_wait_seconds,
+        )
         self.logger.info(Colors.GREEN("\nUploaded build is"))
         self.printer.print_resource(build, True)
         return build

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -917,9 +917,7 @@ class PublishArgument(cli.Argument):
             "in App Store Connect before proceeding with submission TestFlight or App Store. "
             "Works in conjunction with TestFlight beta review submission, or App Store review submission "
             "and operations that depend on either one of those. If the build does not become available "
-            "within the specified timeframe, further submission will be terminated. "
-            "Waiting will be skipped if the value is set to 0, further actions will fail "
-            "if the build is not found."
+            "within the specified timeframe, further submission will be terminated."
         ),
         argparse_kwargs={
             "required": False,

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -913,9 +913,9 @@ class PublishArgument(cli.Argument):
         flags=("--max-find-build-wait",),
         type=Types.MaxFindBuildWait,
         description=(
-            "Maximum amount of minutes to wait for the freshly uploaded build to become discoverable "
-            "in App Store Connect before proceeding with submission TestFlight or App Store. "
-            "Works in conjunction with TestFlight beta review submission, or App Store review submission "
+            "The maximum amount of minutes to wait for the freshly uploaded build to become discoverable "
+            "in App Store Connect before proceeding with submission to TestFlight or App Store. "
+            "Works in conjunction with TestFlight beta review submission or App Store review submission "
             "and operations that depend on either one of those. If the build does not become available "
             "within the specified timeframe, further submission will be terminated."
         ),

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -923,7 +923,6 @@ class PublishArgument(cli.Argument):
         ),
         argparse_kwargs={
             "required": False,
-            "default": Types.MaxFindBuildWait.default_value,
         },
     )
     MAX_BUILD_PROCESSING_WAIT = cli.ArgumentProperties(
@@ -941,7 +940,6 @@ class PublishArgument(cli.Argument):
         ),
         argparse_kwargs={
             "required": False,
-            "default": Types.MaxBuildProcessingWait.default_value,
         },
     )
     EXPIRE_BUILD_SUBMITTED_FOR_REVIEW = cli.ArgumentProperties(

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -913,11 +913,12 @@ class PublishArgument(cli.Argument):
         flags=("--max-find-build-wait",),
         type=Types.MaxFindBuildWait,
         description=(
-            "The maximum amount of minutes to wait for the freshly uploaded build to become discoverable "
-            "in App Store Connect before proceeding with submission to TestFlight or App Store. "
-            "Works in conjunction with TestFlight beta review submission or App Store review submission "
-            "and operations that depend on either one of those. If the build does not become available "
-            "within the specified timeframe, further submission will be terminated."
+            "The maximum amount of minutes to wait for the freshly uploaded build "
+            "to become discoverable in App Store Connect. Works in conjunction with "
+            "TestFlight beta review submission or App Store review submission and "
+            "operations that depend on either one of those. If the build does not "
+            "become available within the specified timeframe, further submission "
+            "will be terminated."
         ),
         argparse_kwargs={
             "required": False,

--- a/src/codemagic/tools/_app_store_connect/arguments.py
+++ b/src/codemagic/tools/_app_store_connect/arguments.py
@@ -147,6 +147,15 @@ class Types:
         argument_type = bool
         environment_variable_key = "APP_STORE_CONNECT_ALTOOL_VERBOSE_LOGGING"
 
+    class MaxFindBuildWait(cli.TypedCliArgument[int]):
+        argument_type = int
+        environment_variable_key = "APP_STORE_CONNECT_MAX_FIND_BUILD_WAIT"
+        default_value = 10
+
+        @classmethod
+        def _is_valid(cls, value: int) -> bool:
+            return value > 0
+
     class MaxBuildProcessingWait(cli.TypedCliArgument[int]):
         argument_type = int
         environment_variable_key = "APP_STORE_CONNECT_MAX_BUILD_PROCESSING_WAIT"
@@ -899,6 +908,24 @@ class PublishArgument(cli.Argument):
             "required": False,
         },
     )
+    MAX_BUILD_FIND_WAIT = cli.ArgumentProperties(
+        key="max_find_build_wait",
+        flags=("--max-find-build-wait",),
+        type=Types.MaxFindBuildWait,
+        description=(
+            "Maximum amount of minutes to wait for the freshly uploaded build to become discoverable "
+            "in App Store Connect before proceeding with submission TestFlight or App Store. "
+            "Works in conjunction with TestFlight beta review submission, or App Store review submission "
+            "and operations that depend on either one of those. If the build does not become available "
+            "within the specified timeframe, further submission will be terminated. "
+            "Waiting will be skipped if the value is set to 0, further actions will fail "
+            "if the build is not found."
+        ),
+        argparse_kwargs={
+            "required": False,
+            "default": Types.MaxFindBuildWait.default_value,
+        },
+    )
     MAX_BUILD_PROCESSING_WAIT = cli.ArgumentProperties(
         key="max_build_processing_wait",
         flags=("--max-build-processing-wait", "-w"),
@@ -914,6 +941,7 @@ class PublishArgument(cli.Argument):
         ),
         argparse_kwargs={
             "required": False,
+            "default": Types.MaxBuildProcessingWait.default_value,
         },
     )
     EXPIRE_BUILD_SUBMITTED_FOR_REVIEW = cli.ArgumentProperties(


### PR DESCRIPTION
**Resolves #350.**

Once a binary is uploaded to Apple using `app-store-connect publish` it can take quite some time for the corresponding build to appear in App Store Connect UI and API responses. Build reference is needed to automatically submit the freshly uploaded version to TestFlight or App Store right after publishing.

For now there is a fixed 10 minute timeout period to find the build after upload completes. Occasionally this does not suffice and consequently publishing as a whole fails.

Changes in this pull request introduce new command line option `--max-find-build-wait` which can be used to configure the duration of the waiting period before.

![Screenshot 2023-09-25 at 15 36 15](https://github.com/codemagic-ci-cd/cli-tools/assets/2756611/2c7241a3-998f-4b93-988c-b74df4054bbd)

**Updated actions**
- `app-store-connect publish`
