### PR TITLE
Bugfix: Pass correct keystore_password to jarsigner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.57.3
+-------------
+
+**Bugfixes**
+- Fix action `android-app-bundle sign` when invoked with keystore arguments. [PR #449](https://github.com/codemagic-ci-cd/cli-tools/pull/449)
+
 Version 0.57.2
 -------------
 

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.2.dev"
+__version__ = "0.57.3.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/shell_tools/jarsigner.py
+++ b/src/codemagic/shell_tools/jarsigner.py
@@ -33,7 +33,7 @@ class Jarsigner(ShellTool):
                 *("-sigalg", "SHA1withRSA"),
                 *("-digestalg", "SHA1"),
                 *("-keystore", keystore),
-                *("-storepass", *keystore_password),
+                *("-storepass", keystore_password),
                 *("-keypass", key_password),
                 file_to_sign,
                 key_alias,


### PR DESCRIPTION
Pass correct `keystore_password` to `jarsigner` which was introduced in https://github.com/codemagic-ci-cd/cli-tools/pull/446