### PR TITLE
Update cache paths in GitHub Actions

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,12 +16,11 @@ jobs:
       with:
         python-version: 3.7
 
-    - uses: actions/cache@v3
+    - name: Cache Python dependencies
+      uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: .venv
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-7
-        restore-keys: |
-          ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |
@@ -51,12 +50,11 @@ jobs:
       with:
         python-version: 3.11
 
-    - uses: actions/cache@v3
+    - name: Cache Python dependencies
+      uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: .venv
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-11
-        restore-keys: |
-          ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |
@@ -86,12 +84,11 @@ jobs:
       with:
         python-version: 3.12
 
-    - uses: actions/cache@v3
+    - name: Cache Python dependencies
+      uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: .venv
         key: ${{ runner.os }}-pip-${{ hashFiles('**/poetry.lock') }}-py-3-12
-        restore-keys: |
-          ${{ runner.os }}-pip-
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
For quite some time already Python dependencies have been installed to `.venv` in CI jobs. GitHub Actions however cachede `~/.cache/pip`, which is of no use.