### PR TITLE
Retry `altool --upload-app` on return codes `-5` and `-11`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.54.2
 -------------
 
 **Bugfixes**
-- Introduce a new retrying condition for `altool` commands as part of `app-store-connect` action when unknown return codes occurs. [PR #435](https://github.com/codemagic-ci-cd/cli-tools/pull/435)
+- Introduce a new retrying condition for `altool` commands as part of `app-store-connect` action when unexpected return codes occurs. [PR #435](https://github.com/codemagic-ci-cd/cli-tools/pull/435)
 
 
 Version 0.54.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version 0.54.2
 -------------
 
 **Bugfixes**
-- Introduce a new retrying condition for `altool` commands as part of `app-store-connect` action when unknown return codes occurs.
+- Introduce a new retrying condition for `altool` commands as part of `app-store-connect` action when unknown return codes occurs. [PR #435](https://github.com/codemagic-ci-cd/cli-tools/pull/435)
 
 
 Version 0.54.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.54.2
+-------------
+
+**Bugfixes**
+- Introduce a new retrying condition for `altool` commands as part of `app-store-connect` action when unknown return codes occurs.
+
+
 Version 0.54.1
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.54.1"
+version = "0.54.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.54.1.dev"
+__version__ = "0.54.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -290,7 +290,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
 
     def _should_retry_command(self, command_error: AltoolCommandError) -> bool:
         if command_error.return_code in [-5, -11]:
-            self.logger.info(f"Unknown altool exit code {command_error.return_code}, retrying...")
+            self.logger.info(f"Unexpected altool exit code {command_error.return_code}, retrying...")
             return True
         patterns = (
             re.compile("Unable to authenticate.*-19209"),

--- a/src/codemagic/models/altool/altool.py
+++ b/src/codemagic/models/altool/altool.py
@@ -39,9 +39,10 @@ StrTuple = Union[Tuple[()], Tuple[str, ...]]  # Empty or variable length tuple w
 
 
 class AltoolCommandError(Exception):
-    def __init__(self, error_message: str, process_output: str):
+    def __init__(self, error_message: str, process_output: str, return_code: int = 1):
         super().__init__(error_message)
         self.process_output = process_output
+        self.return_code = return_code
 
 
 class Altool(RunningCliAppMixin, StringConverterMixin):
@@ -196,7 +197,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
                 return self._run_command(command, f'Failed to {action_name} archive at "{artifact_path}"', cli_app)
             except AltoolCommandError as error:
                 has_retries = retries > 0
-                should_retry = self._should_retry_command(error.process_output)
+                should_retry = self._should_retry_command(error)
                 if has_retries and should_retry:
                     if attempt == 1:
                         print_fn(f"Failed to {action_name} archive, but this might be a temporary issue, retrying...")
@@ -258,6 +259,7 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
             raise AltoolCommandError(
                 error_message,
                 self._hide_environment_variable_values(cpe.stdout),
+                cpe.returncode,
             )
 
         self._log_process_output(stdout, cli_app)
@@ -286,14 +288,16 @@ class Altool(RunningCliAppMixin, StringConverterMixin):
 
         return output
 
-    @classmethod
-    def _should_retry_command(cls, process_output: str):
+    def _should_retry_command(self, command_error: AltoolCommandError) -> bool:
+        if command_error.return_code in [-5, -11]:
+            self.logger.info(f"Unknown altool exit code {command_error.return_code}, retrying...")
+            return True
         patterns = (
             re.compile("Unable to authenticate.*-19209"),
             re.compile("server returned an invalid response.*try your request again"),
             re.compile("The request timed out."),
         )
-        return any(pattern.search(process_output) for pattern in patterns)
+        return any(pattern.search(command_error.process_output) for pattern in patterns)
 
     @classmethod
     def _get_action_result(cls, action_stdout: AnyStr) -> Optional[AltoolResult]:

--- a/tests/models/altool/test_altool_retrying.py
+++ b/tests/models/altool/test_altool_retrying.py
@@ -155,8 +155,8 @@ def test_retrying_command_by_return_code_and_success(caplog, mock_altool, mock_s
         result = mock_altool.upload_app(pathlib.Path("app.ipa"), retries=4, retry_wait_seconds=0)
 
     assert result is mock_success_result
-    assert caplog.text.count("Unknown altool exit code -11, retrying...") == 1
-    assert caplog.text.count("Unknown altool exit code -5, retrying...") == 2
+    assert caplog.text.count("Unexpected altool exit code -11, retrying...") == 1
+    assert caplog.text.count("Unexpected altool exit code -5, retrying...") == 2
 
 
 @mock.patch.object(PlatformType, "from_path", lambda _artifact_path: PlatformType.IOS)


### PR DESCRIPTION
Application loader tool can exit unexpectedly with return code `-5` or `-11` when running `altool --upload-app` without any error or warning messages in log output even though the application binary and authentication information are both valid. Subsequent `altool --upload-app` calls using the same binary can complete normally.

Handle such unexpected exits by enabling retrying for those exit codes.

**Updated actions:**
- `app-store-connect publish`