### PR TITLE
Add graceful handling for missing bundle ID identifer on `app-store-connect fetch-signing-files` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.54.3
+-------------
+
+**Improvements**
+- Fail action `app-store-connect fetch-signing-files` early with descriptive error message if bundle ID identifier is not given. [PR #438](https://github.com/codemagic-ci-cd/cli-tools/pull/438)
+
 Version 0.54.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.54.2"
+version = "0.54.3"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.54.2.dev"
+__version__ = "0.54.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py
@@ -61,7 +61,7 @@ class FetchSigningFilesAction(AbstractBaseAction, metaclass=ABCMeta):
 
         if not bundle_id_identifier:
             raise BundleIdArgument.BUNDLE_ID_IDENTIFIER.raise_argument_error(
-                "Bundle ID identifier must be specified, empty values are not allowed. For example `com.example.app`.",
+                'Bundle ID identifier must be specified, empty values are not allowed. For example "com.example.app".',
             )
 
         private_key = self._get_certificate_key(certificate_key, certificate_key_password)

--- a/src/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/fetch_signing_files_action.py
@@ -59,6 +59,11 @@ class FetchSigningFilesAction(AbstractBaseAction, metaclass=ABCMeta):
         for Bundle ID with given identifier
         """
 
+        if not bundle_id_identifier:
+            raise BundleIdArgument.BUNDLE_ID_IDENTIFIER.raise_argument_error(
+                "Bundle ID identifier must be specified, empty values are not allowed. For example `com.example.app`.",
+            )
+
         private_key = self._get_certificate_key(certificate_key, certificate_key_password)
         if private_key is None:
             raise AppStoreConnectError(f"Cannot save {SigningCertificate.s} without certificate private key")


### PR DESCRIPTION
App Store Connect [list bundle IDs](https://developer.apple.com/documentation/appstoreconnectapi/list_bundle_ids) API endpoint requires that parameter `filter[identifier]` is not an empty string. Currently this is not enforced by `app-store-connect fetch-signing-files` and can result in weird error message that does not translate well into executed CLI command.

Apply runtime parameter validation and raise an argument error in case empty identifier is used:

```shell
% app-store-connect fetch-signing-files ''
usage: app-store-connect [-h] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v]
                   {app-store-version-localizations,app-store-version-phased-releases,app-store-version-submissions,app-store-versions,apps,beta-app-review-submissions,beta-build-localizations,beta-groups,buildsbundle-idget-bundle-icertificatedevicefetch-signing-files,get-latest-app-store-build-number,get-latest-build-number,get-latest-testflight-build-number,profilesdelete-profilpublish,review-submission-items,review-submissions}
                   ...
app-store-connect: error: argument bundle_id_identifier: Bundle ID identifier must be specified, empty values are not allowed. For example "com.example.app".
```

**Updated actions:**
- `app-store-connect fetch-signing-files`