### PR TITLE
Fix action documentation links in action group readme tables

### DIFF
--- a/docs/app-store-connect/app-store-version-localizations/README.md
+++ b/docs/app-store-connect/app-store-version-localizations/README.md
@@ -91,7 +91,7 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](app-store-version-localizations/create.md)|Create an App Store Version Localization. Add localized version-level information for a new locale.|
-|[`delete`](app-store-version-localizations/delete.md)|Delete an App Store Version Localization. Remove a language from your version metadata.|
-|[`get`](app-store-version-localizations/get.md)|Read App Store Version Localization Information. Get localized version-level information.|
-|[`modify`](app-store-version-localizations/modify.md)|Modify an App Store Version Localization. Edit localized version-level information for a particular language.|
+|[`create`](create.md)|Create an App Store Version Localization. Add localized version-level information for a new locale.|
+|[`delete`](delete.md)|Delete an App Store Version Localization. Remove a language from your version metadata.|
+|[`get`](get.md)|Read App Store Version Localization Information. Get localized version-level information.|
+|[`modify`](modify.md)|Modify an App Store Version Localization. Edit localized version-level information for a particular language.|

--- a/docs/app-store-connect/app-store-version-phased-releases/README.md
+++ b/docs/app-store-connect/app-store-version-phased-releases/README.md
@@ -91,6 +91,6 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`cancel`](app-store-version-phased-releases/cancel.md)|Cancel a planned App Store version phased release that has not been started|
-|[`enable`](app-store-version-phased-releases/enable.md)|Enable phased release for an App Store version|
-|[`set-state`](app-store-version-phased-releases/set-state.md)|Pause or resume an App Store version phased release, or immediately release an app|
+|[`cancel`](cancel.md)|Cancel a planned App Store version phased release that has not been started|
+|[`enable`](enable.md)|Enable phased release for an App Store version|
+|[`set-state`](set-state.md)|Pause or resume an App Store version phased release, or immediately release an app|

--- a/docs/app-store-connect/app-store-version-submissions/README.md
+++ b/docs/app-store-connect/app-store-version-submissions/README.md
@@ -91,5 +91,5 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](app-store-version-submissions/create.md)|Submit an App Store Version to App Review|
-|[`delete`](app-store-version-submissions/delete.md)|Remove a version submission from App Store review|
+|[`create`](create.md)|Submit an App Store Version to App Review|
+|[`delete`](delete.md)|Remove a version submission from App Store review|

--- a/docs/app-store-connect/app-store-versions/README.md
+++ b/docs/app-store-connect/app-store-versions/README.md
@@ -91,9 +91,9 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](app-store-versions/create.md)|Add a new App Store version to an app using specified build.|
-|[`delete`](app-store-versions/delete.md)|Delete specified App Store version from Apple Developer portal|
-|[`get`](app-store-versions/get.md)|Read App Store Version information|
-|[`phased-release`](app-store-versions/phased-release.md)|Read the phased release status and configuration for a version with phased release enabled.|
-|[`localizations`](app-store-versions/localizations.md)|List All App Store Version Localizations for an App Store Version. Get a list of localized, version-level information about an app, for all locales.|
-|[`modify`](app-store-versions/modify.md)|Update the app store version for a specific app.|
+|[`create`](create.md)|Add a new App Store version to an app using specified build.|
+|[`delete`](delete.md)|Delete specified App Store version from Apple Developer portal|
+|[`get`](get.md)|Read App Store Version information|
+|[`phased-release`](phased-release.md)|Read the phased release status and configuration for a version with phased release enabled.|
+|[`localizations`](localizations.md)|List All App Store Version Localizations for an App Store Version. Get a list of localized, version-level information about an app, for all locales.|
+|[`modify`](modify.md)|Update the app store version for a specific app.|

