### PR TITLE
Fix certificates globbing from relative paths for `keychain add-certificates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+Version 0.47.3
+-------------
+
+**Bugfixes**
+- Fix handling of relative certificate path patterns for action `keychain add-certificates`. [PR #374](https://github.com/codemagic-ci-cd/cli-tools/pull/374)
+
 Version 0.47.2
 -------------
 
 **Bugfixes**
 - Fix actions `firebase-app-distribution get-latest-build-version` and `firebase-app-distribution releases list` for cases when specified application does not have any releases available. [PR #373](https://github.com/codemagic-ci-cd/cli-tools/pull/373)
-
 
 Version 0.47.1
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.47.2"
+version = "0.47.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.47.2.dev"
+__version__ = "0.47.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/keychain.py
+++ b/src/codemagic/tools/keychain.py
@@ -339,7 +339,7 @@ class Keychain(cli.CliApp, PathFinderMixin):
             add_for_apps = list(self._get_certificate_allowed_applications(allowed_applications))
 
         self.logger.info("Add certificates to keychain %s", self.path)
-        certificate_paths = list(self.find_paths(*certificate_path_patterns))
+        certificate_paths = list(self.find_paths(*(p.resolve() for p in certificate_path_patterns)))
         if not certificate_paths:
             raise KeychainError("Did not find any certificates from specified locations")
 


### PR DESCRIPTION
It is possible to specify custom certificate paths or path patterns for action `keychain add-certificates` via CLI option `--certificate`. As this option accepts either path literals, or a glob patterns to match certificates, then relative reference `.` to current directory should also be an acceptable input. This however results in an error when globbing matches:

```python
>>> list(Path().glob('.'))
Traceback (most recent call last):
  File "/Users/priit/development/nevercode/cli-tools/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py", line 3553, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-23-b1f87bcdf599>", line 1, in <cell line: 0>
    list(Path().glob('.'))
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/pathlib.py", line 1094, in glob
    selector = _make_selector(tuple(pattern_parts), self._flavour, case_sensitive)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/pathlib.py", line 83, in _make_selector
    pat = pattern_parts[0]
          ~~~~~~~~~~~~~^^^
IndexError: tuple index out of range
```

To overcome that limitation, just resolve the relative path pattern before attempting glob search. Then the path becomes absolute which can be safely globbed.

**Updated actions:**
- `keychain add-certificates`