### PR TITLE
Fix converting bytes to strings on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 0.57.7
 **Bugfixes**
 - Use retrying for Google API requests to avoid intermittent timeout errors. [PR #456](https://github.com/codemagic-ci-cd/cli-tools/pull/456)
 - Fix errors in `AabPackage.get_summary` and `ApkPackage.get_summary` methods for cases when certificate contained unexpected issuer and subject attributes. [PR #457](https://github.com/codemagic-ci-cd/cli-tools/pull/457)
+- Fix converting bytes to strings on Windows using Windows-1252 encoding. [PR #458](https://github.com/codemagic-ci-cd/cli-tools/pull/458)
 
 Version 0.57.6
 -------------

--- a/src/codemagic/mixins/str_converter.py
+++ b/src/codemagic/mixins/str_converter.py
@@ -1,3 +1,4 @@
+import os
 from typing import AnyStr
 from typing import Union
 
@@ -13,6 +14,15 @@ class StringConverterMixin:
     @classmethod
     def _str(cls, str_or_bytes: Union[str, bytes, AnyStr]) -> str:
         if isinstance(str_or_bytes, bytes):
-            return str_or_bytes.decode(encoding="utf-8")
+            return cls._bytes_to_str(str_or_bytes)
         else:
             return str_or_bytes
+
+    @classmethod
+    def _bytes_to_str(cls, bs: bytes) -> str:
+        try:
+            return bs.decode(encoding="utf-8")
+        except UnicodeDecodeError:
+            if os.name == "nt":  # Running on Windows, try Windows-1252 encoding too
+                return bs.decode(encoding="windows-1252")
+            raise


### PR DESCRIPTION
Subprocess output can be encoded using [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) on Windows. This causes problems when converting `bytes` to `str` and only allowing UTF-8. This PR adds an exemption on Windows to also allow Windows-1252 encoding when the program is also running on Windows.

Example stacktrace:
```python
Traceback (most recent call last):
  File "codemagic\models\application_package\aab_package.py", line 156, in get_summary
  File "codemagic\models\application_package\aab_package.py", line 129, in get_app_name
  File "functools.py", line 981, in __get__
  File "codemagic\models\application_package\aab_package.py", line 67, in _resources
  File "codemagic\shell_tools\bundletool.py", line 83, in dump
  File "codemagic\shell_tools\shell_tool.py", line 51, in _get_stdout
  File "codemagic\mixins\str_converter.py", line 16, in _str
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xec in position 5786: invalid continuation byte
```