--- a/docs/app-store-connect/apps/README.md
+++ b/docs/app-store-connect/apps/README.md
@@ -91,12 +91,12 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`cancel-review-submissions`](apps/cancel-review-submissions.md)|Find and cancel review submissions in App Store Connect for the given application|
-|[`expire-builds`](apps/expire-builds.md)|Expire all application builds except the given build(s)|
-|[`expire-build-submitted-for-review`](apps/expire-build-submitted-for-review.md)|Expire application build that is currently waiting for review, or is currently in review in TestFlight|
-|[`get`](apps/get.md)|Get information about a specific app|
-|[`builds`](apps/builds.md)|Get a list of builds associated with a specific app matching given constrains|
-|[`pre-release-versions`](apps/pre-release-versions.md)|Get a list of prerelease versions associated with a specific app|
-|[`app-store-versions`](apps/app-store-versions.md)|Get a list of App Store versions associated with a specific app|
-|[`list`](apps/list.md)|Find and list apps added in App Store Connect|
-|[`list-review-submissions`](apps/list-review-submissions.md)|Find and list review submissions in App Store Connect for the given application|
+|[`cancel-review-submissions`](cancel-review-submissions.md)|Find and cancel review submissions in App Store Connect for the given application|
+|[`expire-builds`](expire-builds.md)|Expire all application builds except the given build(s)|
+|[`expire-build-submitted-for-review`](expire-build-submitted-for-review.md)|Expire application build that is currently waiting for review, or is currently in review in TestFlight|
+|[`get`](get.md)|Get information about a specific app|
+|[`builds`](builds.md)|Get a list of builds associated with a specific app matching given constrains|
+|[`pre-release-versions`](pre-release-versions.md)|Get a list of prerelease versions associated with a specific app|
+|[`app-store-versions`](app-store-versions.md)|Get a list of App Store versions associated with a specific app|
+|[`list`](list.md)|Find and list apps added in App Store Connect|
+|[`list-review-submissions`](list-review-submissions.md)|Find and list review submissions in App Store Connect for the given application|

--- a/docs/app-store-connect/beta-app-review-submissions/README.md
+++ b/docs/app-store-connect/beta-app-review-submissions/README.md
@@ -91,5 +91,5 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](beta-app-review-submissions/create.md)|Submit an app for beta app review to allow external testing|
-|[`list`](beta-app-review-submissions/list.md)|Find and list beta app review submissions of a build|
+|[`create`](create.md)|Submit an app for beta app review to allow external testing|
+|[`list`](list.md)|Find and list beta app review submissions of a build|

--- a/docs/app-store-connect/beta-build-localizations/README.md
+++ b/docs/app-store-connect/beta-build-localizations/README.md
@@ -91,8 +91,8 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](beta-build-localizations/create.md)|Create a beta build localization if it doesn't exist or update existing beta build localization for specified locale|
-|[`delete`](beta-build-localizations/delete.md)|Delete a beta build localization|
-|[`get`](beta-build-localizations/get.md)|Get beta build localization|
-|[`list`](beta-build-localizations/list.md)|List beta build localizations|
-|[`modify`](beta-build-localizations/modify.md)|Update a beta build localization|
+|[`create`](create.md)|Create a beta build localization if it doesn't exist or update existing beta build localization for specified locale|
+|[`delete`](delete.md)|Delete a beta build localization|
+|[`get`](get.md)|Get beta build localization|
+|[`list`](list.md)|List beta build localizations|
+|[`modify`](modify.md)|Update a beta build localization|

--- a/docs/app-store-connect/beta-groups/README.md
+++ b/docs/app-store-connect/beta-groups/README.md
@@ -91,5 +91,5 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`add-build`](beta-groups/add-build.md)|Add build to Beta groups|
-|[`remove-build`](beta-groups/remove-build.md)|Remove build from Beta groups|
+|[`add-build`](add-build.md)|Add build to Beta groups|
+|[`remove-build`](remove-build.md)|Remove build from Beta groups|

