### PR TITLE
Fix `android-app-bundle build-apks` and  `android-app-bundle build-universal-apk` actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.57.0
+Version 0.57.1
 -------------
 
 **Bugfixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Version 0.57.0
 -------------
 
+**Bugfixes**
+- Fix actions `android-app-bundle build-apks` and `android-app-bundle build-universal-apk` when invoked with keystore arguments. [PR #447](https://github.com/codemagic-ci-cd/cli-tools/pull/447)
+
+Version 0.57.0
+-------------
+
 This release contains changes from [PR #446](https://github.com/codemagic-ci-cd/cli-tools/pull/446) and adds new features to tool `google-play` to manage Google Play releases and application uploads.
 
 **Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.57.0"
+version = "0.57.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.0.dev"
+__version__ = "0.57.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/shell_tools/bundletool.py
+++ b/src/codemagic/shell_tools/bundletool.py
@@ -127,7 +127,7 @@ class Bundletool(JavaJarTool):
 
         obfuscate_patterns = []
         if keystore:
-            cmd.extend(("--keystore", keystore))
+            cmd.extend(("--ks", keystore))
         if keystore_password:
             obfuscate_patterns.append(f"pass:{keystore_password}")
             cmd.extend(("--ks-pass", f"pass:{keystore_password}"))
@@ -135,7 +135,7 @@ class Bundletool(JavaJarTool):
             cmd.extend(("--ks-key-alias", key_alias))
         if key_password:
             obfuscate_patterns.append(f"pass:{key_password}")
-            cmd.extend(("--key-password", f"pass:{key_password}"))
+            cmd.extend(("--key-pass", f"pass:{key_password}"))
 
         self._run_command(
             cmd,


### PR DESCRIPTION
Fix a regression from #446 that caused `android-app-bundle build-apks` and  `android-app-bundle build-universal-apk` actions to fail unexpectedly if keystore arguments were provided.

Keystore and key password arguments were passed to bundletool using invalid flags (originally in version 0.56.0 like [this](https://github.com/codemagic-ci-cd/cli-tools/blob/v0.56.0/src/codemagic/tools/android_app_bundle.py#L477-L484) and in 0.57.0 as [this](https://github.com/codemagic-ci-cd/cli-tools/blob/v0.57.0/src/codemagic/shell_tools/bundletool.py#L129-L138)).