### PR TITLE
Support `APPLE_SILICON_MAC` device class on App Store Connect `Device` responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.54.2"
+version = "0.54.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.54.2.dev"
+__version__ = "0.54.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/apple/resources/enums.py
+++ b/src/codemagic/apple/resources/enums.py
@@ -259,6 +259,7 @@ class ContentRightsDeclaration(ResourceEnum):
 
 
 class DeviceClass(ResourceEnum):
+    APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
     APPLE_TV = "APPLE_TV"
     APPLE_VISION_PRO = "APPLE_VISION_PRO"
     APPLE_WATCH = "APPLE_WATCH"
@@ -271,7 +272,10 @@ class DeviceClass(ResourceEnum):
         if profile_type.is_tvos_profile:
             return self is DeviceClass.APPLE_TV
         elif profile_type.is_macos_profile:
-            return self is DeviceClass.MAC
+            return self in (
+                DeviceClass.APPLE_SILICON_MAC,
+                DeviceClass.MAC,
+            )
         else:
             return self in (
                 DeviceClass.APPLE_VISION_PRO,


### PR DESCRIPTION
App Store Connect API has started to include devices with undocumented `APPLE_SILICON_MAC` device class in [list devices](https://developer.apple.com/documentation/appstoreconnectapi/list_devices) endpoint response. Such as

```json
{
    "data": [
        {
            "type": "devices",
            "id": "2BWA3JVC8A",
            "attributes": {
                "addedDate": "2024-03-18T23:18:33.000+00:00",
                "name": "soda mac",
                "deviceClass": "APPLE_SILICON_MAC",
                "model": null,
                "udid": "00006020-0C10A7180CC1E002",
                "platform": "IOS",
                "status": "ENABLED"
            },
            "links": {
                "self": "https://api.appstoreconnect.apple.com/v1/devices/2BWA3JVC8A"
            }
        }
    ]
}
```

Missing definitions for this device class can fail `app-store-connect fetch-signing-files` with the following error

```python
Traceback (most recent call last):
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 243, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/cli_app.py", line 184, in _invoke_action
    return cli_action(**action_args)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py", line 82, in fetch_signing_files
    profiles = self._get_or_create_profiles(
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py", line 199, in _get_or_create_profiles
    profiles.extend(created_profiles)
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py", line 217, in _create_missing_profiles
    device_ids = [d.id for d in devices if d.attributes.deviceClass.is_compatible(profile_type)]
  File "/Users/builder/.pyenv/versions/3.8.13/lib/python3.8/site-packages/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py", line 217, in <listcomp>
    device_ids = [d.id for d in devices if d.attributes.deviceClass.is_compatible(profile_type)]
AttributeError: 'GracefulDeviceClass' object has no attribute 'is_compatible'
```

**Updated actions:**
- `app-store-connect fetch-signing-files`