### PR TITLE
Fix: deprecate fields for App Store Connect App resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 0.50.3
+-------------
+
+**Bugfixes**
+- Remove deprecated attributes and relationships for App Store Connect [App](https://developer.apple.com/documentation/appstoreconnectapi/app/) data structure. [PR #392](https://github.com/codemagic-ci-cd/cli-tools/pull/392)
+  - `availableInNewTerritories` attribute,
+  - `availableTerritories` and `prices` relationships.
+
 Version 0.50.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.50.2"
+version = "0.50.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.50.2.dev"
+__version__ = "0.50.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/app.py
+++ b/src/codemagic/apple/resources/app.py
@@ -23,7 +23,6 @@ class App(Resource):
         name: str
         primaryLocale: Locale
         sku: str
-        availableInNewTerritories: bool
         contentRightsDeclaration: ContentRightsDeclaration
         isOrEverWasMadeForKids: bool
 
@@ -39,7 +38,6 @@ class App(Resource):
 
         appInfos: Relationship
         appStoreVersions: Relationship
-        availableTerritories: Relationship
         betaAppLocalizations: Relationship
         betaAppReviewDetail: Relationship
         betaGroups: Relationship
@@ -50,7 +48,6 @@ class App(Resource):
         inAppPurchases: Relationship
         preOrder: Relationship
         preReleaseVersions: Relationship
-        prices: Relationship
 
         betaTesters: Optional[Relationship] = None
         ciProduct: Optional[Relationship] = None


### PR DESCRIPTION
Listing applications now fails due to the deprecation of the following fields from App Store Connect [App](https://developer.apple.com/documentation/appstoreconnectapi/app/) data structure:
* `availableInNewTerritories` [attribute](https://developer.apple.com/documentation/appstoreconnectapi/app/attributes),
* `availableTerritories` and `prices` [relationships](https://developer.apple.com/documentation/appstoreconnectapi/app/relationships).

# Details
<details>
<summary>Exception traceback for deprecated attribute</summary>

```
[14:59:14] ERROR > Exception traceback:
Traceback (most recent call last):
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/cli_app.py", line 243, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/cli_app.py", line 184, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/tools/app_store_connect/action_groups/apps_action_group.py", line 82, in list_apps
    return self._list_resources(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/tools/app_store_connect/mixins/resource_manager_mixin.py", line 84, in _list_resources
    resources = list_resources(resource_filter=resource_filter)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/app_store_connect/apps/apps.py", line 61, in list
    return [App(app) for app in apps]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/app_store_connect/apps/apps.py", line 61, in <listcomp>
    return [App(app) for app in apps]
            ^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/resources/resource.py", line 236, in __init__
    self.attributes = self._create_attributes(api_response)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/resources/resource.py", line 221, in _create_attributes
    return cls.Attributes(**defined_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: App.Attributes.__init__() missing 1 required positional argument: 'availableInNewTerritories'
```
</details>

<details>
<summary>Exception traceback for deprecated relationships</summary>

```
[15:00:42] ERROR > Exception traceback:
Traceback (most recent call last):
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/cli_app.py", line 243, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/cli_app.py", line 184, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/tools/app_store_connect/action_groups/apps_action_group.py", line 82, in list_apps
    return self._list_resources(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/tools/app_store_connect/mixins/resource_manager_mixin.py", line 84, in _list_resources
    resources = list_resources(resource_filter=resource_filter)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/app_store_connect/apps/apps.py", line 61, in list
    return [App(app) for app in apps]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/app_store_connect/apps/apps.py", line 61, in <listcomp>
    return [App(app) for app in apps]
            ^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/resources/resource.py", line 238, in __init__
    self.relationships = self._create_relationships(api_response)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemii/codemagic/cli-tools/src/codemagic/apple/resources/resource.py", line 230, in _create_relationships
    return cls.Relationships(**defined_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: App.Relationships.__init__() missing 2 required positional arguments: 'availableTerritories' and 'prices'
```
</details>

# QA
✅ Application listing works as expected
```
(codemagic-cli-tools-py3.11) artemii@Artemiis-iMac cli-tools % python -m codemagic.tools.app_store_connect apps list --app-name "Manifesto"
Found 1 App matching specified filters: name=Manifesto.
-- App --
Id: 6474964435
Type: apps
Bundle id: io.codemagic.Manifesto
Name: Manifesto Generator
Primary locale: en-US
Sku: io.codemagic.Manifesto
Is or ever was made for kids: False
```