### PR TITLE
Fix `firebase-app-distribution` release ordering rejected by the Firebase API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.69.0
+-------------
+
+**Bugfixes**
+- Fix `firebase-app-distribution` actions `get-latest-build-version` and `releases list`. The Firebase App Distribution API changed `orderBy` query parameter validation and rejects the previously tolerated `createTimeDesc`, requiring the documented space-separated grammar `createTime desc` instead.
+
 Version 0.68.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codemagic-cli-tools"
-version = "0.68.0"
+version = "0.69.0"
 description = "CLI tools used in Codemagic builds"
 authors = [{ name = "Priit Lätt", email = "priit@nevercode.io" }]
 requires-python = ">=3.8,<4"

--- a/src/codemagic/__version__.py
+++ b/src/codemagic/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "codemagic-cli-tools"
 __description__ = "CLI tools used in Codemagic builds"
-__version__ = "0.68.0.dev"
+__version__ = "0.69.0.dev"
 __url__ = "https://github.com/codemagic-ci-cd/cli-tools"
 __licence__ = "GNU General Public License v3.0"

--- a/src/codemagic/google/resources/firebase/order_by.py
+++ b/src/codemagic/google/resources/firebase/order_by.py
@@ -2,5 +2,11 @@ from codemagic.models.enums import ResourceEnum
 
 
 class OrderBy(ResourceEnum):
-    CREATE_TIME_DESC = "createTimeDesc"
+    """
+    Values follow the Firebase App Distribution `releases.list` `orderBy` grammar, which uses a
+    space-separated `desc` suffix, see
+    https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.apps.releases/list
+    """
+
+    CREATE_TIME_DESC = "createTime desc"
     CREATE_TIME_ASC = "createTime"

--- a/src/codemagic/tools/firebase_app_distribution/action_groups/releases_action_group.py
+++ b/src/codemagic/tools/firebase_app_distribution/action_groups/releases_action_group.py
@@ -4,9 +4,9 @@ from typing import List
 from codemagic import cli
 from codemagic.cli import Colors
 from codemagic.google.errors import GoogleError
-from codemagic.google.resources.firebase import OrderBy
 from codemagic.google.resources.firebase import Release
 
+from ..argument_types import ReleasesOrderByArgument
 from ..arguments import ReleasesArgument
 from ..arguments import ResourcesArgument
 from ..errors import FirebaseAppDistributionError
@@ -26,7 +26,7 @@ class ReleasesActionGroup(FirebaseAppDistributionAction, ABC):
         self,
         app_id: str,
         limit: int = ResourcesArgument.LIMIT.get_default(),
-        order_by: OrderBy = ResourcesArgument.ORDER_BY.get_default(),
+        order_by: ReleasesOrderByArgument = ResourcesArgument.ORDER_BY.get_default(),
         should_print: bool = True,
     ) -> List[Release]:
         """
@@ -34,7 +34,7 @@ class ReleasesActionGroup(FirebaseAppDistributionAction, ABC):
         """
 
         try:
-            releases = self.client.releases.list(self.project_number, app_id, order_by, limit)
+            releases = self.client.releases.list(self.project_number, app_id, order_by.order_by, limit)
         except GoogleError as e:
             raise FirebaseAppDistributionError(str(e))
 

--- a/src/codemagic/tools/firebase_app_distribution/argument_types.py
+++ b/src/codemagic/tools/firebase_app_distribution/argument_types.py
@@ -3,6 +3,17 @@ import json
 from typing import Dict
 
 from codemagic import cli
+from codemagic.google.resources.firebase import OrderBy
+from codemagic.models.enums import ResourceEnum
+
+
+class ReleasesOrderByArgument(ResourceEnum):
+    CREATE_TIME_DESC = "createTimeDesc"
+    CREATE_TIME_ASC = "createTime"
+
+    @property
+    def order_by(self) -> OrderBy:
+        return OrderBy[self.name]
 
 
 class CredentialsArgument(cli.EnvironmentArgumentValue[dict]):

