### PR TITLE
Fix certificates exporting with LibreSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.53.6
+Version 0.53.7
 -------------
 
 **Bugfixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Version 0.53.6
 -------------
 
+**Bugfixes**
+- Fix saving Apple code signing certificates to disk when using LibreSSL 3.0.0+. [PR #427](https://github.com/codemagic-ci-cd/cli-tools/pull/427)
+
+Version 0.53.6
+-------------
+
 **Features**
 - Update tool `app-store-connect` to support all Apple's [locales](https://developer.apple.com/documentation/appstoreconnectapi/app_store/app_metadata/app_info_localizations/managing_metadata_in_your_app_by_using_locale_shortcodes). [PR #425](https://github.com/codemagic-ci-cd/cli-tools/pull/425)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.53.6"
+version = "0.53.7"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.53.6.dev"
+__version__ = "0.53.7.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/certificate_p12_exporter.py
+++ b/src/codemagic/models/certificate_p12_exporter.py
@@ -54,6 +54,9 @@ class _OpenSsl:
                 capture_output=True,
                 check=False,
             )
+            # Check both stdout and stderr because LibreSSL doesn't have help commands per-se.
+            # Execution fails, and it just outputs "unknown option '-help'" along with full
+            # command usage to stderr.
             self.__SUPPORTS_NOENC__ = b"-noenc" in completed_process.stdout or b"-noenc" in completed_process.stderr
 
         return self.__SUPPORTS_NOENC__


### PR DESCRIPTION
**Fixes #419**

PR #411 introduced a regression when exporting Apple code signing certificates to PKCS#12 containers.

Just checking `openssl version` to decide whether `-noenc` option is supported for PKCS#12 export can yield misleading results as there are different implementations whose versioning schemes and APIs do not agree with each other.

For example OpenSSL 3.0.0+ has deprecated `-nodes` in favor of `-noenc`, while LibreSSL 3.3.6. still uses `-nodes` and doesn't even recognize `-noenc`.

To choose correct flag to skip private key encryption for `openssl pkcs12`, just check the help message and see if it contains `-noenc`, otherwise use the legacy `-nodes`.

**Updated actions**:
- `app-store-connect certificates create`,
- `app-store-connect certificates get`,
- `app-store-connect certificates list`,
- `app-store-connect fetch-signing-files`.

**QA notes**

<details>
<summary>Tested on systems with different <code>openssl</code> installations</summary>

```shell
% openssl version
LibreSSL 3.3.6
```

```shell
% openssl version
OpenSSL 3.3.1 4 Jun 2024 (Library: OpenSSL 3.3.1 4 Jun 2024)
```

</details>