### PR TITLE
Bugfix: Ignore empty relationships on App Store Connect resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+UNRELEASED
+-------------
+
+**Bugfixes**
+- Fix App Store Connect API responses deserialization for cases when resource contains an empty relationship. [PR #401](https://github.com/codemagic-ci-cd/cli-tools/pull/401)
+
 Version 0.50.7
 -------------
 

--- a/src/codemagic/apple/resources/resource.py
+++ b/src/codemagic/apple/resources/resource.py
@@ -207,9 +207,14 @@ class Resource(LinkedResourceData, metaclass=PrettyNameAbcMeta):
     class Relationships(DictSerializable, GracefulDataclassMixin):
         def __post_init__(self):
             for field in self.__dict__:
-                value = getattr(self, field)
-                if not isinstance(value, (Relationship, type(None))):
-                    setattr(self, field, Relationship(**value))
+                current_value = getattr(self, field)
+                if current_value is None or isinstance(current_value, Relationship):
+                    continue
+
+                # Relationships should have at least 'links' attribute.
+                # Set the value to none for empty relationships.
+                updated_value = Relationship(**current_value) if current_value else None
+                setattr(self, field, updated_value)
 
     @classmethod
     def _create_attributes(cls, api_response) -> Attributes:

--- a/tests/apple/resources/conftest.py
+++ b/tests/apple/resources/conftest.py
@@ -12,6 +12,12 @@ def api_app_store_version() -> Dict:
 
 
 @pytest.fixture
+def api_app() -> Dict:
+    mock_path = pathlib.Path(__file__).parent / "mocks" / "app.json"
+    return json.loads(mock_path.read_text())
+
+
+@pytest.fixture
 def api_build() -> Dict:
     mock_path = pathlib.Path(__file__).parent / "mocks" / "build.json"
     return json.loads(mock_path.read_text())

--- a/tests/apple/resources/mocks/app.json
+++ b/tests/apple/resources/mocks/app.json
@@ -1,88 +1,115 @@
 {
-    "type": "apps",
+    "attributes": {
+        "bundleId": "io.codemagic.banaan",
+        "contentRightsDeclaration": "DOES_NOT_USE_THIRD_PARTY_CONTENT",
+        "isOrEverWasMadeForKids": false,
+        "name": "Banaan Codemagic",
+        "primaryLocale": "en-GB",
+        "sku": "banaanike",
+        "subscriptionStatusUrl": null,
+        "subscriptionStatusUrlForSandbox": null,
+        "subscriptionStatusUrlVersion": null,
+        "subscriptionStatusUrlVersionForSandbox": null
+    },
     "id": "1481211155",
     "links": {
         "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155"
     },
-    "attributes": {
-        "bundleId": "io.codemagic.banaan",
-        "name": "Banaan Codemagic",
-        "primaryLocale": "en-GB",
-        "sku": "banaanike",
-        "contentRightsDeclaration": "DOES_NOT_USE_THIRD_PARTY_CONTENT",
-        "isOrEverWasMadeForKids": false
-    },
     "relationships": {
+        "alternativeDistributionKey": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/alternativeDistributionKey",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/alternativeDistributionKey"
+            }
+        },
+        "analyticsReportRequests": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/analyticsReportRequests",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/analyticsReportRequests"
+            }
+        },
+        "appAvailability": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appAvailability",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appAvailability"
+            }
+        },
+        "appAvailabilityV2": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appAvailabilityV2",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appAvailabilityV2"
+            }
+        },
+        "appClips": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appClips",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appClips"
+            }
+        },
+        "appCustomProductPages": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appCustomProductPages",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appCustomProductPages"
+            }
+        },
+        "appEvents": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appEvents",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appEvents"
+            }
+        },
         "appInfos": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appInfos",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appInfos"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appInfos",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appInfos"
