### PR TITLE
Fix Google Play release promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.46.1
+-------------
+
+**Bugfixes**
+- Fix Google Play release promotion with action `google-play tracks promote-release` for releases that have release notes. [PR #361](https://github.com/codemagic-ci-cd/cli-tools/pull/361)
+
 Version 0.46.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.46.0"
+version = "0.46.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.46.0.dev"
+__version__ = "0.46.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google_play/resources/track.py
+++ b/src/codemagic/google_play/resources/track.py
@@ -54,7 +54,9 @@ class Release(Resource):
 
     def __post_init__(self):
         if isinstance(self.releaseNotes, list):
-            self.releaseNotes = [LocalizedText(**note) for note in self.releaseNotes]
+            self.releaseNotes = [
+                note if isinstance(note, LocalizedText) else LocalizedText(**note) for note in self.releaseNotes
+            ]
         if isinstance(self.status, str):
             self.status = ReleaseStatus(self.status)
         if isinstance(self.countryTargeting, dict):

--- a/tests/google_play/resources/test_track_resource.py
+++ b/tests/google_play/resources/test_track_resource.py
@@ -6,6 +6,8 @@ import pytest
 from codemagic.google_play.resources import Release
 from codemagic.google_play.resources import ReleaseStatus
 from codemagic.google_play.resources import Track
+from codemagic.google_play.resources.track import CountryTargeting
+from codemagic.google_play.resources.track import LocalizedText
 
 
 def test_track_initialization(api_track):
@@ -35,17 +37,30 @@ def test_max_version_code_error_no_version_codes(api_track):
     assert str(e.value) == 'Failed to get version code from "internal" track: releases with version code do not exist'
 
 
-def test_release_duplication():
-    source_release = Release(
+def test_release():
+    release = Release(
         **{
             "name": "1.2.3",
             "versionCodes": ["123"],
-            "releaseNotes": [{"language": "en-US", "text": "* Release notes\n\nwith some new lines"}],
+            "releaseNotes": [{"language": "en-US", "text": "* Release\n\nnotes"}],
             "status": "draft",
         },
     )
+
+    assert release.name == "1.2.3"
+    assert release.versionCodes == ["123"]
+    assert release.releaseNotes == [LocalizedText(language="en-US", text="* Release\n\nnotes")]
+    assert release.status is ReleaseStatus.DRAFT
+    assert release.countryTargeting is None
+
     updated_release = dataclasses.replace(
-        source_release,
+        release,
         status=ReleaseStatus.COMPLETED,
+        countryTargeting={"countries": ["EE", "GB"], "includeRestOfWorld": False},  # type: ignore
     )
+
+    assert updated_release.name == release.name
+    assert updated_release.versionCodes == release.versionCodes
+    assert updated_release.releaseNotes == release.releaseNotes
     assert updated_release.status is ReleaseStatus.COMPLETED
+    assert updated_release.countryTargeting == CountryTargeting(countries=["EE", "GB"], includeRestOfWorld=False)

--- a/tests/google_play/resources/test_track_resource.py
+++ b/tests/google_play/resources/test_track_resource.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
+from codemagic.google_play.resources import Release
+from codemagic.google_play.resources import ReleaseStatus
 from codemagic.google_play.resources import Track
 
 
@@ -29,3 +33,19 @@ def test_max_version_code_error_no_version_codes(api_track):
     with pytest.raises(ValueError) as e:
         track.get_max_version_code()
     assert str(e.value) == 'Failed to get version code from "internal" track: releases with version code do not exist'
+
+
+def test_release_duplication():
+    source_release = Release(
+        **{
+            "name": "1.2.3",
+            "versionCodes": ["123"],
+            "releaseNotes": [{"language": "en-US", "text": "* Release notes\n\nwith some new lines"}],
+            "status": "draft",
+        },
+    )
+    updated_release = dataclasses.replace(
+        source_release,
+        status=ReleaseStatus.COMPLETED,
+    )
+    assert updated_release.status is ReleaseStatus.COMPLETED


### PR DESCRIPTION
**Fixes #360**

There is a bug in `codemagic.google_play.resources.Release` initialization due to naive expectation in `__post_init__` method that release notes are always passed as lists of dictionaries like they come from Google Play API responses. It should also be possible to initialize the object in case the notes are given with their expected target type `List[LocalizedText]`.

One possible consequence of this is that duplicating release with notes fails with the following error:

```python
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/dataclasses.py:1579: in replace
    return obj.__class__(**changes)
<string>:10: in __init__
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Release(status=<ReleaseStatus.COMPLETED: 'completed'>, name='1.2.3', userFraction=None, countryTargeting={'countries':...ppUpdatePriority=None, versionCodes=['123'], releaseNotes=[LocalizedText(language='en-US', text='* Release\n\nnotes')])

    def __post_init__(self):
        if isinstance(self.releaseNotes, list):
>           self.releaseNotes = [LocalizedText(**note) for note in self.releaseNotes]
E           TypeError: codemagic.google_play.resources.track.LocalizedText() argument after ** must be a mapping, not LocalizedText

../../../src/codemagic/google_play/resources/track.py:60: TypeError
```

Update `__post_init__` so that release notes that are already of type `LocalizedText` are left in place.

**Updated actions:**
- `google-play tracks promote-release`
