### PR TITLE
Do not publish source distributions to PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.53.9
+-------------
+
+**Development**
+- Change release pipeline not to include source distributions in PyPI releases. Those are still available from GitHub. [PR #429](https://github.com/codemagic-ci-cd/cli-tools/pull/429)
+
 Version 0.53.8
 -------------
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -84,6 +84,7 @@ workflows:
           rm dist/codemagic_cli_tools-latest-py3-none-any.whl
       - name: Publish release to PyPI Test environment
         script: |
+          rm dist/codemagic_cli_tools-*.tar.gz
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry publish \
             --repository test-pypi \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -127,5 +127,7 @@ workflows:
               dist/codemagic*.tar.gz
           rm dist/codemagic_cli_tools-latest-py3-none-any.whl
       - name: Publish release to PyPI
-        script: poetry publish --username "__token__" --password "${PYPI_TOKEN:?}"
+        script: |
+          rm dist/codemagic_cli_tools-*.tar.gz
+          poetry publish --username "__token__" --password "${PYPI_TOKEN:?}"
     artifacts: *artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.53.8"
+version = "0.53.9"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.53.8.dev"
+__version__ = "0.53.9.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"


### PR DESCRIPTION
By default PyPI imposes 10GB limit to total uploaded artifact size. This package already hit this limit which caused the release pipeline to fail.

Reduce PyPI artifact size by not uploading source tarballs there as those are readily available from GitHub anyway.