### PR TITLE
Fix App Store submission options for `app-store-connect publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.57.4
+-------------
+
+**Bugfixes**
+- Fix submitting uploaded application to App Store when running action `app-store-connect publish` using `--app-store` flag. [PR #452](https://github.com/codemagic-ci-cd/cli-tools/pull/452)
+
 Version 0.57.3
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.57.3"
+version = "0.57.4"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.3.dev"
+__version__ = "0.57.4.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/app_store_connect/actions/publish_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/publish_action.py
@@ -353,12 +353,12 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
                 self.logger.error(Colors.RED(error.args[0]))
 
         if failed_packages:
-            raise AppStoreConnectError(f'Failed to publish {", ".join(failed_packages)}')
+            raise AppStoreConnectError(f"Failed to publish {', '.join(failed_packages)}")
 
     def _log_skip_validation_deprecation(self):
         flag = PublishArgument.SKIP_PACKAGE_VALIDATION.flag
         message = (
-            f'{Colors.YELLOW("Deprecation warning!")} Support for {Colors.WHITE(flag)} is deprecated'
+            f"{Colors.YELLOW('Deprecation warning!')} Support for {Colors.WHITE(flag)} is deprecated"
             "and this flag will be removed in future releases."
             "\n"
             f"Starting from version 0.14.0 package validation "
@@ -406,7 +406,12 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
         build = self._get_uploaded_build(app, application_package, max_find_build_wait)
 
         if beta_test_info_options:
-            self.add_beta_test_info(build.id, **beta_test_info_options.__dict__)
+            self.add_beta_test_info(
+                build.id,
+                beta_build_localizations=beta_test_info_options.beta_build_localizations,
+                locale=beta_test_info_options.locale,
+                whats_new=beta_test_info_options.whats_new,
+            )
 
         if testflight_options or app_store_options or beta_group_options:
             self.wait_until_build_is_processed(build, max_build_processing_wait)
@@ -422,7 +427,7 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             self.submit_to_testflight(
                 build.id,
                 max_build_processing_wait=0,
-                **dataclasses.asdict(testflight_options),
+                expire_build_submitted_for_review=testflight_options.expire_build_submitted_for_review,
             )
 
         if app_store_options:
@@ -434,7 +439,26 @@ class PublishAction(AbstractBaseAction, metaclass=ABCMeta):
             self.submit_to_app_store(
                 build.id,
                 max_build_processing_wait=0,
-                **dataclasses.asdict(app_store_options),
+                cancel_previous_submissions=app_store_options.cancel_previous_submissions,
+                # App Store Version information arguments
+                copyright=app_store_options.copyright,
+                earliest_release_date=app_store_options.earliest_release_date,
+                platform=app_store_options.platform,
+                release_type=app_store_options.release_type,
+                version_string=app_store_options.version_string,
+                app_store_version_info=app_store_options.app_store_version_info,
+                # App Store Version Localization arguments
+                description=app_store_options.description,
+                keywords=app_store_options.keywords,
+                locale=app_store_options.locale,
+                marketing_url=app_store_options.marketing_url,
+                promotional_text=app_store_options.promotional_text,
+                support_url=app_store_options.support_url,
+                whats_new=app_store_options.whats_new,
+                app_store_version_localizations=app_store_options.app_store_version_localizations,
+                # App Store Version Phased Release arguments
+                enable_phased_release=app_store_options.enable_phased_release,
+                disable_phased_release=app_store_options.disable_phased_release,
             )
 
     def _find_build(

--- a/tests/tools/app_store_connect/actions/publish_action/test_app_store_submission.py
+++ b/tests/tools/app_store_connect/actions/publish_action/test_app_store_submission.py
@@ -1,6 +1,8 @@
 import pathlib
 from unittest import mock
 
+from codemagic.apple.app_store_connect import IssuerId
+from codemagic.apple.app_store_connect import KeyIdentifier
 from codemagic.apple.resources import Locale
 from codemagic.apple.resources import Platform
 from codemagic.apple.resources import ReleaseType
@@ -9,7 +11,12 @@ from codemagic.tools.app_store_connect.arguments import AppStoreVersionLocalizat
 from codemagic.tools.app_store_connect.arguments import Types
 
 
-def test_app_store_submission(app_store_connect: AppStoreConnect):
+def test_app_store_submission():
+    app_store_connect = AppStoreConnect(
+        issuer_id=IssuerId("issuer-id"),
+        key_identifier=KeyIdentifier("key-identifier"),
+        private_key="private-key",
+    )
     mock_ipa = mock.MagicMock(version="1.2.3", is_for_tvos=lambda: False)
     mock_build = mock.MagicMock(id="mock-build-id")
 

--- a/tests/tools/app_store_connect/actions/publish_action/test_app_store_submission.py
+++ b/tests/tools/app_store_connect/actions/publish_action/test_app_store_submission.py
@@ -1,0 +1,70 @@
+import pathlib
+from unittest import mock
+
+from codemagic.apple.resources import Locale
+from codemagic.apple.resources import Platform
+from codemagic.apple.resources import ReleaseType
+from codemagic.tools import AppStoreConnect
+from codemagic.tools.app_store_connect.arguments import AppStoreVersionLocalizationInfo
+from codemagic.tools.app_store_connect.arguments import Types
+
+
+def test_app_store_submission(app_store_connect: AppStoreConnect):
+    mock_ipa = mock.MagicMock(version="1.2.3", is_for_tvos=lambda: False)
+    mock_build = mock.MagicMock(id="mock-build-id")
+
+    with mock.patch.object(
+        app_store_connect,
+        "_get_publishing_application_packages",
+        return_value=[mock_ipa],
+    ), mock.patch.object(
+        app_store_connect,
+        "_publish_application_package",
+    ), mock.patch.object(
+        app_store_connect,
+        "_get_uploaded_build_application",
+        return_value=mock.MagicMock(),
+    ), mock.patch.object(
+        app_store_connect,
+        "_get_uploaded_build",
+        return_value=mock_build,
+    ), mock.patch.object(
+        app_store_connect,
+        "wait_until_build_is_processed",
+    ), mock.patch.object(
+        app_store_connect,
+        "submit_to_app_store",
+    ) as mock_submit_to_app_store:
+        app_store_connect.publish(
+            [pathlib.Path("path/to/application.ipa")],
+            submit_to_app_store=True,
+            release_type=ReleaseType.MANUAL,
+            app_store_version_localizations=Types.AppStoreVersionLocalizationInfoArgument(
+                raw_value='[{"locale":"en-GB", "whats_new":"U.K. notes"}, {"locale":"fi","whats_new":"Finnish notes"}]',
+            ),
+        )
+
+    mock_submit_to_app_store.assert_called_once_with(
+        "mock-build-id",
+        max_build_processing_wait=0,
+        app_store_version_info=None,
+        app_store_version_localizations=[
+            AppStoreVersionLocalizationInfo(locale=Locale.EN_GB, whats_new="U.K. notes"),
+            AppStoreVersionLocalizationInfo(locale=Locale.FI, whats_new="Finnish notes"),
+        ],
+        cancel_previous_submissions=False,
+        copyright=None,
+        description=None,
+        disable_phased_release=None,
+        earliest_release_date=None,
+        enable_phased_release=None,
+        keywords=None,
+        locale=None,
+        marketing_url=None,
+        platform=Platform.IOS,
+        promotional_text=None,
+        release_type=ReleaseType.MANUAL,
+        support_url=None,
+        version_string="1.2.3",
+        whats_new=None,
+    )


### PR DESCRIPTION
**Fixes #451.**

Fix issues related to submitting apps to App Store using action `app-store-connect publish` with `--app-store` option.

**Issue description**

AppStoreConnect.publish first uploads the binaries using the private method _process_application_after_upload. If that succeeds, post-processing is carried out by another private method, _process_application_after_upload, which invokes additional actions based on the supplied CLI options.

The arguments for these actions are gathered using special dataclasses that mimic the signatures of the actions. However, the actions themselves were invoked via the Python API using dictionary unpacking, where arguments were passed as `**dataclasses.asdict(action_args_dataclass)`. This conversion to a dictionary resulted in the loss of type information. Consequently, non-primitive values, such as:
```python
[AppStoreVersionLocalizationInfo(locale='en-GB', ...)]
```
were converted to:
```python
[{"locale": "en-GB", ...}]
```
which is not the expected format.

While it would be possible to use `**action_args_dataclass.__dict__` instead of `**dataclasses.asdict(action_args_dataclass)` to retain the original types, a better approach for readability, linter, and type checker support would be to explicitly pass all values one by one. This ensures clarity and prevents type-related issues when invoking actions.

**Updated actions**
- `app-store-connect publish`