### PR TITLE
Do not require TestFlight submission when adding build to beta groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Version 0.52.0
 -------------
 
 **Feature**
+- Update action `app-store-connect publish` to allow adding builds to beta groups without submitting to TestFlight. [PR #410](https://github.com/codemagic-ci-cd/cli-tools/pull/410)
+
+Version 0.52.0
+-------------
+
+**Feature**
 - Add optional argument `--platform` to action `app-store-connect apps builds` to list builds only for selected platform. [PR #407](https://github.com/codemagic-ci-cd/cli-tools/pull/407)
 - Add optional argument `--platform` to action `app-store-connect builds list` to list builds only for selected platform. [PR #407](https://github.com/codemagic-ci-cd/cli-tools/pull/407)
 - Add optional argument `--platform` to action `app-store-connect apps expire-build-submitted-for-review` to expire builds only for specified platform. [PR #407](https://github.com/codemagic-ci-cd/cli-tools/pull/407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.52.0
+Version 0.53.0
 -------------
 
 **Feature**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.52.0"
+version = "0.53.0"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.55.0.dev"
+__version__ = "0.53.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/publish_action.py
@@ -435,7 +435,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 build.id,
                 max_build_processing_wait=0,
                 **dataclasses.asdict(app_store_options),
-            )  # type: ignore
+            )
 
     def _find_build(
         self,

--- a/src/codemagic/tools/app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/publish_action.py
@@ -259,7 +259,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 enable_phased_release=enable_phased_release,
                 disable_phased_release=disable_phased_release,
             )
-        if submit_to_testflight and beta_group_names:
+        if beta_group_names:
             # Only builds submitted to TestFlight can be added to beta groups
             add_build_to_beta_group_options = AddBuildToBetaGroupOptions(
                 beta_group_names=beta_group_names,
@@ -411,6 +411,12 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         if testflight_options or app_store_options or beta_group_options:
             self.wait_until_build_is_processed(build, max_build_processing_wait)
 
+        if beta_group_options:
+            self.add_build_to_beta_groups(
+                build.id,
+                beta_group_names=beta_group_options.beta_group_names,
+            )
+
         if testflight_options:
             # Overwrite waiting since we already waited above.
             self.submit_to_testflight(
@@ -418,9 +424,6 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 max_build_processing_wait=0,
                 **dataclasses.asdict(testflight_options),
             )
-
-        if beta_group_options:
-            self.add_build_to_beta_groups(build.id, **beta_group_options.__dict__)
 
         if app_store_options:
             if not app_store_options.version_string:

--- a/src/codemagic/tools/app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/publish_action.py
@@ -57,13 +57,11 @@ class AddBuildToBetaGroupOptions:
 
 @dataclass
 class SubmitToTestFlightOptions:
-    max_build_processing_wait: int
     expire_build_submitted_for_review: bool
 
 
 @dataclass
 class SubmitToAppStoreOptions:
-    max_build_processing_wait: int
     cancel_previous_submissions: bool
     # App Store Version information arguments
     copyright: Optional[str] = None
@@ -194,7 +192,6 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         submit_to_testflight: Optional[bool],
         submit_to_app_store: Optional[bool],
         # Submit to TestFlight arguments
-        max_build_processing_wait: Optional[Types.MaxBuildProcessingWait] = None,
         expire_build_submitted_for_review: bool = False,
         # Beta test info arguments
         beta_build_localizations: Optional[Types.BetaBuildLocalizations] = None,
@@ -231,7 +228,6 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
 
         if submit_to_testflight:
             submit_to_testflight_options = SubmitToTestFlightOptions(
-                max_build_processing_wait=Types.MaxBuildProcessingWait.resolve_value(max_build_processing_wait),
                 expire_build_submitted_for_review=expire_build_submitted_for_review,
             )
         if submit_to_app_store:
@@ -242,7 +238,6 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             if isinstance(app_store_version_localizations, Types.AppStoreVersionLocalizationInfoArgument):
                 app_store_version_localizations = app_store_version_localizations.value
             submit_to_app_store_options = SubmitToAppStoreOptions(
-                max_build_processing_wait=Types.MaxBuildProcessingWait.resolve_value(max_build_processing_wait),
                 cancel_previous_submissions=cancel_previous_submissions,
                 # Non localized app metadata
                 copyright=copyright,
@@ -311,6 +306,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         altool_retry_wait: Optional[Types.AltoolRetryWait] = None,
         altool_verbose_logging: Optional[bool] = None,
         max_find_build_wait: Union[Types.MaxFindBuildWait, int] = PublishArgument.MAX_BUILD_FIND_WAIT.get_default(),
+        max_build_processing_wait: Optional[Union[Types.MaxBuildProcessingWait, int]] = None,
         **app_store_connect_submit_options,
     ) -> None:
         """
@@ -344,6 +340,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 self._process_application_after_upload(
                     application_package,
                     Types.MaxFindBuildWait.resolve_value(max_find_build_wait),
+                    Types.MaxBuildProcessingWait.resolve_value(max_build_processing_wait),
                     *self._get_app_store_connect_submit_options(
                         application_package,
                         submit_to_testflight,
@@ -396,6 +393,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         self,
         application_package: Union[Ipa, MacOsPackage],
         max_find_build_wait: int,
+        max_build_processing_wait: int,
         testflight_options: Optional[SubmitToTestFlightOptions],
         app_store_options: Optional[SubmitToAppStoreOptions],
         beta_test_info_options: Optional[AddBetaTestInfoOptions],
@@ -410,26 +408,31 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         if beta_test_info_options:
             self.add_beta_test_info(build.id, **beta_test_info_options.__dict__)
 
-        if testflight_options:
-            self.wait_until_build_is_processed(build, testflight_options.max_build_processing_wait)
-        elif app_store_options:
-            self.wait_until_build_is_processed(build, app_store_options.max_build_processing_wait)
+        if testflight_options or app_store_options or beta_group_options:
+            self.wait_until_build_is_processed(build, max_build_processing_wait)
 
         if testflight_options:
             # Overwrite waiting since we already waited above.
-            tf_options = dataclasses.replace(testflight_options, max_build_processing_wait=0)
-            self.submit_to_testflight(build.id, **tf_options.__dict__)
+            self.submit_to_testflight(
+                build.id,
+                max_build_processing_wait=0,
+                **dataclasses.asdict(testflight_options),
+            )
 
         if beta_group_options:
             self.add_build_to_beta_groups(build.id, **beta_group_options.__dict__)
 
         if app_store_options:
-            app_store_submission_kwargs = {
-                **app_store_options.__dict__,
-                "max_build_processing_wait": 0,  # Overwrite waiting since we already waited above.
-                "version_string": app_store_options.version_string or application_package.version,
-            }
-            self.submit_to_app_store(build.id, **app_store_submission_kwargs)  # type: ignore
+            if not app_store_options.version_string:
+                app_store_options = dataclasses.replace(
+                    app_store_options,
+                    version_string=application_package.version,
+                )
+            self.submit_to_app_store(
+                build.id,
+                max_build_processing_wait=0,
+                **dataclasses.asdict(app_store_options),
+            )  # type: ignore
 
     def _find_build(
         self,


### PR DESCRIPTION
**Addresses #409**

Action `app-store-connect publish` requires that build needs to be submitted to TestFlight in order to add the build to beta groups. This is not necessary and actually builds can be assigned to beta groups regardless of their TestFlight submission status.

This PR removes that arbitrary limitation and makes it possible to add published build to beta groups without TestFlight submission.

**Examples**

- Publish ipa and just add it to beta groups:
```shell
app-store-connect publish --path app.ipa --beta-group "Group 1" "Group 2"
```

- Publish ipa and just submit it to TestFlight:
```shell
app-store-connect publish --path app.ipa --testflight --whats-new "..."
```

- Publish ipa and both add it to beta groups and submit it to TestFlight:
```shell
app-store-connect publish \
    --path app.ipa \
    --beta-group "Group 1" "Group 2" \
    --testflight --whats-new "..."
```

**Updated actions**
- `app-store-connect publish`