--- a/docs/app-store-connect/builds/README.md
+++ b/docs/app-store-connect/builds/README.md
@@ -91,13 +91,13 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`add-beta-test-info`](builds/add-beta-test-info.md)|Add localized What's new (what to test) information|
-|[`expire`](builds/expire.md)|Expire a specific build, an expired build becomes unavailable for testing|
-|[`get`](builds/get.md)|Get information about a specific build|
-|[`app`](builds/app.md)|Get the App details for a specific build.|
-|[`app-store-version`](builds/app-store-version.md)|Get the App Store version of a specific build.|
-|[`beta-details`](builds/beta-details.md)|Get Build Beta Details Information of a specific build.|
-|[`pre-release-version`](builds/pre-release-version.md)|Get the prerelease version for a specific build|
-|[`list`](builds/list.md)|List Builds from Apple Developer Portal matching given constraints|
-|[`submit-to-app-store`](builds/submit-to-app-store.md)|Submit build to App Store review|
-|[`submit-to-testflight`](builds/submit-to-testflight.md)|Submit build to TestFlight|
+|[`add-beta-test-info`](add-beta-test-info.md)|Add localized What's new (what to test) information|
+|[`expire`](expire.md)|Expire a specific build, an expired build becomes unavailable for testing|
+|[`get`](get.md)|Get information about a specific build|
+|[`app`](app.md)|Get the App details for a specific build.|
+|[`app-store-version`](app-store-version.md)|Get the App Store version of a specific build.|
+|[`beta-details`](beta-details.md)|Get Build Beta Details Information of a specific build.|
+|[`pre-release-version`](pre-release-version.md)|Get the prerelease version for a specific build|
+|[`list`](list.md)|List Builds from Apple Developer Portal matching given constraints|
+|[`submit-to-app-store`](submit-to-app-store.md)|Submit build to App Store review|
+|[`submit-to-testflight`](submit-to-testflight.md)|Submit build to TestFlight|

--- a/docs/app-store-connect/bundle-ids/README.md
+++ b/docs/app-store-connect/bundle-ids/README.md
@@ -91,11 +91,11 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](bundle-ids/create.md)|Create Bundle ID in Apple Developer portal for specifier identifier|
-|[`delete`](bundle-ids/delete.md)|Delete specified Bundle ID from Apple Developer portal|
-|[`disable-capabilities`](bundle-ids/disable-capabilities.md)|Disable identifier capabilities|
-|[`enable-capabilities`](bundle-ids/enable-capabilities.md)|Enable capabilities for identifier|
-|[`get`](bundle-ids/get.md)|Get specified Bundle ID from Apple Developer portal|
-|[`capabilities`](bundle-ids/capabilities.md)|Check the capabilities that are enabled for identifier|
-|[`profiles`](bundle-ids/profiles.md)|List provisioning profiles from Apple Developer Portal for specified Bundle IDs|
-|[`list`](bundle-ids/list.md)|List Bundle IDs from Apple Developer portal matching given constraints|
+|[`create`](create.md)|Create Bundle ID in Apple Developer portal for specifier identifier|
+|[`delete`](delete.md)|Delete specified Bundle ID from Apple Developer portal|
+|[`disable-capabilities`](disable-capabilities.md)|Disable identifier capabilities|
+|[`enable-capabilities`](enable-capabilities.md)|Enable capabilities for identifier|
+|[`get`](get.md)|Get specified Bundle ID from Apple Developer portal|
+|[`capabilities`](capabilities.md)|Check the capabilities that are enabled for identifier|
+|[`profiles`](profiles.md)|List provisioning profiles from Apple Developer Portal for specified Bundle IDs|
+|[`list`](list.md)|List Bundle IDs from Apple Developer portal matching given constraints|

--- a/docs/app-store-connect/certificates/README.md
+++ b/docs/app-store-connect/certificates/README.md
@@ -91,7 +91,7 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](certificates/create.md)|Create code signing certificates of given type|
-|[`delete`](certificates/delete.md)|Delete specified Signing Certificate from Apple Developer portal|
-|[`get`](certificates/get.md)|Get specified Signing Certificate from Apple Developer portal|
-|[`list`](certificates/list.md)|List Signing Certificates from Apple Developer Portal matching given constraints|
+|[`create`](create.md)|Create code signing certificates of given type|
+|[`delete`](delete.md)|Delete specified Signing Certificate from Apple Developer portal|
+|[`get`](get.md)|Get specified Signing Certificate from Apple Developer portal|
+|[`list`](list.md)|List Signing Certificates from Apple Developer Portal matching given constraints|

