### PR TITLE
Add missing App Store Connect locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Version 0.53.6
 **Bugfixes**
 - Cache generated fallback enumeration types so that enum identity checks work for undefined, but allowed enumerations. [PR #425](https://github.com/codemagic-ci-cd/cli-tools/pull/425)
 
+**Docs**
+- Update documentations for the following actions: [PR #425](https://github.com/codemagic-ci-cd/cli-tools/pull/425)
+  - `app-store-connect app-store-versions localizations`,
+  - `app-store-connect beta-build-localizations create`,
+  - `app-store-connect beta-build-localizations list`,
+  - `app-store-connect builds add-beta-test-info`,
+  - `app-store-connect builds submit-to-app-store`,
+  - `app-store-connect publish`.
 
 Version 0.53.5
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 0.53.6
+-------------
+
+**Features**
+- Update tool `app-store-connect` to support all Apple's [locales](https://developer.apple.com/documentation/appstoreconnectapi/app_store/app_metadata/app_info_localizations/managing_metadata_in_your_app_by_using_locale_shortcodes). [PR #425](https://github.com/codemagic-ci-cd/cli-tools/pull/425)
+
+**Bugfixes**
+- Cache generated fallback enumeration types so that enum identity checks work for undefined, but allowed enumerations. [PR #425](https://github.com/codemagic-ci-cd/cli-tools/pull/425)
+
+
 Version 0.53.5
 -------------
 

--- a/docs/app-store-connect/app-store-versions/localizations.md
+++ b/docs/app-store-connect/app-store-versions/localizations.md
@@ -28,7 +28,7 @@ app-store-connect app-store-versions localizations [-h] [--log-stream STREAM] [-
 UUID value of the App Store Version
 ### Optional arguments for action `localizations`
 
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for App Store metadata in different languages. See available locale code names from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes. Multiple arguments

--- a/docs/app-store-connect/beta-build-localizations/create.md
+++ b/docs/app-store-connect/beta-build-localizations/create.md
@@ -29,7 +29,7 @@ app-store-connect beta-build-localizations create [-h] [--log-stream STREAM] [--
 Alphanumeric ID value of the Build
 ### Optional arguments for action `create`
 
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale from test information is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/docs/app-store-connect/beta-build-localizations/list.md
+++ b/docs/app-store-connect/beta-build-localizations/list.md
@@ -28,7 +28,7 @@ app-store-connect beta-build-localizations list [-h] [--log-stream STREAM] [--no
 Alphanumeric ID value of the Build
 ### Optional arguments for action `list`
 
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/docs/app-store-connect/builds/add-beta-test-info.md
+++ b/docs/app-store-connect/builds/add-beta-test-info.md
@@ -34,7 +34,7 @@ Alphanumeric ID value of the Build
 
 
 Localized beta test info for what's new in the uploaded build as a JSON encoded list. For example, `[{"locale": "en-US", "whats_new": "What's new in English"}]`. See `--locale` for possible locale options. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_BETA_BUILD_LOCALIZATIONS`. Alternatively to entering `BETA_BUILD_LOCALIZATIONS` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale from test information is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/docs/app-store-connect/builds/submit-to-app-store.md
+++ b/docs/app-store-connect/builds/submit-to-app-store.md
@@ -85,7 +85,7 @@ A description of your app, detailing features and functionality.
 
 
 Include one or more keywords that describe your app. Keywords make App Store search results more accurate. Separate keywords with an English comma, Chinese comma, or a mix of both.
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for App Store metadata in different languages. In case not provided, application's primary locale is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/docs/app-store-connect/publish.md
+++ b/docs/app-store-connect/publish.md
@@ -175,7 +175,7 @@ Release App Store version update in phases. With this option your version update
 Turn off phased release for your App Store version update. Learon more about phased releases from https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases. Mutually exclusive with option `--phased-release`.
 ### Optional arguments to add localized meta information about build for TestFlight or App Store review submission
 
-##### `--locale, -l=da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | id | it | ja | ko | ms | nl-NL | no | pt-BR | pt-PT | ru | sv | th | tr | vi | zh-Hans | zh-Hant`
+##### `--locale, -l=ar-SA | ca | cs | da | de-DE | el | en-AU | en-CA | en-GB | en-US | es-ES | es-MX | fi | fr-CA | fr-FR | he | hi | hr | hu | id | it | ja | ko | ms | nl-NL | no | pl | pt-BR | pt-PT | ro | ru | sk | sv | th | tr | uk | zh-Hans | zh-Hant`
 
 
 The locale code name for App Store metadata in different languages, or for displaying localized "What's new" content in TestFlight. In case not provided, application's primary locale is used instead. Learn more from https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizationcreaterequest/data/attributes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.53.5"
+version = "0.53.6"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.53.5.dev"
+__version__ = "0.53.6.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -434,37 +434,47 @@ class ReviewSubmissionItemState(ResourceEnum):
 
 class Locale(ResourceEnum):
     """
-    Referenced in https://developer.apple.com/documentation/appstoreconnectapi/betaapplocalization/attributes#discussion
+    https://developer.apple.com/documentation/appstoreconnectapi/app_store/app_metadata/app_info_localizations/managing_metadata_in_your_app_by_using_locale_shortcodes
     """
 
-    DA = "da"
-    DE_DE = "de-DE"
-    EL = "el"
-    EN_AU = "en-AU"
-    EN_CA = "en-CA"
-    EN_GB = "en-GB"
-    EN_US = "en-US"
-    ES_ES = "es-ES"
-    ES_MX = "es-MX"
-    FI = "fi"
-    FR_CA = "fr-CA"
-    FR_FR = "fr-FR"
-    ID = "id"
-    IT = "it"
-    JA = "ja"
-    KO = "ko"
-    MS = "ms"
-    NL_NL = "nl-NL"
-    NO = "no"
-    PT_BR = "pt-BR"
-    PT_PT = "pt-PT"
-    RU = "ru"
-    SV = "sv"
-    TH = "th"
-    TR = "tr"
-    VI = "vi"
-    ZH_HANS = "zh-Hans"
-    ZH_HANT = "zh-Hant"
+    AR_SA = "ar-SA"  # Arabic
+    CA = "ca"  # Catalan
+    CS = "cs"  # Czech
+    DA = "da"  # Danish
+    DE_DE = "de-DE"  # German
+    EL = "el"  # Greek
+    EN_AU = "en-AU"  # English (Australia)
+    EN_CA = "en-CA"  # English (Canada)
+    EN_GB = "en-GB"  # English (U.K.)
+    EN_US = "en-US"  # English (U.S.)
+    ES_ES = "es-ES"  # Spanish (Spain)
+    ES_MX = "es-MX"  # Spanish (Mexico)
+    FI = "fi"  # Finnish
+    FR_CA = "fr-CA"  # French (Canada)
+    FR_FR = "fr-FR"  # French
+    HE = "he"  # Hebrew
+    HI = "hi"  # Hindi
+    HR = "hr"  # Croatian
+    HU = "hu"  # Hungarian
+    ID = "id"  # Indonesian
+    IT = "it"  # Italian
+    JA = "ja"  # Japanese
+    KO = "ko"  # Korean
+    MS = "ms"  # Malay
+    NL_NL = "nl-NL"  # Dutch
+    NO = "no"  # Norwegian
+    PL = "pl"  # Polish
+    PT_BR = "pt-BR"  # Portuguese (Brazil)
+    PT_PT = "pt-PT"  # Portuguese (Portugal)
+    RO = "ro"  # Romanian
+    RU = "ru"  # Russian
+    SK = "sk"  # Slovak
+    SV = "sv"  # Swedish
+    TH = "th"  # Thai
+    TR = "tr"  # Turkish
+    UK = "uk"  # Ukrainian
+    ZH_HANS = "zh-Hans"  # Chinese (Simplified)
+    ZH_HANT = "zh-Hant"  # Chinese (Traditional)
 
 
 class SubscriptionStatusUrlVersion(ResourceEnum):

--- a/src/codemagic/models/enums.py
+++ b/src/codemagic/models/enums.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import contextlib
 import enum
 import re
+from typing import Any
+from typing import Dict
+from typing import Tuple
 
 from codemagic.utilities import log
 
@@ -19,6 +24,8 @@ class ResourceEnumMeta(enum.EnumMeta):
     graceful_fallback = True
     enable_name_transformation = False
 
+    __graceful_fallback_cache: Dict[Tuple[str, Any], Any] = {}
+
     def __call__(cls, value, *args, **kwargs):  # noqa: N805
         try:
             return super().__call__(value, *args, **kwargs)
@@ -29,10 +36,20 @@ class ResourceEnumMeta(enum.EnumMeta):
             logger = log.get_logger(cls, log_to_stream=False)
             logger.warning("Undefined Resource enumeration: %s", ve)
             try:
-                enum_class = ResourceEnum(f"Graceful{cls.__name__}", {value: value})
-                return enum_class(value)
+                return cls._create_graceful_fallback_instance(value)
             except TypeError:
                 raise ve
+
+    def _create_graceful_fallback_instance(cls, value):  # noqa: N805
+        cache_key = (cls.__name__, value)
+
+        try:
+            enum_class = cls.__graceful_fallback_cache[cache_key]
+        except KeyError:
+            enum_class = ResourceEnum(f"Graceful{cls.__name__}", {value: value})
+            cls.__graceful_fallback_cache[cache_key] = enum_class
+
+        return enum_class(value)
 
     def _transform_class_name(cls):  # noqa: N805
         """

--- a/src/codemagic/models/enums.py
+++ b/src/codemagic/models/enums.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import enum
 import re
-from typing import Any
 from typing import Dict
 from typing import Tuple
 
@@ -24,7 +23,7 @@ class ResourceEnumMeta(enum.EnumMeta):
     graceful_fallback = True
     enable_name_transformation = False
 
-    __graceful_fallback_cache: Dict[Tuple[str, Any], Any] = {}
+    __graceful_fallback_cache: Dict[Tuple[str, str], str] = {}
 
     def __call__(cls, value, *args, **kwargs):  # noqa: N805
         try:

--- a/tests/models/enums/test_resource_enum.py
+++ b/tests/models/enums/test_resource_enum.py
@@ -44,3 +44,12 @@ def test_context_manager(is_graceful_before):
         with pytest.raises(ValueError):
             MockEnum("invalid value")
     assert ResourceEnumMeta.graceful_fallback is is_graceful_before
+
+
+def test_graceful_fallback_identity():
+    ResourceEnumMeta.graceful_fallback = True
+    e1 = MockEnum("undefined-value")
+    e2 = MockEnum("undefined-value")
+    assert e1 is e2  # Enumerations with the same value should persist identity
+    assert e1 == e2  # Enumerations with the same value should be equal
+    assert e1.value == e2.value  # And of course their values should also be equal


### PR DESCRIPTION
Update `codemagic.apple.resources.enums.Locale` to match the [locales supported by Apple](https://developer.apple.com/documentation/appstoreconnectapi/app_store/app_metadata/app_info_localizations/managing_metadata_in_your_app_by_using_locale_shortcodes).

For now some locales are missing from our definitions and this can cause troubles when working with any resource that relies on locale value.

**Updated actions:**
  - `app-store-connect app-store-versions localizations`,
  - `app-store-connect beta-build-localizations create`,
  - `app-store-connect beta-build-localizations list`,
  - `app-store-connect builds add-beta-test-info`,
  - `app-store-connect builds submit-to-app-store`,
  - `app-store-connect publish`.
 