### PR TITLE
Remove `distutils.version.LooseVersion` usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Version 0.47.0
+-------------
+
+Changes in this release are from [PR #370](https://github.com/codemagic-ci-cd/cli-tools/pull/370) and add Python 3.12 compatibility.
+
+[PEP-632](https://peps.python.org/pep-0632/) deprecated `distutils` module, and it was removed entirely in Python 3.12. This release ensures that `distutils` module is not used any more.
+
+**None of the breaking changes have an effect on command line usage**, only the Python API is affected.
+
+**Development**
+- **Breaking**: Type of `codemagic.models.Xcode.version` property was changed. Instead of `distutils.version.LooseVersion` it is now `packaging.version.Version`.
+- **Breaking**: Type of `codemagic.models.simulator.Runtime.runtime_version` property was changed. Instead of `distutils.version.LooseVersion` it is now `packaging.version.Version`.
+
 Version 0.46.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.46.2"
+version = "0.47.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.46.2.dev"
+__version__ = "0.47.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/code_sign_entitlements.py
+++ b/src/codemagic/models/code_sign_entitlements.py
@@ -5,12 +5,13 @@ import plistlib
 import shutil
 import subprocess
 import tempfile
-from distutils.version import LooseVersion
 from typing import Any
 from typing import AnyStr
 from typing import Dict
 from typing import List
 from typing import Tuple
+
+from packaging.version import Version
 
 from codemagic.mixins import RunningCliAppMixin
 from codemagic.mixins import StringConverterMixin
@@ -38,7 +39,7 @@ class CodeSignEntitlements(RunningCliAppMixin, StringConverterMixin):
     def _get_codesign_command(cls, app_path: pathlib.Path) -> Tuple[str, ...]:
         from codemagic.models import Xcode
 
-        if Xcode.get_selected().version < LooseVersion("13.3"):
+        if Xcode.get_selected().version < Version("13.3"):
             # The "--entitlements" option of codesign takes "path" parameter to specify where the
             # entitlements should be displayed. In order to send the output to stdout instead
             # of file, "-" needs to be specified. Until Xcode 13.2 it had the following

--- a/src/codemagic/models/simulator/runtime.py
+++ b/src/codemagic/models/simulator/runtime.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import enum
 import re
-from distutils.version import LooseVersion
 from functools import total_ordering
 from typing import Optional
+
+from packaging.version import Version
 
 
 @total_ordering
@@ -52,11 +53,11 @@ class Runtime:
         return None
 
     @property
-    def runtime_version(self) -> LooseVersion:
+    def runtime_version(self) -> Version:
         match = self._PATTERN.search(self.raw_name)
         if not match:
             raise ValueError(f"Invalid runtime {self.raw_name!r}")
-        return LooseVersion(match.groupdict()["version"].replace("-", "."))
+        return Version(match.groupdict()["version"].replace("-", "."))
 
     @property
     def runtime_name(self) -> Name:

--- a/src/codemagic/models/xcode.py
+++ b/src/codemagic/models/xcode.py
@@ -4,9 +4,10 @@ import pathlib
 import plistlib
 import shutil
 import subprocess
-from distutils.version import LooseVersion
 from functools import lru_cache
 from typing import Dict
+
+from packaging.version import Version
 
 from codemagic.mixins import RunningCliAppMixin
 
@@ -27,9 +28,9 @@ class Xcode(RunningCliAppMixin):
             return plistlib.load(fd)
 
     @property
-    def version(self) -> LooseVersion:
+    def version(self) -> Version:
         version_info = self._get_version_info()
-        return LooseVersion(version_info["CFBundleShortVersionString"])
+        return Version(version_info["CFBundleShortVersionString"])
 
     @property
     def build_version(self) -> str:

--- a/src/codemagic/models/xcodebuild.py
+++ b/src/codemagic/models/xcodebuild.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import tempfile
 import time
-from distutils.version import LooseVersion
 from functools import reduce
 from operator import add
 from typing import IO
@@ -17,6 +16,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+
+from packaging.version import Version
 
 from codemagic.cli import CliProcess
 from codemagic.mixins import RunningCliAppMixin
@@ -141,7 +142,7 @@ class Xcodebuild(RunningCliAppMixin):
                 code_signing_options.append(f"DEVELOPMENT_TEAM={export_options.teamID}")
             if export_options.signingCertificate:
                 code_signing_options.append(f"CODE_SIGN_IDENTITY={export_options.signingCertificate}")
-            if LooseVersion("14") <= xcode.version:
+            if Version("14") <= xcode.version:
                 code_signing_options.append("CODE_SIGN_STYLE=Manual")
 
         return [

--- a/tests/models/simulator/test_runtime.py
+++ b/tests/models/simulator/test_runtime.py
@@ -1,7 +1,6 @@
-from distutils.version import LooseVersion
-
 import pytest
 from codemagic.models.simulator import Runtime
+from packaging.version import Version
 
 
 @pytest.mark.parametrize(
@@ -21,7 +20,7 @@ from codemagic.models.simulator import Runtime
 )
 def test_get_runtime_version(raw_runtime_name, expected_runtime_version):
     runtime_version = Runtime(raw_runtime_name).runtime_version
-    assert runtime_version == LooseVersion(expected_runtime_version)
+    assert runtime_version == Version(expected_runtime_version)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_certificate.py
+++ b/tests/models/test_certificate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from datetime import timezone
-from distutils.version import LooseVersion
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -12,6 +11,7 @@ from codemagic.models import Certificate
 from codemagic.models import PrivateKey
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
+from packaging.version import Version
 
 
 @pytest.fixture
@@ -98,7 +98,7 @@ def certificate(certificate_asn1) -> Certificate:
 
 
 @pytest.mark.skipif(
-    LooseVersion(cryptography.__version__) < LooseVersion("36.0.0"),
+    Version(cryptography.__version__) < Version("36.0.0"),
     reason=(
         f"Cryptography {cryptography.__version__} < 36.0.0 generates "
         f"slightly different CSR public bytes for certificate request "

--- a/tests/models/test_xcode.py
+++ b/tests/models/test_xcode.py
@@ -1,9 +1,9 @@
 import pathlib
-from distutils.version import LooseVersion
 from unittest import mock
 
 import pytest
 from codemagic.models import Xcode
+from packaging.version import Version
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def test_get_selected(mock_developer_dir):
 
 def test_version(mock_developer_dir):
     xcode = Xcode(mock_developer_dir)
-    assert xcode.version == LooseVersion("12.0.1")
+    assert xcode.version == Version("12.0.1")
 
 
 def test_build_version(mock_developer_dir):


### PR DESCRIPTION
**Description**

[PEP-632](https://peps.python.org/pep-0632/) deprecated `distutils` module in Python 3.10, and starting from 3.12 it is not included in standard library any more.

CLI tools used `LooseVersion` from `distutils.version` for version number comparisons in number of places and now related imports are broken on Python 3.12 unless `distutils` is manually installed on the system.

To overcome that issue, use [PEP-440](https://peps.python.org/pep-0440/) compliant version handling layer from [`packaging`](https://packaging.pypa.io/en/latest/index.html) library by [PyPA](https://github.com/pypa):
```python
from packaging.version import Version
```
which, for our use-cases, is a drop-in replacement for `LooseVersion`.

**The changes induce backwards-incompatibility in two places for Python API:**
- Type of `codemagic.models.Xcode.version` property was changed from `distutils.version.LooseVersion` to `packaging.version.Version`.
- Type of `codemagic.models.simulator.Runtime.runtime_version` property was changed from `distutils.version.LooseVersion` to `packaging.version.Version`. 

**Dependencies**

No new dependencies are required as `packaging` was added already in #306.