### PR TITLE
Make deprecated relations on `App` resource optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 0.54.3
 
 **Bugfixes**
 - Support device class `APPLE_SILICON_MAC` on App Store Connect API [`Device`](https://developer.apple.com/documentation/appstoreconnectapi/device) responses. [PR #437](https://github.com/codemagic-ci-cd/cli-tools/pull/437)
+- Make undocumented `preOrder` and deprecated `inAppPurchases` relationships on App Store connect https://developer.apple.com/documentation/appstoreconnectapi/app/relationships-data.dictionary model optional . [PR #439](https://github.com/codemagic-ci-cd/cli-tools/pull/439)
 
 **Improvements**
 - Fail action `app-store-connect fetch-signing-files` early with descriptive error message if bundle ID identifier is not given. [PR #438](https://github.com/codemagic-ci-cd/cli-tools/pull/438)

--- a/src/codemagic/apple/resources/app.py
+++ b/src/codemagic/apple/resources/app.py
@@ -80,8 +80,6 @@ class App(Resource):
         builds: Relationship
         endUserLicenseAgreement: Relationship
         gameCenterEnabledVersions: Relationship
-        inAppPurchases: Relationship
-        preOrder: Relationship
         preReleaseVersions: Relationship
 
         alternativeDistributionKey: Optional[Relationship] = None
@@ -98,9 +96,11 @@ class App(Resource):
         ciProduct: Optional[Relationship] = None
         customerReviews: Optional[Relationship] = None
         gameCenterDetail: Optional[Relationship] = None
+        inAppPurchases: Optional[Relationship] = None
         inAppPurchasesV2: Optional[Relationship] = None
         marketplaceSearchDetail: Optional[Relationship] = None
         perfPowerMetrics: Optional[Relationship] = None
+        preOrder: Optional[Relationship] = None
         pricePoints: Optional[Relationship] = None
         promotedPurchases: Optional[Relationship] = None
         reviewSubmissions: Optional[Relationship] = None


### PR DESCRIPTION
Occasionally App Store Connect [list apps](https://developer.apple.com/documentation/appstoreconnectapi/list_apps) and [read app information](https://developer.apple.com/documentation/appstoreconnectapi/read_app_information) endpoints respond with payloads where included [application resources](https://developer.apple.com/documentation/appstoreconnectapi/app) are lacking `preOrder` relationship, which is currently declared as mandatory.

That causes `App` object initialization to fail:

```python
File "/usr/local/lib/python3.11/site-packages/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/codemagic/tools/app_store_connect/action_groups/beta_groups_action_group.py", line 33, in add_build_to_beta_groups
    matched_beta_groups, matched_beta_group_names = self._get_beta_groups(build_id, beta_group_names)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/codemagic/tools/app_store_connect/action_groups/beta_groups_action_group.py", line 107, in _get_beta_groups
    app = self.api_client.builds.read_app(build_id)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/codemagic/apple/app_store_connect/builds/builds.py", line 96, in read_app
     return App(response["data"])
            ^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/codemagic/apple/resources/resource.py", line 253, in __init__
    self.relationships = self._create_relationships(api_response)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/codemagic/apple/resources/resource.py", line 245, in _create_relationships
    return cls.Relationships(**defined_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: App.Relationships.__init__() missing 1 required positional argument: 'preOrder'
```

Overcome this by making `preOrder` relationship optional.

It can also be seen that `inAppPurchases` relationship is marked as deprecated which means that it could be removed from response payloads in the future too. Mark that relationship as optional too for safety.