### PR TITLE
Update GitHb Action CI jobs

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -74,3 +74,38 @@ jobs:
 
     - name: Test with pytest
       run: poetry run pytest
+
+  test-py-3-12:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.12
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        curl -sSL https://install.python-poetry.org | python
+        poetry config virtualenvs.in-project true
+        poetry install --no-interaction
+
+    - name: Check code formatting
+      run: |
+        poetry run black --check .
+        poetry run ruff check .
+
+    - name: Static type checks with mypy
+      run: poetry run mypy .
+
+    - name: Test with pytest
+      run: poetry run pytest

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-7
         restore-keys: |
           ${{ runner.os }}-pip-
 
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-11
         restore-keys: |
           ${{ runner.os }}-pip-
 
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-12
         restore-keys: |
           ${{ runner.os }}-pip-
 

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.12
 

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-7
@@ -44,14 +44,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-11
@@ -79,14 +79,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Version 0.46.1
 **Bugfixes**
 - Fix Google Play release promotion with action `google-play tracks promote-release` for releases that have release notes. [PR #361](https://github.com/codemagic-ci-cd/cli-tools/pull/361)
 
+**Development**
+- Add GitHub Actions job to run tests with Python 3.12. [PR #362](https://github.com/codemagic-ci-cd/cli-tools/pull/362)
+
 Version 0.46.0
 -------------
 
@@ -66,7 +69,7 @@ Additions and changes from [pull request #345](https://github.com/codemagic-ci-c
 **Development**
 - Define a new common argument type `bounded_number` for CLI usage that can be used to load floats and integers from CLI inputs within specified ranges.
 - Add a new client method `update_track` to update release track in Google Play API client `codemagic.google_play.api_client.GooglePlayDeveloperAPIClient`.
--
+
 **Documentation**
 - Update documentation for action group `google-play tracks`.
 - Add documentation for action `google-play tracks promote-release`.


### PR DESCRIPTION
Update job declarations for GitHub Actions:
- add job to run tests with Python 3.12,
- use `actions/cache@v3` instead of `actions/cache@v1`,
- use `actions/setup-python@v4` instead of `actions/setup-python@v1`,
- use unique cache key per job.
