### PR TITLE
Fix setting provisioning profile specifiers for specific SDKs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.47.1
+-------------
+
+**Bugfixes**
+- Update action `xcode-project use-profiles`. Fix assigning provisioning profiles to Xcode targets that have SDK specific provisioning profile specifiers. [PR #371](https://github.com/codemagic-ci-cd/cli-tools/pull/371)
+
 Version 0.47.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.47.0"
+version = "0.47.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.47.0.dev"
+__version__ = "0.47.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/scripts/code_signing_manager.rb
+++ b/src/codemagic/scripts/code_signing_manager.rb
@@ -235,7 +235,7 @@ class CodeSigningManager
     build_configuration.build_settings["DEVELOPMENT_TEAM"] = profile["team_id"]
 
     build_configuration.build_settings.each do |build_setting, _value|
-      if build_setting.start_with? "CODE_SIGN_IDENTITY[sdk="
+      if build_setting.start_with?("CODE_SIGN_IDENTITY[sdk=", "PROVISIONING_PROFILE_SPECIFIER[sdk=")
         build_configuration.build_settings.delete build_setting
       end
     end
@@ -255,6 +255,11 @@ class CodeSigningManager
     unless target.product_type == UNIT_TESTING_PRODUCT_TYPE
       target_attributes[target.uuid]["ProvisioningStyle"] = "Manual"
       build_configuration.build_settings["PROVISIONING_PROFILE_SPECIFIER"] = profile['name']
+      build_configuration.build_settings.each do |build_setting, _value|
+        if build_setting.start_with? "PROVISIONING_PROFILE_SPECIFIER[sdk="
+          build_configuration.build_settings[build_setting] = profile["name"]
+        end
+      end
     end
 
     build_configuration.build_settings["CODE_SIGN_IDENTITY"] = profile["certificate_common_name"]


### PR DESCRIPTION
Setting code signing settings for Xcode project with [`xcode-project use-profiles`](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/xcode-project/use-profiles.md) does not override platform-specific provisioning profile assignations. For example, if my project file already contains entry such as
```
"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Original Profile";
```
then running `xcode-project use-profile` just adds another `PROVISIONING_PROFILE_SPECIFIER` definition for the target:
```
PROVISIONING_PROFILE_SPECIFIER = "Another Profile";
```
which results in a conflicting provisioning code signing setup because both profiles are defined in the `project.pbxproj` file:
```
"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Original Profile";
PROVISIONING_PROFILE_SPECIFIER = "Another Profile";
```

Now, if the original profile that is referenced for specific SDK does not exist in `~/Library/MobileDevice/Provisioning Profiles`, which might very well be the case when build is running on a VM from CI environment, then `xcodebuild build` is destined to fail.

Changes to `code_signing_manager.rb` ensure that all `PROVISIONING_PROFILE_SPECIFIER` build settings for target are properly updated when `xcode-project use-profiles` is launched.

**Updated actions:**
- `xcode-project use-profiles`