### PR TITLE
Androguard improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 Version 0.57.6
 -------------
 
+This release contains changes from [PR #455](https://github.com/codemagic-ci-cd/cli-tools/pull/455)
+
+**Features**
+- Add action `codemagic-cli-tools ensure-androguard` to pre-install [`androguard`](https://github.com/androguard/androguard) dependency that is required for working with APK files.
+
 **Bugfixes**
-- Fix `ValueError` when initializing more than one `ApkPackage` instances using Python APIs. [PR #454](https://github.com/codemagic-ci-cd/cli-tools/pull/454)
+- Fix `ValueError` when initializing more than one `ApkPackage` instances using Python APIs.
+- Fix available commands listings in terminal help messages for tools with hidden deprecated actions.
+
+**Development**
+- Add possibility to define hidden actions which are excluded from Markdown docs and terminal help messages.
 
 Version 0.57.5
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.57.6
+-------------
+
+**Bugfixes**
+- Fix `ValueError` when initializing more than one `ApkPackage` instances using Python APIs. [PR #454](https://github.com/codemagic-ci-cd/cli-tools/pull/454)
+
 Version 0.57.5
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.57.5"
+version = "0.57.6"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.5.dev"
+__version__ = "0.57.6.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/cli/action.py
+++ b/src/codemagic/cli/action.py
@@ -44,6 +44,7 @@ def action(
     action_group: Optional[ActionGroup] = None,
     action_options: Optional[Dict[str, Any]] = None,
     deprecation_info: Optional[ActionDeprecationInfo] = None,
+    suppress_help: bool = False,
 ) -> Callable[[_Fn], _Fn]:
     """
     Decorator to mark that the method is usable from CLI
@@ -55,6 +56,7 @@ def action(
                              backwards compatibility, and in which version it was deprecated.
                              The action is registered on the root arguments parser with this name
                              without explicit documentation.
+    :param suppress_help: Whether to suppress action info in help messages
     """
 
     # Ensure that each argument is used exactly once
@@ -75,6 +77,7 @@ def action(
         func.is_cli_action = True
         func.deprecation_info = deprecation_info
         func.action_options = action_options or {}
+        func.suppress_help = suppress_help
 
         @wraps(func)
         def wrapper(self: CliApp, *args, **kwargs):

--- a/src/codemagic/cli/argument/action_callable.py
+++ b/src/codemagic/cli/argument/action_callable.py
@@ -21,6 +21,7 @@ class ActionCallable:
     is_cli_action: bool
     action_options: Dict[str, Any]
     deprecation_info: Optional[ActionDeprecationInfo]
+    suppress_help: bool
     __name__: str
     __call__: Callable
 

--- a/src/codemagic/cli/argument/argument_parser_builder.py
+++ b/src/codemagic/cli/argument/argument_parser_builder.py
@@ -75,6 +75,12 @@ class ArgumentParserBuilder:
                 formatter_class=CliHelpFormatter,
                 description=f"{deprecation_message} {Colors.BOLD(self._cli_action.__doc__)}",
             )
+        elif self._cli_action.suppress_help:
+            return parent_parser.add_parser(
+                self._cli_action.action_name,
+                formatter_class=CliHelpFormatter,
+                description=Colors.BOLD(self._cli_action.__doc__),
+            )
         else:
             return parent_parser.add_parser(
                 self._cli_action.action_name,
@@ -99,7 +105,7 @@ class ArgumentParserBuilder:
             type=str,
             default="stderr",
             choices=["stderr", "stdout"],
-            help=f'Log output stream. {ArgumentFormatter.format_default_value("stderr")}',
+            help=f"Log output stream. {ArgumentFormatter.format_default_value('stderr')}",
         )
         options_group.add_argument(
             "--no-color",

--- a/src/codemagic/cli/cli_app.py
+++ b/src/codemagic/cli/cli_app.py
@@ -393,13 +393,16 @@ class CliApp(metaclass=abc.ABCMeta):
         current_action_parsers: SubParsersAction,
         deprecated_action_parsers: SubParsersAction,
     ):
+        if main_or_group_action.suppress_help:
+            CliHelpFormatter.suppress_action(main_or_group_action.action_name)
+
         ArgumentParserBuilder(cls, main_or_group_action, current_action_parsers).build()
         if not main_or_group_action.deprecation_info:
             return
 
         # Also register the deprecated alias
         ArgumentParserBuilder(cls, main_or_group_action, deprecated_action_parsers, for_deprecated_alias=True).build()
-        CliHelpFormatter.suppress_deprecated_action(main_or_group_action.deprecation_info.alias)
+        CliHelpFormatter.suppress_action(main_or_group_action.deprecation_info.alias)
 
     def _obfuscate_command(
         self,

--- a/src/codemagic/cli/cli_help_formatter.py
+++ b/src/codemagic/cli/cli_help_formatter.py
@@ -8,7 +8,7 @@ from .colors import Colors
 
 
 class CliHelpFormatter(argparse.HelpFormatter):
-    _deprecated_actions: Set[str] = set()
+    _suppressed_actions: Set[str] = set()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -19,12 +19,12 @@ class CliHelpFormatter(argparse.HelpFormatter):
             self._width = sys.maxsize
 
     @classmethod
-    def suppress_deprecated_action(cls, action_name: str):
-        cls._deprecated_actions.add(action_name)
+    def suppress_action(cls, action_name: str):
+        cls._suppressed_actions.add(action_name)
 
-    def _exclude_deprecated_actions(self, message: str) -> str:
-        for deprecated_action in self._deprecated_actions:
-            message = re.sub(f"[^ ]{deprecated_action},?", "", message)
+    def _exclude_suppressed_actions(self, message: str) -> str:
+        for suppressed_action in self._suppressed_actions:
+            message = re.sub(f"(?<=[^ ]){suppressed_action},?", "", message)
         return message
 
     def _format_args(self, *args, **kwargs):
@@ -38,7 +38,7 @@ class CliHelpFormatter(argparse.HelpFormatter):
         fmt = super()._format_action_invocation(action)
 
         if action.dest == "action":
-            fmt = self._exclude_deprecated_actions(fmt)
+            fmt = self._exclude_suppressed_actions(fmt)
 
         parts = fmt.split(", ")
         color = Colors.BRIGHT_BLUE if action.option_strings else Colors.GREEN
@@ -66,7 +66,7 @@ class CliHelpFormatter(argparse.HelpFormatter):
         # short action name; start on the same line and pad two spaces
         elif len(Colors.remove(action_header)) <= action_width:
             right_padding = max(0, action_width - len(Colors.remove(action_header))) + 2
-            action_header = f'{" " * self._current_indent}{action_header}{" " * right_padding}'
+            action_header = f"{' ' * self._current_indent}{action_header}{' ' * right_padding}"
             indent_first = 0
 
         # long action name; start on the next line
@@ -99,4 +99,4 @@ class CliHelpFormatter(argparse.HelpFormatter):
 
     def _format_usage(self, *args, **kwargs) -> str:
         usage = super()._format_usage(*args, **kwargs)
-        return self._exclude_deprecated_actions(usage)
+        return self._exclude_suppressed_actions(usage)

--- a/src/codemagic/models/application_package/apk_package.py
+++ b/src/codemagic/models/application_package/apk_package.py
@@ -48,9 +48,9 @@ def _silence_androguard_warnings():
     # Androguard uses hardcoded logger handler ID and subsequent calls
     # to set_log can cause errors because handler with ID 0 is removed
     # and the new handler might not have the same ID.
-    from androguard import util
+    from androguard.util import set_log
 
-    util.set_log("ERROR")
+    set_log("ERROR")
 
 
 def _get_androguard_apk(apk_path: pathlib.Path, _install_androguard: bool = True) -> APK:

--- a/src/codemagic/models/application_package/apk_package.py
+++ b/src/codemagic/models/application_package/apk_package.py
@@ -32,11 +32,11 @@ def _silence_androguard_warnings():
 
 @run_once
 def _ensure_androguard():
-    from codemagic.tools import GooglePlay
+    from codemagic.tools import CodemagicCliTools
 
-    running_app = GooglePlay.get_running_app()
+    running_app = CodemagicCliTools.get_running_app()
     verbose = running_app.verbose if running_app else False
-    GooglePlay(verbose=verbose).ensure_apk_tooling(notify_installed=False)
+    CodemagicCliTools(verbose=verbose).ensure_androguard(notify_installed=False)
 
 
 def _get_androguard_apk(apk_path: pathlib.Path) -> APK:

--- a/src/codemagic/models/application_package/apk_package.py
+++ b/src/codemagic/models/application_package/apk_package.py
@@ -10,7 +10,6 @@ from typing import Optional
 from cryptography import x509
 from cryptography.x509 import load_der_x509_certificate
 
-from codemagic.tools.codemagic_cli_tools import CodemagicCliTools
 from codemagic.utilities.decorators import run_once
 
 from .abstract_package import AbstractPackage
@@ -33,6 +32,8 @@ def _silence_androguard_warnings():
 
 @run_once
 def _ensure_androguard():
+    from codemagic.tools.codemagic_cli_tools import CodemagicCliTools
+
     running_app = CodemagicCliTools.get_running_app()
     verbose = running_app.verbose if running_app else False
     CodemagicCliTools(verbose=verbose).ensure_apk_tools(notify_installed=False)
@@ -41,6 +42,7 @@ def _ensure_androguard():
 def _get_androguard_apk(apk_path: pathlib.Path) -> APK:
     _ensure_androguard()
     _silence_androguard_warnings()
+
     from androguard.core.apk import APK
 
     return APK(str(apk_path))

--- a/src/codemagic/models/application_package/apk_package.py
+++ b/src/codemagic/models/application_package/apk_package.py
@@ -32,11 +32,11 @@ def _silence_androguard_warnings():
 
 @run_once
 def _ensure_androguard():
-    from codemagic.tools.codemagic_cli_tools import CodemagicCliTools
+    from codemagic.tools import GooglePlay
 
-    running_app = CodemagicCliTools.get_running_app()
+    running_app = GooglePlay.get_running_app()
     verbose = running_app.verbose if running_app else False
-    CodemagicCliTools(verbose=verbose).ensure_apk_tools(notify_installed=False)
+    GooglePlay(verbose=verbose).ensure_apk_tooling(notify_installed=False)
 
 
 def _get_androguard_apk(apk_path: pathlib.Path) -> APK:

--- a/src/codemagic/models/application_package/apk_package.py
+++ b/src/codemagic/models/application_package/apk_package.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import pathlib
-import subprocess
-import sys
 from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import Any
@@ -12,8 +10,7 @@ from typing import Optional
 from cryptography import x509
 from cryptography.x509 import load_der_x509_certificate
 
-from codemagic.cli import CliApp
-from codemagic.cli import Colors
+from codemagic.tools.codemagic_cli_tools import CodemagicCliTools
 from codemagic.utilities.decorators import run_once
 
 from .abstract_package import AbstractPackage
@@ -22,25 +19,6 @@ if TYPE_CHECKING:
     from androguard.core.apk import APK
 
     from codemagic.models import Certificate
-
-
-def _install_missing_androguard():
-    commands = [
-        [sys.executable, "-m", "ensurepip"],
-        [sys.executable, "-m", "pip", "install", "androguard"],
-    ]
-    if cli_app := CliApp.get_running_app():
-        cli_app.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
-        try:
-            for command in commands:
-                cli_process = cli_app.execute(command, show_output=False)
-                cli_process.raise_for_returncode()
-        except subprocess.CalledProcessError:
-            cli_app.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
-            raise
-    else:
-        for command in commands:
-            subprocess.run(command, check=True)
 
 
 @run_once
@@ -53,16 +31,18 @@ def _silence_androguard_warnings():
     set_log("ERROR")
 
 
-def _get_androguard_apk(apk_path: pathlib.Path, _install_androguard: bool = True) -> APK:
-    try:
-        from androguard.core.apk import APK
-    except ImportError:
-        if not _install_androguard:
-            raise
-        _install_missing_androguard()
-        return _get_androguard_apk(apk_path, _install_androguard=False)
+@run_once
+def _ensure_androguard():
+    running_app = CodemagicCliTools.get_running_app()
+    verbose = running_app.verbose if running_app else False
+    CodemagicCliTools(verbose=verbose).ensure_apk_tools(notify_installed=False)
 
+
+def _get_androguard_apk(apk_path: pathlib.Path) -> APK:
+    _ensure_androguard()
     _silence_androguard_warnings()
+    from androguard.core.apk import APK
+
     return APK(str(apk_path))
 
 

--- a/src/codemagic/tools/codemagic_cli_tools.py
+++ b/src/codemagic/tools/codemagic_cli_tools.py
@@ -1,7 +1,11 @@
+import importlib.util
 import shutil
+import subprocess
+import sys
 
 from codemagic import __version__
 from codemagic import cli
+from codemagic.cli import Colors
 
 
 class CodemagicCliTools(cli.CliApp):
@@ -26,6 +30,41 @@ class CodemagicCliTools(cli.CliApp):
         for tool_class in cli.CliApp.__subclasses__():
             executable = tool_class.get_executable_name()
             self.echo(f"{executable} installed at {shutil.which(executable) or executable}")
+
+    def _install_androguard(self):
+        commands = [
+            [sys.executable, "-m", "ensurepip"],
+            [sys.executable, "-m", "pip", "install", "androguard"],
+        ]
+        try:
+            for command in commands:
+                cli_process = self.execute(command, show_output=False)
+                cli_process.raise_for_returncode()
+        except subprocess.CalledProcessError:
+            self.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
+            raise
+
+    @cli.action(
+        "ensure-androguard",
+        suppress_help=True,
+    )
+    def ensure_androguard(self, notify_installed: bool = True) -> None:
+        """
+        Make sure that Codemagic CLI tools environment has Androguard dependency which
+        is required to work with Android APK files. Whenever Androguard is missing but
+        required by some action it will be installed automatically if need be.
+        """
+        if importlib.util.find_spec("androguard"):
+            if notify_installed:
+                self.logger.info(Colors.GREEN("Required Android tools are already installed"))
+            return  # Androguard is already present, no need to install anything
+
+        self.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
+        try:
+            self._install_androguard()
+        except subprocess.CalledProcessError as cpe:
+            raise cli.CliAppException("Installing Android tools failed") from cpe
+        self.logger.info(Colors.GREEN("Required Android tools were successfully installed"))
 
 
 if __name__ == "__main__":

--- a/src/codemagic/tools/codemagic_cli_tools.py
+++ b/src/codemagic/tools/codemagic_cli_tools.py
@@ -44,7 +44,7 @@ class CodemagicCliTools(cli.CliApp):
             self.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
             raise
 
-    @cli.action("ensure-apk-tools")
+    @cli.action("ensure-apk-tools", suppress_help=True)
     def ensure_apk_tools(self, notify_installed: bool = True) -> None:
         """
         Make sure that Codemagic CLI tools environment has tools that

--- a/src/codemagic/tools/codemagic_cli_tools.py
+++ b/src/codemagic/tools/codemagic_cli_tools.py
@@ -56,15 +56,15 @@ class CodemagicCliTools(cli.CliApp):
         """
         if importlib.util.find_spec("androguard"):
             if notify_installed:
-                self.logger.info(Colors.GREEN("Required Android tools are already installed"))
+                self.logger.info(Colors.GREEN("Androguard is already installed"))
             return  # Androguard is already present, no need to install anything
 
-        self.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
+        self.logger.info(Colors.WHITE("Installing Androguard to work with APK files..."))
         try:
             self._install_androguard()
         except subprocess.CalledProcessError as cpe:
-            raise cli.CliAppException("Installing Android tools failed") from cpe
-        self.logger.info(Colors.GREEN("Required Android tools were successfully installed"))
+            raise cli.CliAppException("Installing Androguard failed") from cpe
+        self.logger.info(Colors.GREEN("Androguard successfully installed"))
 
 
 if __name__ == "__main__":

--- a/src/codemagic/tools/codemagic_cli_tools.py
+++ b/src/codemagic/tools/codemagic_cli_tools.py
@@ -1,7 +1,11 @@
+import importlib.util
 import shutil
+import subprocess
+import sys
 
 from codemagic import __version__
 from codemagic import cli
+from codemagic.cli import Colors
 
 
 class CodemagicCliTools(cli.CliApp):
@@ -26,6 +30,37 @@ class CodemagicCliTools(cli.CliApp):
         for tool_class in cli.CliApp.__subclasses__():
             executable = tool_class.get_executable_name()
             self.echo(f"{executable} installed at {shutil.which(executable) or executable}")
+
+    def _install_androguard(self):
+        commands = [
+            [sys.executable, "-m", "ensurepip"],
+            [sys.executable, "-m", "pip", "install", "androguard"],
+        ]
+        try:
+            for command in commands:
+                cli_process = self.execute(command, show_output=False)
+                cli_process.raise_for_returncode()
+        except subprocess.CalledProcessError:
+            self.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
+            raise
+
+    @cli.action("ensure-apk-tools")
+    def ensure_apk_tools(self, notify_installed: bool = True) -> None:
+        """
+        Make sure that Codemagic CLI tools environment has tools that
+        are required to work with Android APK files
+        """
+        if importlib.util.find_spec("androguard"):
+            if notify_installed:
+                self.logger.info(Colors.GREEN("Required Android tools are already installed"))
+            return  # Androguard is already present, no need to install anything
+
+        self.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
+        try:
+            self._install_androguard()
+        except subprocess.CalledProcessError as cpe:
+            raise cli.CliAppException("Installing Android tools failed") from cpe
+        self.logger.info(Colors.GREEN("Required Android tools were successfully installed"))
 
 
 if __name__ == "__main__":

--- a/src/codemagic/tools/codemagic_cli_tools.py
+++ b/src/codemagic/tools/codemagic_cli_tools.py
@@ -1,11 +1,7 @@
-import importlib.util
 import shutil
-import subprocess
-import sys
 
 from codemagic import __version__
 from codemagic import cli
-from codemagic.cli import Colors
 
 
 class CodemagicCliTools(cli.CliApp):
@@ -30,37 +26,6 @@ class CodemagicCliTools(cli.CliApp):
         for tool_class in cli.CliApp.__subclasses__():
             executable = tool_class.get_executable_name()
             self.echo(f"{executable} installed at {shutil.which(executable) or executable}")
-
-    def _install_androguard(self):
-        commands = [
-            [sys.executable, "-m", "ensurepip"],
-            [sys.executable, "-m", "pip", "install", "androguard"],
-        ]
-        try:
-            for command in commands:
-                cli_process = self.execute(command, show_output=False)
-                cli_process.raise_for_returncode()
-        except subprocess.CalledProcessError:
-            self.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
-            raise
-
-    @cli.action("ensure-apk-tools", suppress_help=True)
-    def ensure_apk_tools(self, notify_installed: bool = True) -> None:
-        """
-        Make sure that Codemagic CLI tools environment has tools that
-        are required to work with Android APK files
-        """
-        if importlib.util.find_spec("androguard"):
-            if notify_installed:
-                self.logger.info(Colors.GREEN("Required Android tools are already installed"))
-            return  # Androguard is already present, no need to install anything
-
-        self.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
-        try:
-            self._install_androguard()
-        except subprocess.CalledProcessError as cpe:
-            raise cli.CliAppException("Installing Android tools failed") from cpe
-        self.logger.info(Colors.GREEN("Required Android tools were successfully installed"))
 
 
 if __name__ == "__main__":

--- a/src/codemagic/tools/google_play/action_groups/apks_action_group.py
+++ b/src/codemagic/tools/google_play/action_groups/apks_action_group.py
@@ -1,13 +1,9 @@
-import importlib.util
 import pathlib
-import subprocess
-import sys
 from abc import ABCMeta
 from pathlib import Path
 from typing import List
 from typing import Optional
 from typing import Union
-from typing import cast
 
 from codemagic import cli
 from codemagic.cli import Colors
@@ -196,38 +192,3 @@ class ApksActionGroup(GooglePlayBaseAction, metaclass=ABCMeta):
             raise GooglePlayError(str(ge))
 
         self.logger.info(Colors.GREEN(f"Successfully published APK to Google Play track {track_name}"))
-
-    def _install_androguard(self):
-        commands = [
-            [sys.executable, "-m", "ensurepip"],
-            [sys.executable, "-m", "pip", "install", "androguard"],
-        ]
-        try:
-            for command in commands:
-                cli_process = cast(cli.CliApp, self).execute(command, show_output=False)
-                cli_process.raise_for_returncode()
-        except subprocess.CalledProcessError:
-            self.logger.error(Colors.RED("ERROR: Installing Androguard failed."))
-            raise
-
-    @cli.action(
-        "ensure-tooling",
-        action_group=GooglePlayActionGroups.APKS,
-        suppress_help=True,
-    )
-    def ensure_apk_tooling(self, notify_installed: bool = True) -> None:
-        """
-        Make sure that Codemagic CLI tools environment has tools that
-        are required to work with Android APK files
-        """
-        if importlib.util.find_spec("androguard"):
-            if notify_installed:
-                self.logger.info(Colors.GREEN("Required Android tools are already installed"))
-            return  # Androguard is already present, no need to install anything
-
-        self.logger.info(Colors.WHITE("Installing missing tools to work with APK files..."))
-        try:
-            self._install_androguard()
-        except subprocess.CalledProcessError as cpe:
-            raise cli.CliAppException("Installing Android tools failed") from cpe
-        self.logger.info(Colors.GREEN("Required Android tools were successfully installed"))

--- a/src/codemagic/utilities/decorators.py
+++ b/src/codemagic/utilities/decorators.py
@@ -34,3 +34,21 @@ def deprecated(
         return wrapper
 
     return decorator
+
+
+def run_once(function):
+    """
+    Ensure that decorated function is executed only once.
+    Cache the result for subsequent calls unless the function
+    fails with an exception.
+    """
+
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.return_value = function(*args, **kwargs)
+            wrapper.has_run = True
+        return wrapper.return_value
+
+    wrapper.has_run = False
+    return wrapper

--- a/tests/utilities/decorators/test_run_once.py
+++ b/tests/utilities/decorators/test_run_once.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+import pytest
+
+from codemagic.utilities.decorators import run_once
+
+
+def test_run_once():
+    m = mock.MagicMock(side_effect=[1, 2, 3])
+
+    @run_once
+    def my_function():
+        return m()
+
+    assert my_function() == 1
+    assert my_function() == 1
+    assert my_function() == 1
+    assert my_function() == 1
+    m.assert_called_once()
+
+
+def test_run_once_with_args():
+    m = mock.MagicMock(side_effect=["a", "b", "c"])
+
+    @run_once
+    def my_function(a, b, *, c):
+        return m(a, b, c=c)
+
+    assert my_function(1, 2, c=3) == "a"
+    assert my_function(4, 5, c=6) == "a"
+    assert my_function(7, 8, c=9) == "a"
+    m.assert_called_once_with(1, 2, c=3)
+
+
+def test_run_once_with_exception():
+    m = mock.MagicMock()
+
+    @run_once
+    def my_function(a, b):
+        m(a, b)
+        return a / b
+
+    with pytest.raises(ZeroDivisionError):
+        my_function(1, 0)
+
+    assert my_function(1, 1) == 1
+    assert my_function(1, 2) == 1
+    assert my_function(1, 3) == 1
+    assert m.call_count == 2
+    m.assert_has_calls(
+        [
+            mock.call(1, 0),
+            mock.call(1, 1),
+        ],
+    )


### PR DESCRIPTION
There are couple of problems with [androguard](https://github.com/androguard/androguard) dependency and its usage.

First, updating `androguard` log level multiple times causes `ValueError`s because `androguard.util.set_log` method uses hardcoded ID value to remove `logger`'s handler, but new handler is added gets another ID. 

Changes here ensure that log level is updated only once.

<details>
<summary>Stacktrace</summary>

```python
Traceback (most recent call last):
  File "/home/builder/builder/.venv/lib/python3.10/site-packages/codemagic/models/application_package/apk_package.py", line 63, in _validate_package
    _ = self._apk
  File "/home/builder/.local/share/uv/python/cpython-3.10.16-linux-x86_64-gnu/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/builder/builder/.venv/lib/python3.10/site-packages/codemagic/models/application_package/apk_package.py", line 73, in _apk
    return _get_androguard_apk(self.path)
  File "/home/builder/builder/.venv/lib/python3.10/site-packages/codemagic/models/application_package/apk_package.py", line 56, in _get_androguard_apk
    set_log("ERROR")
  File "/home/builder/builder/.venv/lib/python3.10/site-packages/androguard/util.py", line 37, in set_log
    logger.remove(0)
  File "/home/builder/builder/.venv/lib/python3.10/site-packages/loguru/_logger.py", line 1050, in remove
    raise ValueError("There is no existing handler with id %d" % handler_id) from None
ValueError: There is no existing handler with id 0
```
</details>

Secondly, currently there is no way to control `androguard` availability ahead of time and consequently `google-play` actions that handle APK files can behave unexpectedly when they first need to install the dependency.

To overcome that, add new action `codemagic-cli-tools ensure-androguard` which installs `androguard` if it isn't present in CLI tools environment.