--- a/src/codemagic/tools/firebase_app_distribution/arguments.py
+++ b/src/codemagic/tools/firebase_app_distribution/arguments.py
@@ -1,8 +1,8 @@
 from codemagic import cli
 from codemagic.cli.colors import Colors
-from codemagic.google.resources.firebase import OrderBy
 
 from .argument_types import CredentialsArgument
+from .argument_types import ReleasesOrderByArgument
 
 select_project_group = cli.MutuallyExclusiveGroup(
     name="select project",
@@ -50,12 +50,12 @@ class ResourcesArgument(cli.Argument):
     ORDER_BY = cli.ArgumentProperties(
         key="order_by",
         flags=("--order-by", "-o"),
-        type=OrderBy,
+        type=ReleasesOrderByArgument,
         description="Sort resources in the specified order",
         argparse_kwargs={
             "required": False,
-            "default": OrderBy.CREATE_TIME_DESC,
-            "choices": list(OrderBy),
+            "default": ReleasesOrderByArgument.CREATE_TIME_DESC,
+            "choices": list(ReleasesOrderByArgument),
         },
     )
 

--- a/src/codemagic/tools/firebase_app_distribution/firebase_app_distribution_action.py
+++ b/src/codemagic/tools/firebase_app_distribution/firebase_app_distribution_action.py
@@ -5,8 +5,9 @@ from typing import List
 
 from codemagic.google.firebase_client import FirebaseClient
 from codemagic.google.resources import ResourcePrinter
-from codemagic.google.resources.firebase import OrderBy
 from codemagic.google.resources.firebase import Release
+
+from .argument_types import ReleasesOrderByArgument
 
 
 class FirebaseAppDistributionAction(ABC):
@@ -37,7 +38,7 @@ class FirebaseAppDistributionAction(ABC):
         self,
         app_id: str,
         limit: int = 25,
-        order_by: OrderBy = OrderBy.CREATE_TIME_DESC,
+        order_by: ReleasesOrderByArgument = ReleasesOrderByArgument.CREATE_TIME_DESC,
         should_print: bool = True,
     ) -> List[Release]:
         from .action_groups.releases_action_group import ReleasesActionGroup

--- a/tests/google/firebase_client/test_firebase_client.py
+++ b/tests/google/firebase_client/test_firebase_client.py
@@ -69,6 +69,29 @@ def test_list_releases(firebase_client, release, mock_releases):
     assert releases[1].buildVersion == "71"
 
 
