### PR TITLE
Allow Firebase release not to have `displayVersion` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+Version 0.60.2
+-------------
+
+**Bugfixes**
+- Fix `TypeError` in `firebase-app-distribution` actions if Firebase release response is missing `displayVersion` attribute. [PR #474](https://github.com/codemagic-ci-cd/cli-tools/pull/474)
+
 Version 0.60.1
 -------------
 
 **Bugfixes**
-- Fix action `firebase-app-distribution-debug get-latest-build-version` by supporting new `updateTime` and `expireTime` timestamps for releases. [PR #473](https://github.com/codemagic-ci-cd/cli-tools/pull/473)
+- Fix action `firebase-app-distribution get-latest-build-version` by supporting new `updateTime` and `expireTime` timestamps for releases. [PR #473](https://github.com/codemagic-ci-cd/cli-tools/pull/473)
 
 Version 0.60.0
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codemagic-cli-tools"
-version = "0.60.1"
+version = "0.60.2"
 description = "CLI tools used in Codemagic builds"
 readme = "README.md"
 authors = [

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.60.1.dev"
+__version__ = "0.60.2.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/resources/firebase/release.py
+++ b/src/codemagic/google/resources/firebase/release.py
@@ -18,11 +18,11 @@ class Release(Resource):
     """
 
     name: str
-    buildVersion: str
     createTime: datetime
     firebaseConsoleUri: str
     testingUri: str
     binaryDownloadUri: str
+    buildVersion: str
     displayVersion: str = ""
     releaseNotes: Optional[ReleaseNotes] = None
     updateTime: Optional[datetime] = None

--- a/src/codemagic/google/resources/firebase/release.py
+++ b/src/codemagic/google/resources/firebase/release.py
@@ -18,12 +18,12 @@ class Release(Resource):
     """
 
     name: str
-    displayVersion: str
     buildVersion: str
     createTime: datetime
     firebaseConsoleUri: str
     testingUri: str
     binaryDownloadUri: str
+    displayVersion: str = ""
     releaseNotes: Optional[ReleaseNotes] = None
     updateTime: Optional[datetime] = None
     expireTime: Optional[datetime] = None

--- a/tests/google/resources/firebase/test_release.py
+++ b/tests/google/resources/firebase/test_release.py
@@ -10,6 +10,12 @@ def test_release_initialization(api_firebase_release: dict):
     assert release.dict() == api_firebase_release
 
 
+def test_release_without_display_version(api_firebase_release: dict):
+    api_firebase_release.pop("displayVersion", None)
+    release = Release(**api_firebase_release)
+    assert release.displayVersion == ""
+
+
 def test_release_string_representation(api_firebase_release: dict):
     release = Release(**api_firebase_release)
     expected = textwrap.dedent(

--- a/tests/google/resources/firebase/test_release.py
+++ b/tests/google/resources/firebase/test_release.py
@@ -21,12 +21,12 @@ def test_release_string_representation(api_firebase_release: dict):
     expected = textwrap.dedent(
         """
         Name: projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8
-        Display version: 1.0
-        Build version: 1
         Create time: 2025-02-12T14:12:59.510381+00:00
         Firebase console URI: https://console.firebase.google.com/project/codemagic-cli-tools-test-app/appdistribution/app/android:io.codemagic.cli_tools_firebase/releases/78ruoe1t1uvr8
         Testing URI: https://appdistribution.firebase.google.com/testerapps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8
         Binary download URI: https://firebaseappdistribution.googleapis.com/app-binary-downloads/projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/78ruoe1t1uvr8/binaries/fcdd844be2bd504ae7bb9d672731ddbfcd89c1419a9aa746a0bb6f67d3a1429d/app.apk?token=token
+        Build version: 1
+        Display version: 1.0
         Release notes:
             Text: My release notes
         Update time: 2025-08-25T07:04:39.166957+00:00


### PR DESCRIPTION
When building an Android application using a `build.gradle` file which not specify `versionCode` and `versionName` then the produced `apk` / `aab` will have `null` and `""` values for `versionCode` and `versionName` respectively.

```shell
$ uvx androguard apkid app/build/intermediates/apk/debug/app-debug.apk
{
  "app/build/intermediates/apk/debug/app-debug.apk": [
    "io.codemagic.cli_tools_firebase",
    null,
    ""
  ]
}
```

When such an app is uploaded to Firebase App Distribution, then its JSON representation in responses for [releases](https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.apps.releases) requests is as follows:


```json
{
    "name": "projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/6gob495k4ackg",
    "releaseNotes": {
        "text": "without versionCode and versionName"
    },
    "buildVersion": "0",
    "createTime": "2025-08-28T13:46:53.865380Z",
    "firebaseConsoleUri": "https://console.firebase.google.com/project/codemagic-cli-tools-test-app/appdistribution/app/android:io.codemagic.cli_tools_firebase/releases/6gob495k4ackg",
    "testingUri": "https://appdistribution.firebase.google.com/testerapps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/6gob495k4ackg",
    "binaryDownloadUri": "https://firebaseappdistribution.googleapis.com/app-binary-downloads/projects/146661841143/apps/1:146661841143:android:a8d456e0c8b5e71bd11bf2/releases/6gob495k4ackg/binaries/475a0dc9ec2a8c67fb253f29a4241f487afd150e9150f34b6f180052d07cc77e/app.apk?token=AFb1MRwAAAAAaLBsjxq9hpVCMc5DzcOJCcH_qrR7aVVzr-tPXMDhsu5z0gW3WM1UdpqRGaWLwY_B87-50V4V4vh3FWFGeNKWKgWZYov35uFKtqccGbVy7bfL1tv9AMNiNranJd5H6Mp_R_46xxNLJ3GRHDvsJm5UPThbLat7ZVqm1gEZfY9T4Kq-yn4zBjBr0u_0liFZBgh4HFOrYtNazZWR4aWIXWQDNGNi14YhzNsjWIe8c-zjonvLtKZNmGmHXZ6y7lT6AuaPhKHz7Mtn12LL1JNqg8jqSEEV3PBVBV2ADECppjfZ3p8WLzrSp5LdjwegyNYKXnfjLSPWfCvreM_a60Yo4nEKXH1Mgwk",
    "updateTime": "2025-08-28T13:47:49.609621Z",
    "expireTime": "2026-01-25T13:46:53.865380Z"
}
```

That is the `buildVersion` is treated as `0`, but `displayVersion` is omitted. The latter currently causes a `TypeError`:
```python
Traceback (most recent call last):
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/cli_app.py", line 252, in invoke_cli
    CliApp._running_app._invoke_action(args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/cli_app.py", line 193, in _invoke_action
    return cli_action(**action_args)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/cli/action.py", line 86, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/tools/firebase_app_distribution/action_groups/releases_action_group.py", line 37, in list_releases
    releases = self.client.releases.list(self.project_number, app_id, order_by, limit)
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/google/services/firebase/releases_service.py", line 70, in list
    return [Release.from_api_response(firebase_release) for firebase_release in firebase_releases[:limit]]
            ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/Users/priit/.local/share/uv/tools/codemagic-cli-tools/lib/python3.13/site-packages/codemagic/google/resources/resource.py", line 46, in from_api_response
    return cls(**defined_fields)
TypeError: Release.__init__() missing 1 required positional argument: 'displayVersion'
```

Fix it by using a default value `""` for `displayVersion`.

**Updated actions:**
- `firebase-app-distribution get-latest-build-version`
- `firebase-app-distribution releases list`