### PR TITLE
Handle `xcresulttool` failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.50.1
+-------------
+
+**Bugfixes**
+- Fix error handling for corrupt Xcresult parsing in `xcode-project` actions. [PR #390](https://github.com/codemagic-ci-cd/cli-tools/pull/390)
+
 Version 0.50.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.50.0"
+version = "0.50.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.50.0.dev"
+__version__ = "0.50.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/xctests/__init__.py
+++ b/src/codemagic/models/xctests/__init__.py
@@ -2,3 +2,4 @@ from .collector import XcResultCollector
 from .converter import XcResultConverter
 from .xcresult import ActionsInvocationRecord
 from .xcresulttool import XcResultTool
+from .xcresulttool import XcResultToolError


### PR DESCRIPTION
It is possible that `xcresult` files that contain Xcode test results are corrupted (either by erroneous user interaction or Xcode generated them as such). For example if `Info.plist` is missing from the `xcresult` bundle, then applying any `xcrun xcresulttool` command to this bundle will fail and exits with error code 1.

For example:
```shell
$ xcrun xcresulttool get --format json --path /Users/priit/Library/Developer/Xcode/DerivedData/App-eyutjqzsoxkgpcbycmzihsrczspl/Logs/Test/Test-App-2024.01.10_09-07-42-+0000.xcresult
error: Info.plist at /Users/priit/Library/Developer/Xcode/DerivedData/App-eyutjqzsoxkgpcbycmzihsrczspl/Logs/Test/Test-App-2024.01.10_09-07-42-+0000.xcresult does not exist, the result bundle might be corrupted or the provided path is not a result bundle
```

As it is now, `xcode-project` actions which use `xcresulttool` under the hood do not handle such errors in any way and as a result the action invocation can fail unexpectedly.

<details>
<summary>Example error log of <code>xcode-project run-tests</code></summary>

```shell
Running tests on simulators:
- iOS 17.0 iPhone 15 (E473C396-11F5-426D-8A60-FCAD55546926)

Run tests for App.xcworkspace

Execute "xcodebuild -workspace App.xcworkspace -scheme App -sdk iphonesimulator -enableCodeCoverage YES -destination id=E473C396-11F5-426D-8A60-FCAD55546926 test"


Test run failed

Found test results at
- /Users/priit/Library/Developer/Xcode/DerivedData/App-eyutjqzsoxkgpcbycmzihsrczspl/Logs/Test/Test-App-2024.01.10_09-07-42-+0000.xcresult

Executing "xcode-project run-tests" failed unexpectedly. Detailed logs are available at "/var/folders/w2/rrf5p87d1bbfyphxc7jdnyvh0000gn/T/codemagic-10-01-24.log". To see more details about the error, add "--verbose" command line option.
No valid test result files matching "build/ios/test/*." were found. Test results are not displayed.

Build failed :|
Step 2 script `iOS test` exited with status code 9
```
</details>

Capture the errors that happen during `xcresulttool` runs, log out the error reason and fail the action gracefully with descriptive message in case the main goal of the action could not be completed.

**Updated actions:**
- `xcode-project run-tests`
- `xcode-project test-summary`
- `xcode-project junit-test-results`