+            }
+        },
+        "appPricePoints": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appPricePoints",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appPricePoints"
+            }
+        },
+        "appPriceSchedule": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appPriceSchedule",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appPriceSchedule"
+            }
+        },
+        "appStoreVersionExperimentsV2": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appStoreVersionExperimentsV2",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appStoreVersionExperimentsV2"
             }
         },
         "appStoreVersions": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appStoreVersions",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appStoreVersions"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appStoreVersions",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appStoreVersions"
             }
         },
         "betaAppLocalizations": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppLocalizations",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppLocalizations"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppLocalizations",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppLocalizations"
             }
         },
         "betaAppReviewDetail": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppReviewDetail",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppReviewDetail"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppReviewDetail",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppReviewDetail"
             }
         },
         "betaGroups": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaGroups",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaGroups"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaGroups",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaGroups"
             }
         },
         "betaLicenseAgreement": {
             "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaLicenseAgreement",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaLicenseAgreement"
-            }
-        },
-        "builds": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/builds",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/builds"
-            }
-        },
-        "endUserLicenseAgreement": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/endUserLicenseAgreement",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/endUserLicenseAgreement"
-            }
-        },
-        "gameCenterEnabledVersions": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/gameCenterEnabledVersions",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/gameCenterEnabledVersions"
-            }
-        },
-        "inAppPurchases": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/inAppPurchases",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/inAppPurchases"
-            }
-        },
-        "preOrder": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preOrder",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preOrder"
-            }
-        },
-        "preReleaseVersions": {
-            "links": {
-                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preReleaseVersions",
-                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preReleaseVersions"
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaLicenseAgreement",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaLicenseAgreement"
             }
         },
         "betaTesters": {
@@ -90,10 +117,107 @@
                 "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaTesters"
             }
         },
+        "builds": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/builds",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/builds"
+            }
+        },
+        "ciProduct": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/ciProduct",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/ciProduct"
+            }
+        },
+        "customerReviews": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/customerReviews",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/customerReviews"
+            }
+        },
+        "endUserLicenseAgreement": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/endUserLicenseAgreement",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/endUserLicenseAgreement"
+            }
+        },
+        "gameCenterDetail": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/gameCenterDetail",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/gameCenterDetail"
+            }
+        },
+        "gameCenterEnabledVersions": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/gameCenterEnabledVersions",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/gameCenterEnabledVersions"
+            }
+        },
+        "inAppPurchases": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/inAppPurchases",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/inAppPurchases"
+            }
+        },
+        "inAppPurchasesV2": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/inAppPurchasesV2",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/inAppPurchasesV2"
+            }
+        },
+        "marketplaceSearchDetail": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/marketplaceSearchDetail",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/marketplaceSearchDetail"
+            }
+        },
         "perfPowerMetrics": {
             "links": {
                 "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/perfPowerMetrics"
             }
+        },
+        "preOrder": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preOrder",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preOrder"
+            }
+        },
+        "preReleaseVersions": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preReleaseVersions",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preReleaseVersions"
+            }
+        },
+        "pricePoints": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/pricePoints",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/pricePoints"
+            }
+        },
+        "promotedPurchases": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/promotedPurchases",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/promotedPurchases"
+            }
+        },
+        "reviewSubmissions": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/reviewSubmissions",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/reviewSubmissions"
+            }
+        },
+        "subscriptionGracePeriod": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/subscriptionGracePeriod",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/subscriptionGracePeriod"
+            }
+        },
+        "subscriptionGroups": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/subscriptionGroups",
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/subscriptionGroups"
+            }
         }
-    }
+    },
+    "type": "apps"
 }

