### PR TITLE
Allow custom export options for `xcode-project build-ipa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-Version 0.50.1
+Version 0.50.2
+-------------
+
+**Features**
+- Allow custom export options in export options properly list for `xcode-project build-ipa` actions. [PR #391](https://github.com/codemagic-ci-cd/cli-tools/pull/391)
+
+- Version 0.50.1
 -------------
 
 **Bugfixes**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.50.1"
+version = "0.50.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.50.1.dev"
+__version__ = "0.50.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -143,6 +143,7 @@ class ExportOptions(StringConverterMixin):
         try:
             type_hint = get_type_hints(cls)[field_name]
         except KeyError:
+            # Type info is missing for unknown fields
             return None
         if hasattr(type_hint, "__origin__") and type_hint.__origin__ is Union:
             # Optionals are unions of actual type and NoneType
@@ -223,7 +224,7 @@ class ExportOptions(StringConverterMixin):
             try:
                 data = plistlib.load(fd)  # type: ignore
             except plistlib.InvalidFileException:
-                raise ValueError(f'File "{plist_path}" is not a valid property list')
+                raise ValueError("Invalid plist")
 
         export_options = ExportOptions()
         for key_name, value in data.items():

--- a/src/codemagic/models/export_options.py
+++ b/src/codemagic/models/export_options.py
@@ -205,8 +205,11 @@ class ExportOptions(StringConverterMixin):
         elif field_name == "provisioningProfiles":
             self._set_provisioning_profiles(value)
         elif field_type and not isinstance(value, field_type):
-            with ResourceEnumMeta.without_graceful_fallback():
-                setattr(self, field_name, field_type(value))
+            if issubclass(field_type, enum.Enum):
+                with ResourceEnumMeta.without_graceful_fallback():
+                    setattr(self, field_name, field_type(value))
+            else:
+                raise ValueError(f"Invalid value for {field_name!r}")
         else:
             setattr(self, field_name, value)
 

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -684,10 +684,8 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
             raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(
                 f'Path "{export_options_plist}" does not exist',
             )
-        except ValueError:
-            raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(
-                f'File "{export_options_plist}" is not a valid property list',
-            )
+        except ValueError as ve:
+            raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(str(ve))
 
     def _get_test_destinations(
         self,

--- a/src/codemagic/tools/xcode_project.py
+++ b/src/codemagic/tools/xcode_project.py
@@ -684,8 +684,10 @@ class XcodeProject(cli.CliApp, PathFinderMixin):
             raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(
                 f'Path "{export_options_plist}" does not exist',
             )
-        except ValueError as ve:
-            raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(str(ve))
+        except ValueError:
+            raise ExportIpaArgument.EXPORT_OPTIONS_PATH.raise_argument_error(
+                f'File "{export_options_plist}" is not a valid property list',
+            )
 
     def _get_test_destinations(
         self,

--- a/tests/models/test_export_options.py
+++ b/tests/models/test_export_options.py
@@ -85,6 +85,10 @@ def test_export_options_set_valid_values(field_name, value, export_options_dict)
         ("provisioningProfiles", [ProvisioningProfileInfo("bundle_id", "name"), {"k": "v"}]),
         ("method", "invalid method"),
         ("destination", "invalid destination"),
+        ("teamID", -1),
+        ("teamID", True),
+        ("stripSwiftSymbols", "false"),
+        ("stripSwiftSymbols", "YES"),
     ],
 )
 def test_export_options_set_invalid_values(field_name, value, export_options_dict):

--- a/tests/models/test_export_options.py
+++ b/tests/models/test_export_options.py
@@ -1,9 +1,16 @@
+import logging
+import plistlib
+import tempfile
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import pytest
+from codemagic.cli import Colors
 from codemagic.models import ExportOptions
 from codemagic.models.export_options import ProvisioningProfileInfo
+
+mock_logger = mock.Mock(spec=logging.Logger)
 
 
 def test_export_options_initialize_from_path(export_options_list_path, export_options_dict):
@@ -74,7 +81,6 @@ def test_export_options_set_valid_values(field_name, value, export_options_dict)
         ("manifest", 1),
         ("manifest", 3.4),
         ("manifest", {"invalid_key": 1}),
-        ("invalid_field", -1),
         ("provisioningProfiles", [1]),
         ("provisioningProfiles", [ProvisioningProfileInfo("bundle_id", "name"), {"k": "v"}]),
         ("method", "invalid method"),
@@ -85,3 +91,41 @@ def test_export_options_set_invalid_values(field_name, value, export_options_dic
     export_options = ExportOptions(**export_options_dict)
     with pytest.raises(ValueError):
         export_options.set_value(field_name=field_name, value=value)
+
+
+@mock.patch("codemagic.models.export_options.log.get_logger", new=mock.Mock(return_value=mock_logger))
+def test_export_options_set_unknown_fields():
+    export_options = ExportOptions()
+    export_options.set_value(field_name="unknownExportOption", value=False)
+
+    expected_warning = 'Warning: Using unknown export option "unknownExportOption"'
+    mock_logger.warning.assert_called_once_with(Colors.YELLOW(expected_warning))
+    assert export_options.dict() == {"unknownExportOption": False}
+
+
+@mock.patch("codemagic.models.export_options.log.get_logger", new=mock.Mock(return_value=mock_logger))
+def test_export_options_unknown_fields_notify():
+    export_options = ExportOptions()
+    export_options.set_value(field_name="unknownExportOption", value=False)
+    export_options.notify("Title")
+
+    mock_logger.info.assert_has_calls(
+        [
+            mock.call("Title"),
+            mock.call(Colors.BLUE(" - Unknown Export Option: False")),
+        ],
+    )
+
+
+def test_export_options_unknown_fields_from_path():
+    expected_export_options = {
+        "signingStyle": "manual",  # Known field
+        "unknownExportOption": False,  # Unknown field
+    }
+
+    with tempfile.NamedTemporaryFile(mode="wb") as tf:
+        tf.write(plistlib.dumps(expected_export_options))
+        tf.flush()
+        export_options = ExportOptions.from_path(tf.name)
+
+    assert export_options.dict() == expected_export_options


### PR DESCRIPTION
New Xcode versions can introduce export options that are not defined in our `ExportOptions` class (for example `testFlightInternalTestingOnly` that was added some time ago, but for which we were lacking definition).

Also in general Xcode does not restrict usage of totally custom export options, and as such it makes little to no sense to be very strict about what keys are allowed in export options and what are not. This PR allows usage of export option keys that are not explicitly defined by the fields in `ExportOptions` class. Such fields are persisted when the object is updated and are included when the properly list is saved to disk.

**Updated actions**
- `xcode-project build-ipa`

<details>
<summary>Example log with warning about unknown export option</summary>

```shell
$ xcode-project build-ipa --project banaan.xcodeproj --archive-flags="-destination 'generic/platform=iOS'"
Warning: Using unknown export option "myInterestingCustomOption"
Using Xcode 15.2 (15C500b)

Check banaan.xcodeproj build settings
Execute "xcodebuild -project banaan.xcodeproj -scheme banaan -showBuildSettings"

...
```

</details>
