### PR TITLE
Fix XCResult testcase duration parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.54.1
+-------------
+
+**Bugfixes**
+- Fix testcase duration parsing from `XCResult` bundle when using Xcode 16.0+. [PR #433](https://github.com/codemagic-ci-cd/cli-tools/pull/433)
+
 Version 0.54.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.54.0"
+version = "0.54.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.54.0.dev"
+__version__ = "0.54.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/xctests/converter.py
+++ b/src/codemagic/models/xctests/converter.py
@@ -4,9 +4,8 @@ import pathlib
 import re
 from abc import ABC
 from abc import abstractmethod
-from collections import defaultdict
 from datetime import datetime
-from typing import Dict
+from datetime import timedelta
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -244,21 +243,21 @@ class Xcode16XcResultConverter(XcResultConverter):
 
     @classmethod
     def parse_xcresult_test_node_duration_value(cls, xc_duration: str) -> float:
-        counters: Dict[str, float] = defaultdict(float)
+        duration = timedelta()
 
         try:
             for part in xc_duration.split():
+                part_value = float(part[:-1].replace(",", "."))
                 if part.endswith("s"):
-                    counter = "seconds"
+                    duration += timedelta(seconds=part_value)
                 elif part.endswith("m"):
-                    counter = "minutes"
+                    duration += timedelta(minutes=part_value)
                 else:
                     raise ValueError("Unknown duration unit")
-                counters[counter] = float(part[:-1].replace(",", "."))
         except ValueError as ve:
             raise ValueError("Invalid duration", xc_duration) from ve
 
-        return counters["minutes"] * 60.0 + counters["seconds"]
+        return duration.total_seconds()
 
     @classmethod
     def _get_test_node_duration(cls, xc_test_case: XcTestNode) -> float:

--- a/src/codemagic/models/xctests/xcresult/xcode_16_xcresult.py
+++ b/src/codemagic/models/xctests/xcresult/xcode_16_xcresult.py
@@ -164,7 +164,7 @@ class XcTestInsight(XcModel):
 class XcTests(XcModel):
     """
     Model definitions for `xcresulttool get test-results tests` output.
-    Check schema with `xcrun xcresulttool help get test-results tests.
+    Check schema with `xcrun xcresulttool help get test-results tests`.
     """
 
     devices: List[XcDevice]

--- a/tests/models/xctests/converter/test_xcode_16_converter.py
+++ b/tests/models/xctests/converter/test_xcode_16_converter.py
@@ -139,6 +139,8 @@ def test_converter(mock_datetime, expected_properties):
         ("0,2s", 0.2),
         ("2s", 2.0),
         ("3s", 3.0),
+        ("1m 3,01s", 63.01),
+        ("1m 3.01s", 63.01),
         ("1m 4s", 64.0),
         ("2m 26s", 146.0),
         ("5m 3s", 303.0),

--- a/tests/models/xctests/converter/test_xcode_16_converter.py
+++ b/tests/models/xctests/converter/test_xcode_16_converter.py
@@ -127,3 +127,24 @@ def test_converter(mock_datetime, expected_properties):
         time=3.0,
         error=Error(message="banaanUITests.swift:40: failed - Bad UI", type="Failure"),
     )
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected_value"),
+    (
+        ("0,00045s", 0.00045),
+        ("0,002s", 0.002),
+        ("0,0052s", 0.0052),
+        ("0,26s", 0.26),
+        ("0,2s", 0.2),
+        ("2s", 2.0),
+        ("3s", 3.0),
+        ("1m 4s", 64.0),
+        ("2m 26s", 146.0),
+        ("5m 3s", 303.0),
+        ("6m", 360.0),
+    ),
+)
+def test_parse_xcresult_test_node_duration_value(duration, expected_value):
+    value = Xcode16XcResultConverter.parse_xcresult_test_node_duration_value(duration)
+    assert value == pytest.approx(expected_value)


### PR DESCRIPTION
**Fixes #432**

This PR fixes a bug from #431 which happens when parsing test results from XCResult using Xcode 16.0+ and any of the test cases ran longer than a minute.

Updated actions:
- `xcode-project run-tests`
- `xcode-project test-summary`
- `xcode-project junit-test-results`
