### PR TITLE
Fix uploading APKs to Goole Play on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 0.58.1
+-------------
+
+- Fix `google-play apks publish` and `google-play apks upload` actions on Windows. [PR #463](https://github.com/codemagic-ci-cd/cli-tools/pull/463).
+
 Version 0.58.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.58.0"
+version = "0.58.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.58.0.dev"
+__version__ = "0.58.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/services/google_play/apks_service.py
+++ b/src/codemagic/google/services/google_play/apks_service.py
@@ -49,6 +49,7 @@ class ApksService(ResourceService[Apk, "android_publisher_resources.AndroidPubli
             packageName=package_name,
             editId=edit_id,
             media_body=str(apk_path),
+            media_mime_type="application/octet-stream",
         )
         response = cast(
             "android_publisher_resources.Apk",


### PR DESCRIPTION
Unless mime type is explicitly specified in request parameters, `googleapiclient.discovery` tries to [resolve it by itself](https://github.com/googleapis/google-api-python-client/blob/607bd3d5168f0902632f6a75671d2b3d865b28d9/googleapiclient/discovery.py#L1189-L1196) using [`mimetypes.guess_type`](https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type). On Windows, and any other platform for which the default mime types mapping is missing entry for `.apk` files, this causes the upload request to fail with `UnknownFileType` error.

<details>
<summary>Stacktrace</summary>

```python
Traceback (most recent call last):
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\cli\cli_app.py", line 252, in invoke_cli
    CliApp._running_app._invoke_action(args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\cli\cli_app.py", line 193, in _invoke_action
    return cli_action(**action_args)
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\cli\action.py", line 86, in wrapper
    return func(self, *args, **kwargs)
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\tools\google_play\action_groups\apks_action_group.py", line 141, in publish_apk
    apk = self.upload_apk(
        apk_path,
    ...<2 lines>...
        should_print=should_print,
    )
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\cli\action.py", line 86, in wrapper
    return func(self, *args, **kwargs)
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\tools\google_play\action_groups\apks_action_group.py", line 84, in upload_apk
    apk = self.client.apks.upload(
        package_name,
        edit.id,
        apk_path=apk_path,
    )
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\codemagic\google\services\google_play\apks_service.py", line 48, in upload
    upload_request: android_publisher_resources.ApkHttpRequest = self._apks.upload(
                                                                 ~~~~~~~~~~~~~~~~~^
        packageName=package_name,
        ^^^^^^^^^^^^^^^^^^^^^^^^^
        editId=edit_id,
        ^^^^^^^^^^^^^^^
        media_body=str(apk_path),
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\Users\builder\AppData\Roaming\uv\tools\codemagic-cli-tools\Lib\site-packages\googleapiclient\discovery.py", line 1196, in method
    raise UnknownFileType(media_filename)
googleapiclient.errors.UnknownFileType: C:\Users\builder\clone\artifacts\app-release.apk
```
</details>

This can be fixed by explicitly passing `media_mime_type="application/octet-stream"` argument to the `ApksResource.upload` call, as is done with [internal app sharing](https://github.com/codemagic-ci-cd/cli-tools/blob/657549bfe98642b4f9782bc0fa5dcd96ec16f28e/src/codemagic/google/services/google_play/internal_app_sharing_artifacts_service.py#L44) and [app bundles uploads](https://github.com/codemagic-ci-cd/cli-tools/blob/657549bfe98642b4f9782bc0fa5dcd96ec16f28e/src/codemagic/google/services/google_play/bundles_service.py#L52). 

**Updated actions:**
- `google-play apks upload`
- `google-play apks publish`