--- a/docs/app-store-connect/devices/README.md
+++ b/docs/app-store-connect/devices/README.md
@@ -91,5 +91,5 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`list`](devices/list.md)|List Devices from Apple Developer portal matching given constraints|
-|[`register`](devices/register.md)|Register new Devices for app development|
+|[`list`](list.md)|List Devices from Apple Developer portal matching given constraints|
+|[`register`](register.md)|Register new Devices for app development|

--- a/docs/app-store-connect/profiles/README.md
+++ b/docs/app-store-connect/profiles/README.md
@@ -91,7 +91,7 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](profiles/create.md)|Create provisioning profile of given type|
-|[`delete`](profiles/delete.md)|Delete specified Profile from Apple Developer portal|
-|[`get`](profiles/get.md)|Get specified Profile from Apple Developer portal|
-|[`list`](profiles/list.md)|List Profiles from Apple Developer portal matching given constraints|
+|[`create`](create.md)|Create provisioning profile of given type|
+|[`delete`](delete.md)|Delete specified Profile from Apple Developer portal|
+|[`get`](get.md)|Get specified Profile from Apple Developer portal|
+|[`list`](list.md)|List Profiles from Apple Developer portal matching given constraints|

--- a/docs/app-store-connect/review-submission-items/README.md
+++ b/docs/app-store-connect/review-submission-items/README.md
@@ -91,5 +91,5 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`create`](review-submission-items/create.md)|Add contents to review submission for App Store review request|
-|[`delete`](review-submission-items/delete.md)|Delete specified Review Submission item|
+|[`create`](create.md)|Add contents to review submission for App Store review request|
+|[`delete`](delete.md)|Delete specified Review Submission item|

--- a/docs/app-store-connect/review-submissions/README.md
+++ b/docs/app-store-connect/review-submissions/README.md
@@ -91,8 +91,8 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`cancel`](review-submissions/cancel.md)|Discard a specific review submission from App Review|
-|[`confirm`](review-submissions/confirm.md)|Confirm pending review submission for App Review|
-|[`create`](review-submissions/create.md)|Create a review submission request for application's latest App Store Version|
-|[`get`](review-submissions/get.md)|Read Review Submission information|
-|[`items`](review-submissions/items.md)|List review submission items for specified review submission|
+|[`cancel`](cancel.md)|Discard a specific review submission from App Review|
+|[`confirm`](confirm.md)|Confirm pending review submission for App Review|
+|[`create`](create.md)|Create a review submission request for application's latest App Store Version|
+|[`get`](get.md)|Read Review Submission information|
+|[`items`](items.md)|List review submission items for specified review submission|

--- a/docs/firebase-app-distribution/releases/README.md
+++ b/docs/firebase-app-distribution/releases/README.md
@@ -57,4 +57,4 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`list`](releases/list.md)|List releases for the Firebase application|
+|[`list`](list.md)|List releases for the Firebase application|

--- a/docs/google-play/tracks/README.md
+++ b/docs/google-play/tracks/README.md
@@ -46,6 +46,6 @@ Enable verbose logging for commands
 
 |Action|Description|
 | :--- | :--- |
-|[`get`](tracks/get.md)|Get information about specified track from Google Play Developer API|
-|[`list`](tracks/list.md)|Get information about specified track from Google Play Developer API|
-|[`promote-release`](tracks/promote-release.md)|Promote releases from source track to target track. If filters for source track release are not specified, then the latest release will be promoted|
+|[`get`](get.md)|Get information about specified track from Google Play Developer API|
+|[`list`](list.md)|Get information about specified track from Google Play Developer API|
+|[`promote-release`](promote-release.md)|Promote releases from source track to target track. If filters for source track release are not specified, then the latest release will be promoted|


### PR DESCRIPTION
Reamde files that were added in #444 had broken links to action documentation pages. This PR fixes them.