### PR TITLE
Duplicate readme pages for action groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 UNRELEASED
 -------------
 
+**Documentation**
+- Duplicate action group documentation in respective action group documentation directory in `README.md`. [PR #444](https://github.com/codemagic-ci-cd/cli-tools/pull/444)
+
 **Development**
 - Update `black`, `mypy` and `ruff` development dependencies. [PR #442](https://github.com/codemagic-ci-cd/cli-tools/pull/442)
 - Reformat sources to comply with latest `black` and `ruff` versions. [PR #442](https://github.com/codemagic-ci-cd/cli-tools/pull/442)

--- a/docs/app-store-connect/app-store-version-localizations/README.md
+++ b/docs/app-store-connect/app-store-version-localizations/README.md
@@ -1,0 +1,97 @@
+
+app-store-version-localizations
+===============================
+
+
+**Create and maintain version-specific App Store metadata that is localized.**
+### Usage
+```bash
+app-store-connect app-store-version-localizations [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](app-store-version-localizations/create.md)|Create an App Store Version Localization. Add localized version-level information for a new locale.|
+|[`delete`](app-store-version-localizations/delete.md)|Delete an App Store Version Localization. Remove a language from your version metadata.|
+|[`get`](app-store-version-localizations/get.md)|Read App Store Version Localization Information. Get localized version-level information.|
+|[`modify`](app-store-version-localizations/modify.md)|Modify an App Store Version Localization. Edit localized version-level information for a particular language.|

--- a/docs/app-store-connect/app-store-version-phased-releases/README.md
+++ b/docs/app-store-connect/app-store-version-phased-releases/README.md
@@ -1,0 +1,96 @@
+
+app-store-version-phased-releases
+=================================
+
+
+**Manage App Store phased releases of updates to your app**
+### Usage
+```bash
+app-store-connect app-store-version-phased-releases [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`cancel`](app-store-version-phased-releases/cancel.md)|Cancel a planned App Store version phased release that has not been started|
+|[`enable`](app-store-version-phased-releases/enable.md)|Enable phased release for an App Store version|
+|[`set-state`](app-store-version-phased-releases/set-state.md)|Pause or resume an App Store version phased release, or immediately release an app|

--- a/docs/app-store-connect/app-store-version-submissions/README.md
+++ b/docs/app-store-connect/app-store-version-submissions/README.md
@@ -1,0 +1,95 @@
+
+app-store-version-submissions
+=============================
+
+
+**Manage your application's App Store version review process**
+### Usage
+```bash
+app-store-connect app-store-version-submissions [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](app-store-version-submissions/create.md)|Submit an App Store Version to App Review|
+|[`delete`](app-store-version-submissions/delete.md)|Remove a version submission from App Store review|

--- a/docs/app-store-connect/app-store-versions/README.md
+++ b/docs/app-store-connect/app-store-versions/README.md
@@ -1,0 +1,99 @@
+
+app-store-versions
+==================
+
+
+**Manage the information related to an App Store version of your app**
+### Usage
+```bash
+app-store-connect app-store-versions [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](app-store-versions/create.md)|Add a new App Store version to an app using specified build.|
+|[`delete`](app-store-versions/delete.md)|Delete specified App Store version from Apple Developer portal|
+|[`get`](app-store-versions/get.md)|Read App Store Version information|
+|[`phased-release`](app-store-versions/phased-release.md)|Read the phased release status and configuration for a version with phased release enabled.|
+|[`localizations`](app-store-versions/localizations.md)|List All App Store Version Localizations for an App Store Version. Get a list of localized, version-level information about an app, for all locales.|
+|[`modify`](app-store-versions/modify.md)|Update the app store version for a specific app.|

--- a/docs/app-store-connect/apps/README.md
+++ b/docs/app-store-connect/apps/README.md
@@ -1,0 +1,102 @@
+
+apps
+====
+
+
+**Manage your apps in App Store Connect**
+### Usage
+```bash
+app-store-connect apps [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`cancel-review-submissions`](apps/cancel-review-submissions.md)|Find and cancel review submissions in App Store Connect for the given application|
+|[`expire-builds`](apps/expire-builds.md)|Expire all application builds except the given build(s)|
+|[`expire-build-submitted-for-review`](apps/expire-build-submitted-for-review.md)|Expire application build that is currently waiting for review, or is currently in review in TestFlight|
+|[`get`](apps/get.md)|Get information about a specific app|
+|[`builds`](apps/builds.md)|Get a list of builds associated with a specific app matching given constrains|
+|[`pre-release-versions`](apps/pre-release-versions.md)|Get a list of prerelease versions associated with a specific app|
+|[`app-store-versions`](apps/app-store-versions.md)|Get a list of App Store versions associated with a specific app|
+|[`list`](apps/list.md)|Find and list apps added in App Store Connect|
+|[`list-review-submissions`](apps/list-review-submissions.md)|Find and list review submissions in App Store Connect for the given application|

--- a/docs/app-store-connect/beta-app-review-submissions/README.md
+++ b/docs/app-store-connect/beta-app-review-submissions/README.md
@@ -1,0 +1,95 @@
+
+beta-app-review-submissions
+===========================
+
+
+**Manage your application's TestFlight submissions**
+### Usage
+```bash
+app-store-connect beta-app-review-submissions [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](beta-app-review-submissions/create.md)|Submit an app for beta app review to allow external testing|
+|[`list`](beta-app-review-submissions/list.md)|Find and list beta app review submissions of a build|

--- a/docs/app-store-connect/beta-build-localizations/README.md
+++ b/docs/app-store-connect/beta-build-localizations/README.md
@@ -1,0 +1,98 @@
+
+beta-build-localizations
+========================
+
+
+**Manage your beta builds localizations in App Store Connect**
+### Usage
+```bash
+app-store-connect beta-build-localizations [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](beta-build-localizations/create.md)|Create a beta build localization if it doesn't exist or update existing beta build localization for specified locale|
+|[`delete`](beta-build-localizations/delete.md)|Delete a beta build localization|
+|[`get`](beta-build-localizations/get.md)|Get beta build localization|
+|[`list`](beta-build-localizations/list.md)|List beta build localizations|
+|[`modify`](beta-build-localizations/modify.md)|Update a beta build localization|

--- a/docs/app-store-connect/beta-groups/README.md
+++ b/docs/app-store-connect/beta-groups/README.md
@@ -1,0 +1,95 @@
+
+beta-groups
+===========
+
+
+**Manage your groups of beta testers in App Store Connect**
+### Usage
+```bash
+app-store-connect beta-groups [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`add-build`](beta-groups/add-build.md)|Add build to Beta groups|
+|[`remove-build`](beta-groups/remove-build.md)|Remove build from Beta groups|

--- a/docs/app-store-connect/builds/README.md
+++ b/docs/app-store-connect/builds/README.md
@@ -1,0 +1,103 @@
+
+builds
+======
+
+
+**Manage your builds in App Store Connect**
+### Usage
+```bash
+app-store-connect builds [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`add-beta-test-info`](builds/add-beta-test-info.md)|Add localized What's new (what to test) information|
+|[`expire`](builds/expire.md)|Expire a specific build, an expired build becomes unavailable for testing|
+|[`get`](builds/get.md)|Get information about a specific build|
+|[`app`](builds/app.md)|Get the App details for a specific build.|
+|[`app-store-version`](builds/app-store-version.md)|Get the App Store version of a specific build.|
+|[`beta-details`](builds/beta-details.md)|Get Build Beta Details Information of a specific build.|
+|[`pre-release-version`](builds/pre-release-version.md)|Get the prerelease version for a specific build|
+|[`list`](builds/list.md)|List Builds from Apple Developer Portal matching given constraints|
+|[`submit-to-app-store`](builds/submit-to-app-store.md)|Submit build to App Store review|
+|[`submit-to-testflight`](builds/submit-to-testflight.md)|Submit build to TestFlight|

--- a/docs/app-store-connect/bundle-ids/README.md
+++ b/docs/app-store-connect/bundle-ids/README.md
@@ -1,0 +1,101 @@
+
+bundle-ids
+==========
+
+
+**Manage bundle identifiers and their capabilities**
+### Usage
+```bash
+app-store-connect bundle-ids [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](bundle-ids/create.md)|Create Bundle ID in Apple Developer portal for specifier identifier|
+|[`delete`](bundle-ids/delete.md)|Delete specified Bundle ID from Apple Developer portal|
+|[`disable-capabilities`](bundle-ids/disable-capabilities.md)|Disable identifier capabilities|
+|[`enable-capabilities`](bundle-ids/enable-capabilities.md)|Enable capabilities for identifier|
+|[`get`](bundle-ids/get.md)|Get specified Bundle ID from Apple Developer portal|
+|[`capabilities`](bundle-ids/capabilities.md)|Check the capabilities that are enabled for identifier|
+|[`profiles`](bundle-ids/profiles.md)|List provisioning profiles from Apple Developer Portal for specified Bundle IDs|
+|[`list`](bundle-ids/list.md)|List Bundle IDs from Apple Developer portal matching given constraints|

--- a/docs/app-store-connect/certificates/README.md
+++ b/docs/app-store-connect/certificates/README.md
@@ -1,0 +1,97 @@
+
+certificates
+============
+
+
+**Manage code signing certificates**
+### Usage
+```bash
+app-store-connect certificates [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](certificates/create.md)|Create code signing certificates of given type|
+|[`delete`](certificates/delete.md)|Delete specified Signing Certificate from Apple Developer portal|
+|[`get`](certificates/get.md)|Get specified Signing Certificate from Apple Developer portal|
+|[`list`](certificates/list.md)|List Signing Certificates from Apple Developer Portal matching given constraints|

--- a/docs/app-store-connect/devices/README.md
+++ b/docs/app-store-connect/devices/README.md
@@ -1,0 +1,95 @@
+
+devices
+=======
+
+
+**Manage Apple devices**
+### Usage
+```bash
+app-store-connect devices [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`list`](devices/list.md)|List Devices from Apple Developer portal matching given constraints|
+|[`register`](devices/register.md)|Register new Devices for app development|

--- a/docs/app-store-connect/profiles/README.md
+++ b/docs/app-store-connect/profiles/README.md
@@ -1,0 +1,97 @@
+
+profiles
+========
+
+
+**Manage provisioning profiles**
+### Usage
+```bash
+app-store-connect profiles [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](profiles/create.md)|Create provisioning profile of given type|
+|[`delete`](profiles/delete.md)|Delete specified Profile from Apple Developer portal|
+|[`get`](profiles/get.md)|Get specified Profile from Apple Developer portal|
+|[`list`](profiles/list.md)|List Profiles from Apple Developer portal matching given constraints|

--- a/docs/app-store-connect/review-submission-items/README.md
+++ b/docs/app-store-connect/review-submission-items/README.md
@@ -1,0 +1,95 @@
+
+review-submission-items
+=======================
+
+
+**Manage the contents of your review submission**
+### Usage
+```bash
+app-store-connect review-submission-items [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`create`](review-submission-items/create.md)|Add contents to review submission for App Store review request|
+|[`delete`](review-submission-items/delete.md)|Delete specified Review Submission item|

--- a/docs/app-store-connect/review-submissions/README.md
+++ b/docs/app-store-connect/review-submissions/README.md
@@ -1,0 +1,98 @@
+
+review-submissions
+==================
+
+
+**Manage your App Store version review submissions**
+### Usage
+```bash
+app-store-connect review-submissions [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--log-api-calls]
+    [--api-unauthorized-retries UNAUTHORIZED_REQUEST_RETRIES]
+    [--api-server-error-retries SERVER_ERROR_RETRIES]
+    [--disable-jwt-cache]
+    [--json]
+    [--issuer-id ISSUER_ID]
+    [--key-id KEY_IDENTIFIER]
+    [--private-key PRIVATE_KEY]
+    [--certificates-dir CERTIFICATES_DIRECTORY]
+    [--profiles-dir PROFILES_DIRECTORY]
+    ACTION
+```
+### Optional arguments for command `app-store-connect`
+
+##### `--log-api-calls`
+
+
+Turn on logging for App Store Connect API HTTP requests
+##### `--api-unauthorized-retries, -r=UNAUTHORIZED_REQUEST_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to an authentication error (401 Unauthorized response from the server). In case of the above authentication error, the request is retried usinga new JSON Web Token as many times until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_UNAUTHORIZED_RETRIES`. [Default: 3]
+##### `--api-server-error-retries=SERVER_ERROR_RETRIES`
+
+
+Specify how many times the App Store Connect API request should be retried in case the called request fails due to a server error (response with status code 5xx). In case of server error, the request is retried until the number of retries is exhausted. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_API_SERVER_ERROR_RETRIES`. [Default: 3]
+##### `--disable-jwt-cache`
+
+
+Turn off caching App Store Connect JSON Web Tokens to disk. By default generated tokens are cached to disk to be reused between separate processes, which can can reduce number of false positive authentication errors from App Store Connect API. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_DISABLE_JWT_CACHE`.
+##### `--json`
+
+
+Whether to show the resource in JSON format
+##### `--issuer-id=ISSUER_ID`
+
+
+App Store Connect API Key Issuer ID. Identifies the issuer who created the authentication token. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_ISSUER_ID`. Alternatively to entering `ISSUER_ID` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--key-id=KEY_IDENTIFIER`
+
+
+App Store Connect API Key ID. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_KEY_IDENTIFIER`. Alternatively to entering `KEY_IDENTIFIER` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--private-key=PRIVATE_KEY`
+
+
+App Store Connect API private key used for JWT authentication to communicate with Apple services. Learn more at https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api. If not provided, the key will be searched from the following directories in sequence for a private key file with the name `AuthKey_<key_identifier>.p8`: private_keys, ~/private_keys, ~/.private_keys, ~/.appstoreconnect/private_keys, where <key_identifier> is the value of `--key-id`. If not given, the value will be checked from the environment variable `APP_STORE_CONNECT_PRIVATE_KEY`. Alternatively to entering `PRIVATE_KEY` in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+##### `--certificates-dir=CERTIFICATES_DIRECTORY`
+
+
+Directory where the code signing certificates will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Certificates`
+##### `--profiles-dir=PROFILES_DIRECTORY`
+
+
+Directory where the provisioning profiles will be saved. Default:&nbsp;`$HOME/Library/MobileDevice/Provisioning Profiles`
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`cancel`](review-submissions/cancel.md)|Discard a specific review submission from App Review|
+|[`confirm`](review-submissions/confirm.md)|Confirm pending review submission for App Review|
+|[`create`](review-submissions/create.md)|Create a review submission request for application's latest App Store Version|
+|[`get`](review-submissions/get.md)|Read Review Submission information|
+|[`items`](review-submissions/items.md)|List review submission items for specified review submission|

--- a/docs/firebase-app-distribution/releases/README.md
+++ b/docs/firebase-app-distribution/releases/README.md
@@ -1,0 +1,60 @@
+
+releases
+========
+
+
+**Manage your Firebase application releases**
+### Usage
+```bash
+firebase-app-distribution releases [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    (--project-id PROJECT_ID | --project-number PROJECT_NUMBER)
+    [--credentials FIREBASE_SERVICE_ACCOUNT_CREDENTIALS]
+    ACTION
+```
+### Required mutually exclusive arguments for command `firebase-app-distribution`
+
+##### `--project-id=PROJECT_ID`
+
+
+Deprecated in version 0.53.5. Use `--project-number` instead
+##### `--project-number, -p=PROJECT_NUMBER`
+
+
+Project number in Firebase. For example `228333310124`
+### Optional arguments for command `firebase-app-distribution`
+
+##### `--credentials, -c=FIREBASE_SERVICE_ACCOUNT_CREDENTIALS`
+
+
+Firebase service account credentials with JSON key type to access Firebase. If not given, the value will be checked from the environment variable `FIREBASE_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`list`](releases/list.md)|List releases for the Firebase application|

--- a/docs/google-play/tracks/README.md
+++ b/docs/google-play/tracks/README.md
@@ -1,0 +1,51 @@
+
+tracks
+======
+
+
+**Manage your Google Play release tracks**
+### Usage
+```bash
+google-play tracks [-h] [--log-stream STREAM] [--no-color] [--version] [-s] [-v]
+    [--credentials GCLOUD_SERVICE_ACCOUNT_CREDENTIALS]
+    ACTION
+```
+### Optional arguments for command `google-play`
+
+##### `--credentials=GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`
+
+
+Gcloud service account credentials with the `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. Alternatively to entering CREDENTIALS in plaintext, it may also be specified using the `@env:` prefix followed by an environment variable name, or the `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from the file at `<file_path>`.
+### Common options
+
+##### `-h, --help`
+
+
+show this help message and exit
+##### `--log-stream=stderr | stdout`
+
+
+Log output stream. Default `stderr`
+##### `--no-color`
+
+
+Do not use ANSI colors to format terminal output
+##### `--version`
+
+
+Show tool version and exit
+##### `-s, --silent`
+
+
+Disable log output for commands
+##### `-v, --verbose`
+
+
+Enable verbose logging for commands
+### Actions
+
+|Action|Description|
+| :--- | :--- |
+|[`get`](tracks/get.md)|Get information about specified track from Google Play Developer API|
+|[`list`](tracks/list.md)|Get information about specified track from Google Play Developer API|
+|[`promote-release`](tracks/promote-release.md)|Promote releases from source track to target track. If filters for source track release are not specified, then the latest release will be promoted|


### PR DESCRIPTION
Duplicate action group documentation in respective action group documentation directory in `README.md`.