### PR TITLE
Handle empty reponses from Google APIs for listing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.47.2
+-------------
+
+**Bugfixes**
+- Fix actions `firebase-app-distribution get-latest-build-version` and `firebase-app-distribution releases list` for cases when specified application does not have any releases available. [PR #373](https://github.com/codemagic-ci-cd/cli-tools/pull/373)
+
+
 Version 0.47.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.47.1"
+version = "0.47.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.47.1.dev"
+__version__ = "0.47.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/resource_managers/mixins/acting_manager_mixin.py
+++ b/src/codemagic/google/resource_managers/mixins/acting_manager_mixin.py
@@ -38,8 +38,9 @@ class ActingManagerMixin(Generic[ResourceT], ABC):
         ...
 
     def _execute_request(self, request: HttpRequest) -> Dict[str, Any]:
+        self._logger.info(f">>> {request.method} {request.uri} {request.body}")
         try:
-            return request.execute()
+            response = request.execute()
         except OAuth2ClientError as e:
             self._logger.exception(f"Failed to {self.manager_action} {self.resource_type.get_label()}")
             raise GoogleAuthenticationError(str(e)) from e
@@ -50,3 +51,5 @@ class ActingManagerMixin(Generic[ResourceT], ABC):
         except errors.Error as e:
             self._logger.exception(f"Failed to {self.manager_action} {self.resource_type.get_label()}")
             raise GoogleClientError(str(e)) from e
+        self._logger.info(f"<<< {response}")
+        return response

--- a/src/codemagic/google/resource_managers/mixins/listing_manager_mixin.py
+++ b/src/codemagic/google/resource_managers/mixins/listing_manager_mixin.py
@@ -65,6 +65,7 @@ class ListingManagerMixin(Generic[ResourceT, ResourceIdentifierT], ActingManager
             request = self._get_resources_page_request(page_request_args)
             response = self._execute_request(request)
 
+            # In case no matches are found, then the relevant key is missing from response
             response_items = response.get(self.resource_type.get_label(), [])
             resources.extend(self.resource_type(**item) for item in response_items)
             page_request_args.page_token = response.get("nextPageToken")

--- a/src/codemagic/google/resource_managers/mixins/listing_manager_mixin.py
+++ b/src/codemagic/google/resource_managers/mixins/listing_manager_mixin.py
@@ -65,7 +65,8 @@ class ListingManagerMixin(Generic[ResourceT, ResourceIdentifierT], ActingManager
             request = self._get_resources_page_request(page_request_args)
             response = self._execute_request(request)
 
-            resources.extend(self.resource_type(**item) for item in response[self.resource_type.get_label()])
+            response_items = response.get(self.resource_type.get_label(), [])
+            resources.extend(self.resource_type(**item) for item in response_items)
             page_request_args.page_token = response.get("nextPageToken")
 
             if limit and len(resources) > limit:

--- a/src/codemagic/tools/firebase_app_distribution/action_groups/releases_action_group.py
+++ b/src/codemagic/tools/firebase_app_distribution/action_groups/releases_action_group.py
@@ -2,6 +2,7 @@ from abc import ABC
 from typing import List
 
 from codemagic import cli
+from codemagic.cli import Colors
 from codemagic.google.errors import GoogleError
 from codemagic.google.resources import OrderBy
 from codemagic.google.resources import Release
@@ -43,6 +44,10 @@ class ReleasesActionGroup(FirebaseAppDistributionAction, ABC):
         except GoogleError as e:
             raise FirebaseAppDistributionError(str(e))
 
-        printer = ResourcePrinter(json_output, self.echo)
-        printer.print_resources(releases, should_print)
+        if not releases:
+            self.logger.info(Colors.YELLOW(f"No releases available for {app_identifier.app_id}"))
+        else:
+            printer = ResourcePrinter(json_output, self.echo)
+            printer.print_resources(releases, should_print)
+
         return releases


### PR DESCRIPTION
Firebase releases API has started to return empty respones to listing requests. Handle those by checking if the requested resource key is present in the response object instead of failing unexpectedly with `KeyError`.

**Example traceback:**

```python
[17:39:37 08-11-2023] INFO  acting_manager_mixin.py:42 > >>> GET https://firebaseappdistribution.googleapis.com/v1/projects/228333310124/apps/1:228333310124:ios:5e439e0d0231a788ac8f09/releases?orderBy=createTimeDesc&pageSize=1&alt=json None
[17:39:38 08-11-2023] INFO  acting_manager_mixin.py:47 > <<< {}
[17:39:38 08-11-2023] WARNING cli_app.py:121 > Executing "firebase-app-distribution get-latest-build-version" failed unexpectedly. Detailed logs are available at "/var/folders/wr/c44p23x10f302_kfbj32z0p80000gn/T/codemagic-08-11-23.log". To see more details about the error
, add "--verbose" command line option.
[17:39:38 08-11-2023] ERROR cli_app.py:123 > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/development/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 213, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/development/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 170, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/development/nevercode/cli-tools/src/codemagic/cli/cli_app.py", line 465, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/development/nevercode/cli-tools/src/codemagic/tools/firebase_app_distribution/actions/get_latest_build_version_action.py", line 23, in get_latest_build_version
    releases = self.client.releases.list(app_identifier, limit=1)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/development/nevercode/cli-tools/src/codemagic/google/resource_managers/mixins/listing_manager_mixin.py", line 68, in list
    resources.extend(self.resource_type(**item) for item in response[self.resource_type.get_label()])
                                                            ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'releases'
```

**Updated actions:**
- `firebase-app-distribution get-latest-build-version`
- `firebase-app-distribution releases list`