--- a/tests/apple/resources/mocks/app.json
+++ b/tests/apple/resources/mocks/app.json
@@ -1,0 +1,99 @@
+{
+    "type": "apps",
+    "id": "1481211155",
+    "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155"
+    },
+    "attributes": {
+        "bundleId": "io.codemagic.banaan",
+        "name": "Banaan Codemagic",
+        "primaryLocale": "en-GB",
+        "sku": "banaanike",
+        "contentRightsDeclaration": "DOES_NOT_USE_THIRD_PARTY_CONTENT",
+        "isOrEverWasMadeForKids": false
+    },
+    "relationships": {
+        "appInfos": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appInfos",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appInfos"
+            }
+        },
+        "appStoreVersions": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/appStoreVersions",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/appStoreVersions"
+            }
+        },
+        "betaAppLocalizations": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppLocalizations",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppLocalizations"
+            }
+        },
+        "betaAppReviewDetail": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaAppReviewDetail",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaAppReviewDetail"
+            }
+        },
+        "betaGroups": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaGroups",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaGroups"
+            }
+        },
+        "betaLicenseAgreement": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaLicenseAgreement",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/betaLicenseAgreement"
+            }
+        },
+        "builds": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/builds",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/builds"
+            }
+        },
+        "endUserLicenseAgreement": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/endUserLicenseAgreement",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/endUserLicenseAgreement"
+            }
+        },
+        "gameCenterEnabledVersions": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/gameCenterEnabledVersions",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/gameCenterEnabledVersions"
+            }
+        },
+        "inAppPurchases": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/inAppPurchases",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/inAppPurchases"
+            }
+        },
+        "preOrder": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preOrder",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preOrder"
+            }
+        },
+        "preReleaseVersions": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/preReleaseVersions",
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/preReleaseVersions"
+            }
+        },
+        "betaTesters": {
+            "links": {
+                "self": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/relationships/betaTesters"
+            }
+        },
+        "perfPowerMetrics": {
+            "links": {
+                "related": "https://api.appstoreconnect.apple.com/v1/apps/1481211155/perfPowerMetrics"
+            }
+        }
+    }
+}

--- a/tests/apple/resources/test_app_resource.py
+++ b/tests/apple/resources/test_app_resource.py
@@ -3,11 +3,6 @@ from __future__ import annotations
 from codemagic.apple.resources import App
 
 
-def test_app_initialization(api_app):
-    app = App(api_app)
-    assert app.dict() == api_app
-
-
 def test_app_with_empty_relationship(api_app):
     api_app["relationships"]["ciProduct"] = {}
     app = App(api_app)

--- a/tests/apple/resources/test_app_resource.py
+++ b/tests/apple/resources/test_app_resource.py
@@ -12,3 +12,4 @@ def test_app_with_empty_relationship(api_app):
     api_app["relationships"]["ciProduct"] = {}
     app = App(api_app)
     assert app.relationships.ciProduct is None
+    assert "ciProduct" not in app.dict()["relationships"]

--- a/tests/apple/resources/test_app_resource.py
+++ b/tests/apple/resources/test_app_resource.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from codemagic.apple.resources import App
+
+
+def test_app_initialization(api_app):
+    app = App(api_app)
+    assert app.dict() == api_app
+
+
+def test_app_with_empty_relationship(api_app):
+    api_app["relationships"]["ciProduct"] = {}
+    app = App(api_app)
+    assert app.relationships.ciProduct is None


### PR DESCRIPTION
It is possible that App Store Connect API returns resources with empty relationships. For example [List Apps](https://developer.apple.com/documentation/appstoreconnectapi/list_apps) endpoint can respond with a response where an app has [`ciProduct` relationship](https://developer.apple.com/documentation/appstoreconnectapi/app/relationships/ciproduct) defined as `{}` instead of `null` even though the schema suggests that relationships should always have at least `links` attribute defined. 

Such a response breaks data deserialization.

<details>
<summary>Example with stacktrace</summary>

```python
def test_empty_relationship():
>       App(
            {
                "type": "apps",
                "id": "...",
                "links": {...},
                "attributes": {...},
                "relationships": {
                    ...,
                    "ciProduct": {},  # <-- empty relationship from App Store Connect API response!
                },
            },
        )

test_app_resource.py:18: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../src/codemagic/apple/resources/resource.py:241: in __init__
    self.relationships = self._create_relationships(api_response)
../../../src/codemagic/apple/resources/resource.py:233: in _create_relationships
    return cls.Relationships(**defined_fields)
<string>:18: in __init__
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = App.Relationships(appInfos=Relationship(links=<codemagic.apple.resources.resource.Links object at 0x106058680>, data=N..., perfPowerMetrics={'links': {'related': 'https://api.appstoreconnect.apple.com/v1/apps/1481211155/perfPowerMetrics'}})

    def __post_init__(self):
        for field in self.__dict__:
            value = getattr(self, field)
            if not isinstance(value, (Relationship, type(None))):
>               setattr(self, field, Relationship(**value))
E               TypeError: Relationship.__init__() missing 1 required positional argument: 'links'

../../../src/codemagic/apple/resources/resource.py:215: TypeError
```

</details>

Handle empty relationships by just discarding them.