### PR TITLE
Add support for large iOS application packages x2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.45.2
+-------------
+
+**Bugfixes**
+- Fix initializing `codemagic.models.application_package.Ipa` objects for big binaries (exceeding 4GB in size). [PR #356](https://github.com/codemagic-ci-cd/cli-tools/pull/356)
+
 Version 0.45.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.45.1"
+version = "0.45.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.45.1.dev"
+__version__ = "0.45.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/application_package/abstract_package.py
+++ b/src/codemagic/models/application_package/abstract_package.py
@@ -8,10 +8,12 @@ from typing import Optional
 from typing import Union
 
 from codemagic.mixins import StringConverterMixin
+from codemagic.utilities import log
 
 
 class AbstractPackage(StringConverterMixin, metaclass=abc.ABCMeta):
     def __init__(self, path: Union[pathlib.Path, AnyStr]):
+        self._logger = log.get_file_logger(self.__class__)
         if isinstance(path, (bytes, str)):
             self.path = pathlib.Path(self._str(path))
         else:

--- a/src/codemagic/models/application_package/ipa.py
+++ b/src/codemagic/models/application_package/ipa.py
@@ -63,7 +63,7 @@ class Ipa(AbstractPackage):
         else:
             command_args = ("unzip", "-p", self.path, file_path_in_archive)
 
-        command = shlex.join(map(str, command_args))
+        command = " ".join(shlex.quote(str(arg)) for arg in command_args)
         self._logger.debug(f"Running {command!r}")
 
         try:


### PR DESCRIPTION
Follow up to PR #342.

Extracting files from ipa files can fail with `Bad magic number for file header` error even if the binary is exceptionally large (>4GB).

Full stacktrace:
```python
[18:38:23 29-09-2023] WARNING cli_app.py:114 > Executing AppStoreConnect action publish failed unexpectedly. Detailed logs are available at "/var/folders/vs/tcrc5cns67zgynxt6fssjdg80000gn/T/codemagic-29-09-23.log". To see more details about the error, add `--verbose` command line option.
[18:38:23 29-09-2023] ERROR cli_app.py:116 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 25, in _validate_package
    return bool(self.info_plist)
                ^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 97, in info_plist
    return self._get_info_plist()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 91, in _get_info_plist
    info_plist_contents = self._get_app_file_contents("Info.plist")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 71, in _get_app_file_contents
    return self._extract_file(filename_filter)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 59, in _extract_file
    completed_process = subprocess.run(extract_command, capture_output=True, check=True)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.11.2/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('unzip', '-p', PosixPath('zip_error.ipa'), 'Payload/Runner.app/Info.plist')' returned non-zero exit status 2.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 206, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 163, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 458, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/tools/_app_store_connect/actions/publish_action.py", line 305, in publish
    application_packages = self._get_publishing_application_packages(application_package_path_patterns)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/tools/_app_store_connect/actions/publish_action.py", line 505, in _get_publishing_application_packages
    application_package: Union[Ipa, MacOsPackage] = Ipa(path)
                                                    ^^^^^^^^^
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/abstract_package.py", line 19, in __init__
    self._validate_package()
  File "/Users/priit/nevercode/cli-tools/src/codemagic/models/application_package/ipa.py", line 27, in _validate_package
    raise IOError(f"Not a valid iOS application package at {self.path}") from error
OSError: Not a valid iOS application package at zip_error.ipa
```

It is known that `unzip` is not able to handle files this big, but `7z` is capable of extracting components from there. Use `7z` whenever it is available in place of `unzip`.