### PR TITLE
Fix Firebase Release initialization from API response data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -14,13 +14,13 @@ repos:
       - id: black
         language_version: python3.11
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.10
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Version 0.60.0
 -------------
 
+**Bugfixes**
+- Fix action `firebase-app-distribution-debug get-latest-build-version` by supporting new `updateTime` and `expireTime` timestamps for releases. [PR #473](https://github.com/codemagic-ci-cd/cli-tools/pull/473)
+
+Version 0.60.0
+-------------
+
 This release contains changes from [PR #469](https://github.com/codemagic-ci-cd/cli-tools/pull/469).
 
 **Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.60.0"
+version = "0.60.1"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.60.0.dev"
+__version__ = "0.60.1.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/services/firebase/releases_service.py
+++ b/src/codemagic/google/services/firebase/releases_service.py
@@ -67,4 +67,4 @@ class ReleasesService(ResourceService[Release, "FirebaseAppDistributionResource"
             next_page_token = response["nextPageToken"]
 
         self._logger.debug("Listed %d Firebase releases for app %r", len(firebase_releases[:limit]), app_id)
-        return [Release(**cast(dict, firebase_release)) for firebase_release in firebase_releases[:limit]]
+        return [Release.from_api_response(firebase_release) for firebase_release in firebase_releases[:limit]]

--- a/tests/google/resources/firebase/test_release.py
+++ b/tests/google/resources/firebase/test_release.py
@@ -22,6 +22,9 @@ def test_release_string_representation(api_firebase_release: dict):
         Testing URI: https://appdistribution.firebase.google.com/testerapps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8
         Binary download URI: https://firebaseappdistribution.googleapis.com/app-binary-downloads/projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8/binaries/fcdd844be2bd504ae7bb9d672731ddbfcd89c1419a9aa746a0bb6f67d3a1429d/app.apk?token=token
         Release notes:
-            Text: My release notes""",
+            Text: My release notes
+        Update time: 2025-08-25T07:04:39.166957+00:00
+        Expire time: 2026-01-22T07:04:23.208387+00:00
+        """,
     ).strip()
     assert str(release) == expected

--- a/tests/google/resources/mocks/firebase_release.json
+++ b/tests/google/resources/mocks/firebase_release.json
@@ -8,5 +8,7 @@
     "binaryDownloadUri": "https://firebaseappdistribution.googleapis.com/app-binary-downloads/projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8/binaries/fcdd844be2bd504ae7bb9d672731ddbfcd89c1419a9aa746a0bb6f67d3a1429d/app.apk?token=token",
     "releaseNotes": {
         "text": "My release notes"
-    }
+    },
+    "updateTime": "2025-08-25T07:04:39.166957+00:00",
+    "expireTime": "2026-01-22T07:04:23.208387+00:00"
 }

--- a/tests/google/resources/test_resource.py
+++ b/tests/google/resources/test_resource.py
@@ -16,13 +16,13 @@ def mock_logger():
 def test_from_api_response(mock_logger: mock.MagicMock):
     @dataclasses.dataclass
     class MyGoogleResource(Resource):
-        s: str
+        field: str
 
     resource = MyGoogleResource.from_api_response(
         {
-            "s": "lorem ipsum dolor sit amet",
-            "i": 100,
+            "field": "value",
+            "undefined": 100,
         },
     )
-    assert resource == MyGoogleResource(s="lorem ipsum dolor sit amet")
-    mock_logger.warning.assert_called_once_with("Unknown field %r for resource %s", "i", "MyGoogleResource")
+    assert resource == MyGoogleResource(field="value")
+    mock_logger.warning.assert_called_once_with("Unknown field %r for resource %s", "undefined", "MyGoogleResource")

--- a/tests/google/resources/test_resource.py
+++ b/tests/google/resources/test_resource.py
@@ -1,0 +1,28 @@
+import dataclasses
+from unittest import mock
+
+import pytest
+
+from codemagic.google.resources import Resource
+
+
+@pytest.fixture
+def mock_logger():
+    mock_logger = mock.MagicMock()
+    with mock.patch("codemagic.utilities.log.get_logger", return_value=mock_logger):
+        yield mock_logger
+
+
+def test_from_api_response(mock_logger: mock.MagicMock):
+    @dataclasses.dataclass
+    class MyGoogleResource(Resource):
+        s: str
+
+    resource = MyGoogleResource.from_api_response(
+        {
+            "s": "lorem ipsum dolor sit amet",
+            "i": 100,
+        },
+    )
+    assert resource == MyGoogleResource(s="lorem ipsum dolor sit amet")
+    mock_logger.warning.assert_called_once_with("Unknown field %r for resource %s", "i", "MyGoogleResource")


### PR DESCRIPTION
**Fixes #472.**

[Firebase releases API] started to include undocumented fields `updateTime` and `expireTime` in response payload. Those fields are not mapped to Python attributes and cause the program to crash:

```python
11:31:43 priit@marmot ~ firebase-app-distribution get-latest-build-version \
  --app-id "1:146661841143:android:a8d456e0c8b5e71bd11bf2" \
  --project-number "146661841143" \
  --verbose
[11:31:45] WARNING > Executing "firebase-app-distribution get-latest-build-version" failed unexpectedly. Detailed logs are available at "/var/folders/wr/c44p23x10f302_kfbj32z0p80000gn/T/codemagic-25-08-25.log".
[11:31:45] ERROR > Exception traceback:
Traceback (most recent call last):
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/cli_app.py", line 252, in invoke_cli
    CliApp._running_app._invoke_action(args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/cli_app.py", line 193, in _invoke_action
    return cli_action(**action_args)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/action.py", line 86, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/tools/firebase_app_distribution/actions/get_latest_build_version_action.py", line 21, in get_latest_build_version
    releases = self.client.releases.list(self.project_number, app_id, limit=1)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/google/services/firebase/releases_service.py", line 70, in list
    return [Release(**cast(dict, firebase_release)) for firebase_release in firebase_releases[:limit]]
            ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Release.__init__() got an unexpected keyword argument 'updateTime'. Did you mean 'createTime'?
```

Changes in this PR make sure that undefined fields are ignored when `Release` objects are created. When undefined field is encountered then a warning is logged in a similar manner as is done for undefined attributes and relationships for Apple's resources (see [src](https://github.com/codemagic-ci-cd/cli-tools/blob/6d4864998696ab243b2b15ec1a4cdad6d5d8bead/src/codemagic/apple/resources/resource.py#L48-L64)).