### PR TITLE
Fix version info resolving when submitting app to App Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Version 0.57.4
 -------------
 
 **Bugfixes**
+- Fix Python API for `AppStoreConnect.submit_to_app_store` for macOS applications when platform was specified only via version info and not directly as method argument. [PR #453](https://github.com/codemagic-ci-cd/cli-tools/pull/453)
+
+Version 0.57.4
+-------------
+
+**Bugfixes**
 - Fix submitting uploaded application to App Store when running action `app-store-connect publish` using `--app-store` flag. [PR #452](https://github.com/codemagic-ci-cd/cli-tools/pull/452)
 
 Version 0.57.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.57.4
+Version 0.57.5
 -------------
 
 **Bugfixes**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.57.4"
+version = "0.57.5"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.4.dev"
+__version__ = "0.57.5.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/tools/app_store_connect/actions/submit_to_app_store_action.py
+++ b/src/codemagic/tools/app_store_connect/actions/submit_to_app_store_action.py
@@ -114,7 +114,6 @@ class SubmitToAppStoreAction(AbstractBaseAction, metaclass=ABCMeta):
 
         return self._submit_to_app_store(
             build_id=build_id,
-            platform=platform,
             max_processing_minutes=Types.MaxBuildProcessingWait.resolve_value(max_build_processing_wait),
             app_store_version_info=app_store_version_info,
             app_store_version_localization_infos=app_store_version_localization_infos,
@@ -173,7 +172,6 @@ class SubmitToAppStoreAction(AbstractBaseAction, metaclass=ABCMeta):
     def _submit_to_app_store(
         self,
         build_id: ResourceId,
-        platform: Platform,
         max_processing_minutes: int,
         app_store_version_info: AppStoreVersionInfo,
         app_store_version_localization_infos: List[AppStoreVersionLocalizationInfo],
@@ -188,7 +186,7 @@ class SubmitToAppStoreAction(AbstractBaseAction, metaclass=ABCMeta):
             raise AppStoreConnectError(str(api_error)) from api_error
 
         if cancel_previous_submissions:
-            self._cancel_previous_submissions(application_id=app.id, platform=platform)
+            self._cancel_previous_submissions(application_id=app.id, platform=app_store_version_info.platform)
 
         if max_processing_minutes:
             build = self.wait_until_build_is_processed(build, max_processing_minutes)
@@ -212,7 +210,7 @@ class SubmitToAppStoreAction(AbstractBaseAction, metaclass=ABCMeta):
             app_store_version_localization_infos,
         )
 
-        review_submission = self._create_review_submission(app, platform)
+        review_submission = self._create_review_submission(app, app_store_version_info.platform)
         review_submission_item = self.create_review_submission_item(
             review_submission_id=review_submission.id,
             app_store_version_id=app_store_version.id,

--- a/tests/tools/app_store_connect/actions/test_submit_to_app_store_action.py
+++ b/tests/tools/app_store_connect/actions/test_submit_to_app_store_action.py
@@ -1,0 +1,101 @@
+from unittest import mock
+
+from codemagic.apple.app_store_connect import IssuerId
+from codemagic.apple.app_store_connect import KeyIdentifier
+from codemagic.apple.resources import App
+from codemagic.apple.resources import AppStoreVersion
+from codemagic.apple.resources import Build
+from codemagic.apple.resources import Locale
+from codemagic.apple.resources import Platform
+from codemagic.apple.resources import PreReleaseVersion
+from codemagic.apple.resources import ReleaseType
+from codemagic.apple.resources import ResourceId
+from codemagic.apple.resources import ReviewSubmission
+from codemagic.apple.resources import ReviewSubmissionItem
+from codemagic.tools import AppStoreConnect
+from codemagic.tools.app_store_connect.arguments import AppStoreVersionInfo
+from codemagic.tools.app_store_connect.arguments import AppStoreVersionLocalizationInfo
+
+
+@mock.patch("codemagic.tools.AppStoreConnect.api_client")
+def test_submit_to_app_store_platform_using_version_info(mock_api_client: mock.MagicMock):
+    app_store_connect = AppStoreConnect(
+        issuer_id=IssuerId("issuer-id"),
+        key_identifier=KeyIdentifier("key-identifier"),
+        private_key="private-key",
+    )
+
+    build = mock.MagicMock(spec=Build, id=ResourceId("build-id"))
+    app = mock.MagicMock(spec=App, id=ResourceId("app-id"))
+    pre_release_version = mock.MagicMock(spec=PreReleaseVersion, id=ResourceId("pre-release-version-id"))
+    app_store_version = mock.MagicMock(spec=AppStoreVersion, id=ResourceId("app-store-version-id"))
+    review_submission = mock.MagicMock(spec=ReviewSubmission, id=ResourceId("review-submission-id"))
+    review_submission_item = mock.MagicMock(spec=ReviewSubmissionItem, id=ResourceId("review-submission-item-id"))
+
+    mock_api_client.builds.read_with_include.return_value = (build, app)
+
+    with mock.patch.object(
+        app_store_connect,
+        "_cancel_previous_submissions",
+    ) as mock_cancel_previous_submissions, mock.patch.object(
+        app_store_connect,
+        "wait_until_build_is_processed",
+    ) as mock_wait_until_build_is_processed, mock.patch.object(
+        app_store_connect,
+        "get_build_pre_release_version",
+        return_value=pre_release_version,
+    ), mock.patch.object(
+        app_store_connect,
+        "_ensure_app_store_version",
+        return_value=app_store_version,
+    ), mock.patch.object(
+        app_store_connect,
+        "_manage_app_store_version_phased_release",
+    ) as mock_manage_app_store_version_phased_release, mock.patch.object(
+        app_store_connect,
+        "_create_or_update_app_store_version_localizations",
+    ), mock.patch.object(
+        app_store_connect,
+        "_create_review_submission",
+        return_value=review_submission,
+    ) as mock_create_review_submission, mock.patch.object(
+        app_store_connect,
+        "create_review_submission_item",
+        return_value=review_submission_item,
+    ) as mock_create_review_submission_item, mock.patch.object(
+        app_store_connect,
+        "confirm_review_submission",
+    ) as mock_confirm_review_submission:
+        created_review_submission, created_review_submission_item = app_store_connect.submit_to_app_store(
+            build.id,
+            max_build_processing_wait=23,
+            cancel_previous_submissions=True,
+            app_store_version_info=AppStoreVersionInfo(
+                platform=Platform.MAC_OS,
+                version_string="1.2.3",
+                release_type=ReleaseType.AFTER_APPROVAL,
+                earliest_release_date=None,
+                copyright=None,
+            ),
+            app_store_version_localizations=[
+                AppStoreVersionLocalizationInfo(
+                    locale=Locale.EN_GB,
+                    whats_new="Whats new in English",
+                ),
+            ],
+            enable_phased_release=True,
+            disable_phased_release=None,
+        )
+
+    mock_api_client.builds.read_with_include.assert_called_once_with(build.id, App)
+    mock_cancel_previous_submissions.assert_called_once_with(build, Platform.MAC_OS)
+    mock_wait_until_build_is_processed.assert_called_once_with(build, 23)
+    mock_manage_app_store_version_phased_release.assert_called_once_with(app_store_version, True)
+    mock_create_review_submission.assert_called_once_with(app, Platform.MAC_OS)
+    mock_create_review_submission_item.assert_called_once_with(
+        review_submission_id=review_submission.id,
+        app_store_version_id=app_store_version.id,
+    )
+    mock_confirm_review_submission.assert_called_once_with(review_submission.id)
+    assert created_review_submission == review_submission
+    assert created_review_submission_item == review_submission_item

--- a/tests/tools/app_store_connect/actions/test_submit_to_app_store_action.py
+++ b/tests/tools/app_store_connect/actions/test_submit_to_app_store_action.py
@@ -88,7 +88,7 @@ def test_submit_to_app_store_platform_using_version_info(mock_api_client: mock.M
         )
 
     mock_api_client.builds.read_with_include.assert_called_once_with(build.id, App)
-    mock_cancel_previous_submissions.assert_called_once_with(build, Platform.MAC_OS)
+    mock_cancel_previous_submissions.assert_called_once_with(application_id=app.id, platform=Platform.MAC_OS)
     mock_wait_until_build_is_processed.assert_called_once_with(build, 23)
     mock_manage_app_store_version_phased_release.assert_called_once_with(app_store_version, True)
     mock_create_review_submission.assert_called_once_with(app, Platform.MAC_OS)


### PR DESCRIPTION
Submitting macOS applications to App Store review is broken in case the submission is invoked from Python API by specifying platform info using `AppStoreVersionInfo` instead of the `platform` argument. That is, running
```python
AppStoreConnect(...).submit_to_app_store(
    "build-id",
    app_store_version_info=AppStoreVersionInfo(
        platform=Platform.MAC_OS,
        ...,
    ),
    ...,  # platform uses default value
)
```
will end up using default platform type `Platform.IOS` for the review submission instead of the one that is given in version info. This causes a conflict that fails the App Store submission.

The issue is resolved by altering private `_submit_to_app_store` method to only use platform from the `app_store_version_info` where correct platform type is given.

**Updated actions:**
- `app-store-connect submit-to-app-store`