### PR TITLE
Use retrying by default for Google API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.57.7
+-------------
+
+**Bugfixes**
+- Use retrying for Google API requests to avoid intermittent timeout errors. [PR #456](https://github.com/codemagic-ci-cd/cli-tools/pull/456)
+
 Version 0.57.6
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.57.6"
+version = "0.57.7"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.57.6.dev"
+__version__ = "0.57.7.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/services/google_play/apks_service.py
+++ b/src/codemagic/google/services/google_play/apks_service.py
@@ -52,7 +52,7 @@ class ApksService(ResourceService[Apk, "android_publisher_resources.AndroidPubli
         )
         response = cast(
             "android_publisher_resources.Apk",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded apk for %r", package_name)
         return Apk(**cast(dict, response))

--- a/src/codemagic/google/services/google_play/bundles_service.py
+++ b/src/codemagic/google/services/google_play/bundles_service.py
@@ -53,7 +53,7 @@ class BundlesService(ResourceService[Bundle, "android_publisher_resources.Androi
         )
         response = cast(
             "android_publisher_resources.Bundle",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded App Bundle for %r", package_name)
         return Bundle(**response)

--- a/src/codemagic/google/services/google_play/deobfuscation_files_service.py
+++ b/src/codemagic/google/services/google_play/deobfuscation_files_service.py
@@ -58,7 +58,7 @@ class DeobfuscationFilesService(
         )
         response = cast(
             "android_publisher_resources.DeobfuscationFilesUploadResponse",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded deobfuscation file for %r", package_name)
         return DeobfuscationFile(**cast(dict, response["deobfuscationFile"]))

--- a/src/codemagic/google/services/google_play/expansion_files_service.py
+++ b/src/codemagic/google/services/google_play/expansion_files_service.py
@@ -56,7 +56,7 @@ class ExpansionFilesService(ResourceService[ExpansionFile, "android_publisher_re
         )
         response = cast(
             "android_publisher_resources.ExpansionFilesUploadResponse",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded expansion file for %r", package_name)
         return ExpansionFile(**response["expansionFile"])
@@ -91,7 +91,7 @@ class ExpansionFilesService(ResourceService[ExpansionFile, "android_publisher_re
         )
         response = cast(
             "android_publisher_resources.ExpansionFile",
-            self._execute_request(update_request, "update", retries=3),
+            self._execute_request(update_request, "update"),
         )
         self._logger.debug("Updated expansion file for %r", package_name)
         return ExpansionFile(**response)

--- a/src/codemagic/google/services/google_play/internal_app_sharing_artifacts_service.py
+++ b/src/codemagic/google/services/google_play/internal_app_sharing_artifacts_service.py
@@ -46,7 +46,7 @@ class InternalAppSharingArtifactsService(
         )
         response = cast(
             "android_publisher_resources.InternalAppSharingArtifact",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded APK to internal app sharing for %r", package_name)
         return InternalAppSharingArtifact(**response)
@@ -70,7 +70,7 @@ class InternalAppSharingArtifactsService(
         )
         response = cast(
             "android_publisher_resources.InternalAppSharingArtifact",
-            self._execute_request(upload_request, "upload", retries=3),
+            self._execute_request(upload_request, "upload"),
         )
         self._logger.debug("Uploaded app bundle to internal app sharing for %r", package_name)
         return InternalAppSharingArtifact(**response)

--- a/src/codemagic/google/services/resource_service.py
+++ b/src/codemagic/google/services/resource_service.py
@@ -38,7 +38,7 @@ class ResourceService(Generic[ResourceT, GoogleServiceT], ABC):
         self,
         request: HttpRequest,
         request_type: Literal["commit", "delete", "get", "insert", "list", "update", "upload"],
-        retries: int = 0,
+        retries: int = 3,
     ) -> Dict[str, Any]:
         if isinstance(request.body, bytes):
             self._logger.info(f">>> {request.method} {request.uri} <{len(request.body)} bytes>")


### PR DESCRIPTION
HTTP requests to Google APIs often time out. Example stacktrace:

```python
Traceback (most recent call last):
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/cli/cli_app.py", line 252, in invoke_cli
    CliApp._running_app._invoke_action(args)
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/cli/cli_app.py", line 193, in _invoke_action
    return cli_action(**action_args)
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/cli/action.py", line 83, in wrapper
    return func(self, *args, **kwargs)
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/tools/google_play/action_groups/tracks_action_group.py", line 46, in get_track
    track = self.client.tracks.get(package_name, track_name, edit.id)
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/google/services/google_play/tracks_service.py", line 38, in get
    self._execute_request(get_request, "get"),
  File "/home/builder/.local/lib/python3.10/site-packages/codemagic/google/services/resource_service.py", line 49, in _execute_request
    response = request.execute(num_retries=retries)
  File "/home/builder/.local/lib/python3.10/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/home/builder/.local/lib/python3.10/site-packages/googleapiclient/http.py", line 923, in execute
    resp, content = _retry_request(
  File "/home/builder/.local/lib/python3.10/site-packages/googleapiclient/http.py", line 222, in _retry_request
    raise exception
  File "/home/builder/.local/lib/python3.10/site-packages/googleapiclient/http.py", line 191, in _retry_request
    resp, content = http.request(uri, method, *args, **kwargs)
  File "/home/builder/.local/lib/python3.10/site-packages/oauth2client/transport.py", line 173, in new_request
    resp, content = request(orig_request_method, uri, method, body,
  File "/home/builder/.local/lib/python3.10/site-packages/oauth2client/transport.py", line 280, in request
    return http_callable(uri, method=method, body=body, headers=headers,
  File "/home/builder/.local/lib/python3.10/site-packages/httplib2/__init__.py", line 1724, in request
    (response, content) = self._request(
  File "/home/builder/.local/lib/python3.10/site-packages/httplib2/__init__.py", line 1444, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/home/builder/.local/lib/python3.10/site-packages/httplib2/__init__.py", line 1396, in _conn_request
    response = conn.getresponse()
  File "/usr/lib/python3.10/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/lib/python3.10/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.10/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.10/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib/python3.10/ssl.py", line 1270, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib/python3.10/ssl.py", line 1128, in read
    return self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out
```

Those requests are executed via the [`HttpRequest.execute`](https://github.com/googleapis/google-api-python-client/blob/f84e041b4b9716536458c95a1bfccab6a9546d4d/googleapiclient/http.py#L877) interface that accepts `num_retries` parameter that can be used to configure the number of times to retry:

> `num_retries`: Integer, number of times to retry with randomized
                exponential backoff. If all retries fail, the raised `HttpError`
                represents the last request. If zero (default), we attempt the
                request only once.

Use `num_retries=3` by deafult in all requests with option to override.