### PR TITLE
Bugfix: Remove `idfaDeclarations` field from `AppStoreVersion` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+Version 0.51.1
+-------------
+
+This is a bugfix release containing changes from [PR #405](https://github.com/codemagic-ci-cd/cli-tools/pull/405). Apple removed `idfaDeclaration` key from the data structure that represents App Store Version resources, which caused failures in App Store Connect client methods. Consequently, CLI actions started to fail.
+
+**Bugfixes**
+- Fix actions:
+  - `app-store-connect app-store-versions create`,
+  - `app-store-connect app-store-versions update`,
+  - `app-store-connect apps app-store-versions`,
+  - `app-store-connect builds app-store-version`,
+  - `app-store-connect builds submit-to-app-store`,
+  - `app-store-connect publish` when executed with `--app-store` option.
+
+**Development**
+- Remove attribute `idfaDeclaration` from `AppStoreVersion.Relationships`.
+- Update App Store Connect API mock response for App Store Version.
+
+
 Version 0.51.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.51.0"
+version = "0.51.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.51.0.dev"
+__version__ = "0.51.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/app_store_version.py
+++ b/src/codemagic/apple/resources/app_store_version.py
@@ -53,7 +53,6 @@ class AppStoreVersion(Resource):
         appStoreVersionPhasedRelease: Relationship
         appStoreVersionSubmission: Relationship
         build: Relationship
-        idfaDeclaration: Relationship
         routingAppCoverage: Relationship
 
         app: Optional[Relationship] = None

--- a/tests/apple/resources/mocks/app_store_version.json
+++ b/tests/apple/resources/mocks/app_store_version.json
@@ -55,12 +55,6 @@
           "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/appStoreVersionSubmission"
         }
       },
-      "idfaDeclaration": {
-        "links": {
-          "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/idfaDeclaration",
-          "related": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/idfaDeclaration"
-        }
-      },
       "appClipDefaultExperience": {
         "links": {
           "self": "https://api.appstoreconnect.apple.com/v1/appStoreVersions/33c63053-09a9-4112-86cf-bb1539379896/relationships/appClipDefaultExperience",

--- a/tests/apple/resources/test_app_store_version_resource.py
+++ b/tests/apple/resources/test_app_store_version_resource.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from codemagic.apple.resources import AppStoreVersion
 
 
-def test_build_initialization(api_app_store_version):
+def test_app_store_version_initialization(api_app_store_version):
+    app_store_version = AppStoreVersion(api_app_store_version)
+    assert app_store_version.dict() == api_app_store_version
+
+
+def test_app_store_version_without_idfa_declaration(api_app_store_version):
+    api_relationships = api_app_store_version["relationships"]
+    del api_relationships["idfaDeclaration"]
     app_store_version = AppStoreVersion(api_app_store_version)
     assert app_store_version.dict() == api_app_store_version

--- a/tests/apple/resources/test_app_store_version_resource.py
+++ b/tests/apple/resources/test_app_store_version_resource.py
@@ -3,13 +3,6 @@ from __future__ import annotations
 from codemagic.apple.resources import AppStoreVersion
 
 
-def test_app_store_version_initialization(api_app_store_version):
-    app_store_version = AppStoreVersion(api_app_store_version)
-    assert app_store_version.dict() == api_app_store_version
-
-
-def test_app_store_version_without_idfa_declaration(api_app_store_version):
-    api_relationships = api_app_store_version["relationships"]
-    del api_relationships["idfaDeclaration"]
+def test_app_store_version_initialization(api_app_store_version: dict):
     app_store_version = AppStoreVersion(api_app_store_version)
     assert app_store_version.dict() == api_app_store_version


### PR DESCRIPTION
Appe removed `idfaDeclaration` attribute from App Store Version's relationships which caused model initialization to fail on our end due to `TypeError`. That in turn triggers number of failures when invoking CLI actions.

**Example stacktrace:**

```python
Traceback (most recent call last):
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/cli/cli_app.py", line 243, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/cli/cli_app.py", line 184, in _invoke_action
    return cli_action(**action_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/tools/app_store_connect/action_groups/apps_action_group.py", line 152, in list_app_store_versions_for_app
    return self._list_related_resources(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/tools/app_store_connect/mixins/resource_manager_mixin.py", line 136, in _list_related_resources
    resources = list_related_resources_method(resource_id, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/apple/app_store_connect/apps/apps.py", line 125, in list_app_store_versions
    return [AppStoreVersion(app_store_version) for app_store_version in app_store_versions_data]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/apple/resources/resource.py", line 238, in __init__
    self.relationships = self._create_relationships(api_response)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.pyenv/versions/3.12.0/lib/python3.12/site-packages/codemagic/apple/resources/resource.py", line 230, in _create_relationships
    return cls.Relationships(**defined_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: AppStoreVersion.Relationships.__init__() missing 1 required positional argument: 'idfaDeclaration'
```

**Updated actions:**
  - `app-store-connect app-store-versions create`,
  - `app-store-connect app-store-versions update`,
  - `app-store-connect apps app-store-versions`,
  - `app-store-connect builds app-store-version`,
  - `app-store-connect builds submit-to-app-store`,
  - `app-store-connect publish`. 