### PR TITLE
Bugfix: Support Apple Vision Pro device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.45.3
+-------------
+
+**Bugfixes**
+- Support Apple Vision Pro devices in App Store Connect API read device information and list devices endpoints. This is done by declaring `APPLE_VISION_PRO` definition in enumeration `codemagic.apple.resources.enums.DeviceClass`. [PR #357](https://github.com/codemagic-ci-cd/cli-tools/pull/357)
+
 Version 0.45.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.45.2"
+version = "0.45.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.45.2.dev"
+__version__ = "0.45.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -145,6 +145,7 @@ class ContentRightsDeclaration(ResourceEnum):
 
 class DeviceClass(ResourceEnum):
     APPLE_TV = "APPLE_TV"
+    APPLE_VISION_PRO = "APPLE_VISION_PRO"
     APPLE_WATCH = "APPLE_WATCH"
     IPAD = "IPAD"
     IPHONE = "IPHONE"
@@ -158,6 +159,7 @@ class DeviceClass(ResourceEnum):
             return self is DeviceClass.MAC
         else:
             return self in (
+                DeviceClass.APPLE_VISION_PRO,
                 DeviceClass.APPLE_WATCH,
                 DeviceClass.IPAD,
                 DeviceClass.IPOD,


### PR DESCRIPTION
[Read Device Information](https://developer.apple.com/documentation/appstoreconnectapi/read_device_information) and [List Devices](https://developer.apple.com/documentation/appstoreconnectapi/list_devices) App Store Connect API endpoints can return [devices](https://developer.apple.com/documentation/appstoreconnectapi/device/attributes) whose `deviceClass` attribute value is `APPLE_VISION_PRO`.

As of now such a device class is not supported and causes issues when the device class info is used, such as
```python
[07:54:38 02-10-2023] ERROR cli_app.py:116 > Exception traceback:
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 206, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 163, in _invoke_action
    return cli_action(**action_args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 458, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 1058, in fetch_signing_files
    profiles = self._get_or_create_profiles(
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 1212, in _get_or_create_profiles
    profiles.extend(created_profiles)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 1148, in _create_missing_profiles
    device_ids = [d.id for d in devices if d.attributes.deviceClass.is_compatible(profile_type)]
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect.py", line 1148, in <listcomp>
    device_ids = [d.id for d in devices if d.attributes.deviceClass.is_compatible(profile_type)]
AttributeError: 'GracefulDeviceClass' object has no attribute 'is_compatible'
```

This PR defines `APPLE_VISION_PRO` value for enumeration `codemagic.apple.resources.enums.DeviceClass`.