+@pytest.mark.parametrize(
+    ("order_by", "expected_order_by_param"),
+    (
+        (OrderBy.CREATE_TIME_DESC, "createTime desc"),
+        (OrderBy.CREATE_TIME_ASC, "createTime"),
+    ),
+)
+def test_list_releases_order_by(firebase_client, mock_releases, order_by, expected_order_by_param):
+    firebase_client.releases.list(
+        "firebase-project-id",
+        "firebase-app-id",
+        order_by=order_by,
+        page_size=2,
+    )
+
+    mock_releases.return_value.list.assert_called_once_with(
+        orderBy=expected_order_by_param,
+        parent="projects/firebase-project-id/apps/firebase-app-id",
+        pageSize=2,
+        pageToken="",
+    )
+
+
 def test_list_releases_limit(firebase_client, mock_releases):
     releases = firebase_client.releases.list(
         "firebase-project-number",

--- a/tests/tools/test_firebase_app_distribution.py
+++ b/tests/tools/test_firebase_app_distribution.py
@@ -17,6 +17,7 @@ from codemagic.google.resources.firebase import Release
 from codemagic.google.services.firebase import ReleasesService
 from codemagic.tools.firebase_app_distribution import FirebaseAppDistribution
 from codemagic.tools.firebase_app_distribution.argument_types import CredentialsArgument
+from codemagic.tools.firebase_app_distribution.argument_types import ReleasesOrderByArgument
 from codemagic.tools.firebase_app_distribution.arguments import FirebaseArgument
 from codemagic.tools.firebase_app_distribution.errors import FirebaseAppDistributionError
 
@@ -24,6 +25,25 @@ credentials_argument = FirebaseArgument.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS
 project_number_argument = FirebaseArgument.PROJECT_NUMBER
 project_id_argument = FirebaseArgument.PROJECT_ID
 json_output_argument = FirebaseArgument.JSON_OUTPUT
+
+
+@pytest.mark.parametrize(
+    ("argument", "expected_order_by", "expected_cli_token"),
+    (
+        (ReleasesOrderByArgument.CREATE_TIME_DESC, OrderBy.CREATE_TIME_DESC, "createTimeDesc"),
+        (ReleasesOrderByArgument.CREATE_TIME_ASC, OrderBy.CREATE_TIME_ASC, "createTime"),
+    ),
+)
+def test_releases_order_by_argument(argument, expected_order_by, expected_cli_token):
+    # CLI parameter value stays a single, backwards-compatible token and maps to the API-facing OrderBy.
+    assert argument.value == expected_cli_token
+    assert argument.order_by is expected_order_by
+
+
+def test_every_releases_order_by_argument_maps_to_order_by():
+    # Guards against adding a CLI ordering choice without a matching API-facing OrderBy member.
+    for argument in ReleasesOrderByArgument:
+        assert isinstance(argument.order_by, OrderBy)
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "codemagic-cli-tools"
-version = "0.68.0"
+version = "0.69.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Since around 2026-07-14, `firebase-app-distribution get-latest-build-version` and `firebase-app-distribution releases list` started failing with `Request contains an invalid argument.` for every app, with no changes on our side (reported in #500).

The Firebase App Distribution [`releases.list`](https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.apps.releases/list) API now rejects the previously tolerated camelCase `createTimeDesc`. The documented grammar uses a space-separated `desc` suffix, i.e. `createTime desc`.

The catch is that `OrderBy.value` was doing double duty: it was both the value sent to the API *and* the token accepted by the public `--order-by` CLI argument. Simply changing it to `createTime desc` would fix the API call but break the CLI (`--order-by createTimeDesc` would stop working and the value would need quoting). This PR decouples the two.

**Changes**

- `codemagic.google.resources.firebase.OrderBy` now holds the documented API grammar (`createTime desc` / `createTime`) — this is the value sent to `releases.list`.
- Introduce a CLI-facing `ReleasesOrderByArgument` in the tool layer (`argument_types.py`) that keeps the single-token values (`createTimeDesc` / `createTime`) and maps to `OrderBy` via its `order_by` property. The `--order-by` argument and the `list_releases` action signatures now use this type, converting to `OrderBy` at the point where the action group calls into the service.

**Effect**

- `firebase-app-distribution get-latest-build-version` and `firebase-app-distribution releases list` work again against the updated API.
- The `--order-by` CLI interface is unchanged and fully backwards compatible: same `createTimeDesc` / `createTime` choices and `createTimeDesc` default, and the generated docs are unchanged.

<details>
<summary>QA reference</summary>

```shell
# CLI surface unchanged — same choices and default token
$ uv run firebase-app-distribution releases list --help | grep -A1 'order-by'     
usage: firebase-app-distribution releases list [-h] (--project-id PROJECT_ID | --project-number PROJECT_NUMBER) [--credentials CREDENTIALS] [--json] --app-id APP_ID [--limit LIMIT] [--order-by {createTimeDesc,createTime}] [--log-stream {stderr,stdout}] [--no-color] [--version] [-s] [-v]                                                                                                                                                                                                   

--
  --order-by, -o {createTimeDesc,createTime}
                        Sort resources in the specified order [Default: createTimeDesc]

# CLI token maps to the corrected wire value
$ uv run firebase-app-distribution get-latest-build-version \
  --app-id "1:146661841143:android:a8d456e0c8b5e71bd11bf2" \
  --project-number "146661841143"
No releases available for 1:146661841143:android:a8d456e0c8b5e71bd11bf2
```
</details>
